### PR TITLE
Add macaron check

### DIFF
--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -1,0 +1,38 @@
+name: Macaron check-github-actions
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  macaron-check-github-actions:
+    name: Macaron policy verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Macaron check-github-actions policy
+        uses: oracle/macaron@b31acfe389133a5587d9639063ec70cb84e7bc47 # v0.23.0
+        with:
+          repo_path: https://github.com/${{ github.repository }}
+          policy_file: check-github-actions
+          policy_purl: pkg:github/${{ github.repository }}@${{ github.sha }}
+

--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run Macaron check-github-actions policy
         uses: oracle/macaron@b31acfe389133a5587d9639063ec70cb84e7bc47 # v0.23.0
         with:
-          repo_path: https://github.com/${{ github.repository }}
+          repo_path: ./
           policy_file: check-github-actions
-          policy_purl: pkg:github/${{ github.repository }}@${{ github.sha }}
+          policy_purl: pkg:github.com/${{ github.repository }}@.*
 

--- a/.github/workflows/maven-oracle-17.yml
+++ b/.github/workflows/maven-oracle-17.yml
@@ -11,6 +11,8 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions: {}
+
 jobs:
   test:
     name: Test on java-version 17 and os ${{ matrix.os }}
@@ -20,16 +22,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup Oracle Java SE
-      uses: oracle-actions/setup-java@v1
-      with:
-        website: oracle.com
-        release: 17
-        version: 17.0.12
-   
-    - name: Build with Maven
-      run: |
-        mvn -B install --file Sandwood/pom.xml
-        mvn -B install --file SandwoodMavenPlugin/pom.xml
-        mvn -B test --file SandwoodExamples/pom.xml
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Setup Oracle Java SE
+        uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
+        with:
+          website: oracle.com
+          release: 17
+          version: 17.0.12
+
+      - name: Build with Maven
+        run: |
+          mvn -B install --file Sandwood/pom.xml
+          mvn -B install --file SandwoodMavenPlugin/pom.xml
+          mvn -B test --file SandwoodExamples/pom.xml

--- a/.github/workflows/maven-oracle.yml
+++ b/.github/workflows/maven-oracle.yml
@@ -11,6 +11,8 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions: {}
+
 jobs:
   test:
     name: Test on java-version ${{ matrix.java_version }} and os ${{ matrix.os }}
@@ -21,15 +23,17 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup Oracle Java SE
-      uses: oracle-actions/setup-java@v1
-      with:
-        website: oracle.com
-        release: ${{ matrix.java_version }}
-   
-    - name: Build with Maven
-      run: |
-        mvn -B install --file Sandwood/pom.xml
-        mvn -B install --file SandwoodMavenPlugin/pom.xml
-        mvn -B test --file SandwoodExamples/pom.xml
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Setup Oracle Java SE
+        uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
+        with:
+          website: oracle.com
+          release: ${{ matrix.java_version }}
+
+      - name: Build with Maven
+        run: |
+          mvn -B install --file Sandwood/pom.xml
+          mvn -B install --file SandwoodMavenPlugin/pom.xml
+          mvn -B test --file SandwoodExamples/pom.xml

--- a/.github/workflows/maven-other.yml
+++ b/.github/workflows/maven-other.yml
@@ -12,6 +12,8 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions: {}
+
 jobs:
   test:
     name: Test on java-version ${{ matrix.java_version }} and os ${{ matrix.os }}
@@ -22,16 +24,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK termurin
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{ matrix.java_version }}
-        distribution: 'temurin'
-        cache: maven
-   
-    - name: Build with Maven
-      run: |
-        mvn -B install --file Sandwood/pom.xml
-        mvn -B install --file SandwoodMavenPlugin/pom.xml
-        mvn -B test --file SandwoodExamples/pom.xml
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up JDK termurin
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: ${{ matrix.java_version }}
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build with Maven
+        run: |
+          mvn -B install --file Sandwood/pom.xml
+          mvn -B install --file SandwoodMavenPlugin/pom.xml
+          mvn -B test --file SandwoodExamples/pom.xml


### PR DESCRIPTION
## Summary
Add Macaron policy verification for GitHub Actions using the `check-github-actions` policy.

## What this change does
- Adds a dedicated workflow for Macaron verification
- Checks workflow definitions and local composite actions
- Uses pinned actions and disables persisted checkout credentials

## Why this is required
This helps detect unsafe or vulnerable GitHub Actions usage and reduces risk from software supply chain attacks targeting CI/CD pipelines.

## Required follow-up
- Enable `Macaron policy verification` as a required status check for protected branches
- Resolve any policy findings before merge if applicable