### PR TITLE
Array modifications

### DIFF
--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/APICompile.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/APICompile.java
@@ -95,7 +95,7 @@ import org.sandwood.compiler.trees.outputTree.OutputSandwoodInterfaceGenerated;
 import org.sandwood.compiler.trees.transformationTree.TransSandwoodClassGenerated;
 
 public class APICompile {
-    // A flag used to make the compiler run in serial mode. THis is used to make it easier to debug errors in the
+    // A flag used to make the compiler run in serial mode. This is used to make it easier to debug errors in the
     // compiler and should always be true in production systems.
     public static final boolean parallel = true;
 

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/GetTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/GetTask.java
@@ -37,7 +37,7 @@ public abstract class GetTask<A extends Variable<A>> extends ProducingDataflowTa
     public GetTask(ArrayVariable<A> array, IntVariable index, Location location) {
         this(array, index, false, location);
     }
-    
+
     protected GetTask(ArrayVariable<A> array, IntVariable index, boolean implicit, Location location) {
         super(DFType.GET, array.getElementType(), location, array.getCurrentInstance(), index);
         this.array = array.getCurrentInstance();
@@ -55,6 +55,8 @@ public abstract class GetTask<A extends Variable<A>> extends ProducingDataflowTa
     public IRTreeReturn<A> getForwardIRinternal(CompilationContext compilationCtx) {
         if(compilationCtx.initialized(output))
             return load(output);
+        else if(compilationCtx.initialized(array))
+            return arrayGet(load(array), index.getForwardIR(compilationCtx));
         else
             return arrayGet(array.getForwardIR(compilationCtx), index.getForwardIR(compilationCtx));
     }
@@ -175,7 +177,7 @@ public abstract class GetTask<A extends Variable<A>> extends ProducingDataflowTa
         index.constructTrace(desc);
         desc.trace.pop();
     }
-    
+
     public boolean isImplicit() {
         return implicit;
     }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/Variable.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/Variable.java
@@ -26,6 +26,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.DFType;
 import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask.TraceCallback;
 import org.sandwood.compiler.dataflowGraph.tasks.ProducingDataflowTask;
+import org.sandwood.compiler.dataflowGraph.tasks.arrayTasks.PutTask;
 import org.sandwood.compiler.dataflowGraph.tasks.nonReturnTasks.ObserveVariableTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ReductionInput;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.ArrayType;
@@ -1292,23 +1293,40 @@ public interface Variable<A extends Variable<A>> extends Comparable<Variable<?>>
      * @return
      */
     static Set<Variable<?>> collectInputVariable(Set<Variable<?>> vars, DFType... sTypes) {
-        Set<Variable<?>> variables = new HashSet<>();
-        List<Variable<?>> toProcess = new ArrayList<>(vars);
+        Map<Variable<?>, Integer> variables = new HashMap<>();
+        List<UsedVariable> toProcess = new ArrayList<>();
+        for(Variable<?> v:vars)
+            toProcess.add(new UsedVariable(v, v.getId()));
         Set<DFType> stopTypes = new HashSet<>();
         stopTypes.addAll(Arrays.asList(sTypes));
 
         while(!toProcess.isEmpty()) {
-            Variable<?> v = toProcess.remove(0);
-            if(!variables.contains(v)) {
-                variables.add(v);
-                if(!stopTypes.contains(v.getParent().getType()))
-                    toProcess.addAll(v.getParent().getInputs());
+            UsedVariable u = toProcess.remove(0);
+            if(!variables.containsKey(u.v) || variables.get(u.v) < u.usedId) {
+                variables.put(u.v, u.usedId);
+                ProducingDataflowTask<?> parent = u.v.getParent();
+                if(!stopTypes.contains(parent.getType())) {
+                    for(Variable<?> input:parent.getInputs()) {
+                        if(u.v.getType().isArray()) {
+                            toProcess.add(new UsedVariable(input, u.usedId));
+                            ArrayVariable<?> a = (ArrayVariable<?>) u.v;
+                            for(PutTask<?> pt:a.getPuts(a.scope(), u.usedId))
+                                toProcess.add(new UsedVariable(pt.getOutput(), u.usedId));
+                        } else {
+                            int pId = parent.id();
+                            toProcess.add(new UsedVariable(input, pId));
+                        }
+                    }
+                }
             }
         }
 
-        variables.removeAll(vars);
-        return variables;
+        for(Variable<?> v:vars)
+            variables.remove(v);
+        return new HashSet<>(variables.keySet());
     }
+
+    record UsedVariable(Variable<?> v, int usedId) {}
 
     /**
      * Method to construct a string representing the graph. This is just used for testing to confirm nothing has changed

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/arrayVariable/ArrayVariable.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/arrayVariable/ArrayVariable.java
@@ -8,13 +8,19 @@
 
 package org.sandwood.compiler.dataflowGraph.variables.arrayVariable;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.sandwood.common.exceptions.SandwoodException;
 import org.sandwood.compiler.compilation.CompilationContext;
 import org.sandwood.compiler.dataflowGraph.Sandwood;
+import org.sandwood.compiler.dataflowGraph.scopes.ElseScope;
+import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
+import org.sandwood.compiler.dataflowGraph.scopes.IfScope;
 import org.sandwood.compiler.dataflowGraph.scopes.Scope;
+import org.sandwood.compiler.dataflowGraph.scopes.Scope.ScopeType;
 import org.sandwood.compiler.dataflowGraph.scopes.ScopeStack;
 import org.sandwood.compiler.dataflowGraph.tasks.ArrayProducingDataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.DFType;
@@ -483,6 +489,18 @@ public class ArrayVariable<A extends Variable<A>> extends VariableImplementation
      * @return
      */
     public Set<ArrayVariable<A>> getPossibleInstances(Scope consumerScope, int destinationID) {
+        Map<IfScope, ElseScope> conditionalScopes = new HashMap<>();
+        {
+            Scope s = consumerScope;
+            while(s != GlobalScope.scope) {
+                if(s.getScopeType() == ScopeType.ELSE) {
+                    ElseScope e = (ElseScope) s;
+                    conditionalScopes.put(e.ifScope, e);
+                }
+                s = s.getEnclosingScope();
+            }
+        }
+
         Set<ArrayVariable<A>> vars = new HashSet<>();
 
         // Get any puts that happen after the scope, but could reach it. This goes beyond
@@ -491,7 +509,32 @@ public class ArrayVariable<A extends Variable<A>> extends VariableImplementation
         ArrayVariable<A> vec = instanceHandle;
         while(vec != null) {
             if(vec.getParent().id() < destinationID) {
-                vars.add(vec);
+                Scope s = vec.scope();
+                boolean iterating = false;
+                boolean inScope = true;
+                ElseScope lastElse = null;
+                while(s != GlobalScope.scope) {
+                    switch(s.getScopeType()) {
+                        case ELSE:
+                            lastElse = (ElseScope) s;
+                            break;
+                        case FOR:
+                            iterating = true;
+                            break;
+                        case IF:
+                            ElseScope e = conditionalScopes.get(s);
+                            if(e != null)
+                                inScope = inScope && e == lastElse;
+                            break;
+                        default:
+                            break;
+                    }
+
+                    s = s.getEnclosingScope();
+                }
+
+                if(iterating || inScope)
+                    vars.add(vec);
                 vec = vec.childInstance;
             } else
                 break;

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/transformationTree/transformers/SubstituteKnownValuesTransformer.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/transformationTree/transformers/SubstituteKnownValuesTransformer.java
@@ -522,11 +522,6 @@ public class SubstituteKnownValuesTransformer extends Transformer {
     private final Stack<Stack<IntVariable>> arrayIndexes;
 
     /**
-     * A mapping of for loop ids to the corresponding trees.
-     */
-    private final Map<TreeID, TransFor> forLoopLookup = new HashMap<>();
-
-    /**
      * Constructor.
      * 
      * @param knownValues The values that are known from the calling class.
@@ -1146,7 +1141,7 @@ public class SubstituteKnownValuesTransformer extends Transformer {
         // Return null if this initialisation is not in a sequential tree.
         if(parents.isEmpty())
             return null;
-        
+
         TransSequential ts = parents.peek();
         List<TransTreeVoid> trees = ts.getTrees();
         // A flag to say if we have passed the point that the variable is currently

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/transformationTree/util/ArrayReadFrequency.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/transformationTree/util/ArrayReadFrequency.java
@@ -1,7 +1,7 @@
 /*
  * Sandwood
  *
- * Copyright (c) 2019-2024, Oracle and/or its affiliates
+ * Copyright (c) 2019-2025, Oracle and/or its affiliates
  * 
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
@@ -48,13 +48,52 @@ public class ArrayReadFrequency {
                 Stack<TransTreeReturn<IntVariable>> indexes, IfElseDesc ifElse) {}
 
         private record IfElseDesc(TreeID ifElseID, Boolean inIf, IfElseDesc parent) {
-            public boolean contains(IfElseDesc target) {
-                IfElseDesc d = this;
-                do {
-                    if(d == target)
+
+            /**
+             * A method to test if this is a sub branch of or the same branch as the provided branch.
+             */
+            public boolean isSubBranch(IfElseDesc target) {
+                if(this.equals(target))
+                    return true;
+                if(parent == null)
+                    return false;
+                else
+                    return parent.isSubBranch(target);
+            }
+
+            /**
+             * A test to see if 2 descriptions are in different branches of the same if else node.
+             * 
+             * @param target
+             * @return
+             */
+            public boolean inDifferentBranch(IfElseDesc target) {
+                Stack<IfElseDesc> thisIfElse = new Stack<>();
+                IfElseDesc i = this;
+                while(i != null) {
+                    thisIfElse.push(i);
+                    i = i.parent();
+                }
+
+                Stack<IfElseDesc> targetIfElse = new Stack<>();
+                IfElseDesc t = target;
+                while(t != null) {
+                    targetIfElse.push(t);
+                    t = t.parent();
+                }
+
+                while(!thisIfElse.isEmpty() && !targetIfElse.isEmpty()) {
+                    i = thisIfElse.pop();
+                    t = targetIfElse.pop();
+
+                    if(i.ifElseID != t.ifElseID)
+                        return false;
+
+                    if(i.inIf != t.inIf)
                         return true;
-                    d = d.parent;
-                } while(d != null);
+
+                }
+
                 return false;
             }
         }
@@ -120,6 +159,7 @@ public class ArrayReadFrequency {
                     visit(put.array);
                     indexes.push(put.index);
                     inPut = false;
+                    arrayIndexes.pop();
 
                     updatePutState(put, indexes);
 
@@ -153,8 +193,8 @@ public class ArrayReadFrequency {
 
                     // Remove candidates that depend on variables that are moving out of scope.
                     for(int i = declaredVariables.size() - 1; i >= numDeclared; i--) {
-                        arrayDesces = writeDependencies.get(declaredVariables.remove(i));
-                        removeCandidate(arrayDesces);
+                        VariableDescription<?> var = declaredVariables.remove(i);
+                        removeDeclaredVariable(var);
                     }
 
                     break;
@@ -172,8 +212,8 @@ public class ArrayReadFrequency {
 
                     // Remove candidates that depend on variables that are moving out of scope.
                     for(int i = declaredVariables.size() - 1; i >= numDeclared; i--) {
-                        Set<ArraySetDescription> arrayDesces = writeDependencies.get(declaredVariables.remove(i));
-                        removeCandidate(arrayDesces);
+                        VariableDescription<?> var = declaredVariables.remove(i);
+                        removeDeclaredVariable(var);
                     }
 
                     d = new IfElseDesc(ifElse.id, false, ifElseDesces.peek());
@@ -184,8 +224,8 @@ public class ArrayReadFrequency {
 
                     // Remove candidates that depend on variables that are moving out of scope.
                     for(int i = declaredVariables.size() - 1; i >= numDeclared; i--) {
-                        Set<ArraySetDescription> arrayDesces = writeDependencies.get(declaredVariables.remove(i));
-                        removeCandidate(arrayDesces);
+                        VariableDescription<?> var = declaredVariables.remove(i);
+                        removeDeclaredVariable(var);
                     }
 
                     // Look for arrays that can be merged into a single candidate over riding the preceding ones.
@@ -219,12 +259,23 @@ public class ArrayReadFrequency {
                         arrayName.push(l.varDesc);
                     } else {
                         Set<ArraySetDescription> arrayDesces = readDependencies.get(l.varDesc);
-                        removeCandidate(arrayDesces);
+                        if(arrayDesces != null) {
+                            for(ArraySetDescription ad:arrayDesces) {
+                                // Check this array set description refers to arrays visible from this if branch.
+                                if(!ifElseDesces.peek().inDifferentBranch(ad.ifElse)) {
+                                    Map<Stack<TransTreeReturn<IntVariable>>, CandidateDescription> m = candidates
+                                            .get(ad.arrayName);
+                                    if(m != null)
+                                        m.remove(ad.indexes);
+                                }
+                            }
+                        }
                     }
                     break;
                 }
                 case STORE: {
                     TransStore<?> s = (TransStore<?>) tree;
+                    visit(s.value);
                     Set<ArraySetDescription> arrayDesces = writeDependencies.get(s.varDesc);
                     removeCandidate(arrayDesces);
                     break;
@@ -237,8 +288,8 @@ public class ArrayReadFrequency {
 
                     // Remove candidates that depend on variables that are moving out of scope.
                     for(int i = declaredVariables.size() - 1; i >= numDeclared; i--) {
-                        Set<ArraySetDescription> arrayDesces = writeDependencies.get(declaredVariables.remove(i));
-                        removeCandidate(arrayDesces);
+                        VariableDescription<?> var = declaredVariables.remove(i);
+                        removeDeclaredVariable(var);
                     }
 
                     break;
@@ -247,16 +298,13 @@ public class ArrayReadFrequency {
                 case INITIALIZE: {
                     TransInitialize<?> ti = (TransInitialize<?>) tree;
                     declaredVariables.add(ti.varDesc);
-
-                    tree.traverseTree(this);
+                    visit(ti.value);
                     break;
                 }
 
                 case INITIALIZE_UNSET: {
                     TransInitializeUnset<?> ti = (TransInitializeUnset<?>) tree;
                     declaredVariables.add(ti.varDesc);
-
-                    tree.traverseTree(this);
                     break;
                 }
 
@@ -266,11 +314,41 @@ public class ArrayReadFrequency {
             }
         }
 
+        private void removeDeclaredVariable(VariableDescription<?> var) {
+            Map<VariableDescription<?>, Set<ArraySetDescription>> ifs = ifElseBranchCandidate.get(ifElseDesces.peek());
+            if(ifs != null)
+                ifs.remove(var);
+            removeDeclaredArrayDescs(var, readDependencies);
+            removeDeclaredArrayDescs(var, writeDependencies);
+        }
+
+        private void removeDeclaredArrayDescs(VariableDescription<?> var,
+                Map<VariableDescription<?>, Set<ArraySetDescription>> recorded) {
+            Set<ArraySetDescription> arrayDesces = recorded.remove(var);
+            if(arrayDesces != null) {
+                for(ArraySetDescription arrayDesc:arrayDesces) {
+                    if(arrayDesc.arrayName.equals(var)) {
+                        Map<Stack<TransTreeReturn<IntVariable>>, CandidateDescription> m = candidates
+                                .get(arrayDesc.arrayName);
+                        if(m != null) {
+                            CandidateDescription c = m.get(arrayDesc.indexes);
+                            if(c != null) {
+                                Set<ArraySetDescription> fors = forLoopDependencies.get(c.outerLoop());
+                                if(fors != null)
+                                    fors.remove(arrayDesc);
+                            }
+                        }
+                    }
+                }
+            }
+            removeCandidate(arrayDesces);
+        }
+
         private void removeCandidate(Set<ArraySetDescription> arrayDesces) {
             if(arrayDesces != null) {
                 for(ArraySetDescription ad:arrayDesces) {
                     // Check this array set description refers to arrays visible from this if branch.
-                    if(ifElseDesces.peek().contains(ad.ifElse) || ad.ifElse.contains(ifElseDesces.peek())) {
+                    if(ad.ifElse.isSubBranch(ifElseDesces.peek())) {
                         Map<Stack<TransTreeReturn<IntVariable>>, CandidateDescription> m = candidates.get(ad.arrayName);
                         if(m != null)
                             m.remove(ad.indexes);
@@ -370,7 +448,7 @@ public class ArrayReadFrequency {
                     }
                 }
             }
-            
+
             for(Stack<TransTreeReturn<IntVariable>> indexes:toRemove)
                 m.remove(indexes);
         }
@@ -380,7 +458,7 @@ public class ArrayReadFrequency {
             // TODO weaken this.
             if(candidate.outerLoop != current.outerLoop)
                 return false;
-            if(!candidate.ifElse.contains(ifElseDesces.peek()))
+            if(!candidate.ifElse.isSubBranch(ifElseDesces.peek()))
                 return false;
 
             // Test the indexes are equivalent

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4$MultiThreadCPU_optimisedModel.java
@@ -668,6 +668,7 @@ class Conditional4$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// 
 		// Substituted "cv$valuePos" with its value "0".
 		guard = false;
+		bias[0] = var19;
 		
 		// Save the calculated index value into the array of index value probabilities
 		// 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4$MultiThreadCPU_optimisedModelNoComments.java
@@ -212,6 +212,7 @@ class Conditional4$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 
 	private final void sample4() {
 		guard = false;
+		bias[0] = var19;
 		cv$var4$stateProbabilityGlobal[0] = (((((0.0 <= var19) && (var19 < 0.5))?0.6931471805599453:Double.NEGATIVE_INFINITY) + DistributionSampling.logProbabilityBeta(value, bias[0], 1.0)) - 0.6931471805599453);
 		guard = true;
 		cv$var4$stateProbabilityGlobal[1] = (DistributionSampling.logProbabilityBeta(value, 0.5, 1.0) - 0.6931471805599453);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4$MultiThreadCPU_optimisedModelSingle.java
@@ -660,6 +660,7 @@ class Conditional4$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// 
 		// Substituted "cv$valuePos" with its value "0".
 		guard = false;
+		bias[0] = var19;
 		
 		// Save the calculated index value into the array of index value probabilities
 		// 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4$SingleThreadCPU_optimisedModel.java
@@ -668,6 +668,7 @@ class Conditional4$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		// 
 		// Substituted "cv$valuePos" with its value "0".
 		guard = false;
+		bias[0] = var19;
 		
 		// Save the calculated index value into the array of index value probabilities
 		// 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4$SingleThreadCPU_optimisedModelNoComments.java
@@ -212,6 +212,7 @@ class Conditional4$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	private final void sample4() {
 		guard = false;
+		bias[0] = var19;
 		cv$var4$stateProbabilityGlobal[0] = (((((0.0 <= var19) && (var19 < 0.5))?0.6931471805599453:Double.NEGATIVE_INFINITY) + DistributionSampling.logProbabilityBeta(value, bias[0], 1.0)) - 0.6931471805599453);
 		guard = true;
 		cv$var4$stateProbabilityGlobal[1] = (DistributionSampling.logProbabilityBeta(value, 0.5, 1.0) - 0.6931471805599453);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4$SingleThreadCPU_optimisedModelSingle.java
@@ -660,6 +660,7 @@ class Conditional4$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		// 
 		// Substituted "cv$valuePos" with its value "0".
 		guard = false;
+		bias[0] = var19;
 		
 		// Save the calculated index value into the array of index value probabilities
 		// 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$MultiThreadCPU_model.java
@@ -700,7 +700,6 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		double[] var28 = bias[0];
 		if(!fixedFlag$sample16)
 			var28[1] = t;
-		inner[0] = q;
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, samples, 1,
@@ -720,6 +719,14 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationDistributionsNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -728,6 +735,14 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationValuesNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -850,6 +865,14 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		// Generate sample values for every call to sample in the model.
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 		
 		// Calculate the probabilities for every sample task in the model. These values are
 		// then used to calculate the probabilities of random variables and the model as a
@@ -873,7 +896,14 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// through the model. Any non-fixed sample values may be sampled to random variables
 	// as part of this process.
 	@Override
-	public final void setIntermediates() {}
+	public final void setIntermediates() {
+		double[] inner = bias[0];
+		if(fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(fixedFlag$sample16)
+			var28[1] = t;
+	}
 
 	@Override
 	public String modelCode() {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$MultiThreadCPU_modelNoComments.java
@@ -437,7 +437,6 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		double[] var28 = bias[0];
 		if(!fixedFlag$sample16)
 			var28[1] = t;
-		inner[0] = q;
 		parallelFor(RNG$, 0, samples, 1,
 			(int forStart$var46, int forEnd$var46, int threadID$var46, org.sandwood.random.internal.Rng RNG$1) -> { 
 				for(int var46 = forStart$var46; var46 < forEnd$var46; var46 += 1)
@@ -450,12 +449,28 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationDistributionsNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 	}
 
 	@Override
@@ -528,6 +543,14 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void logProbabilityGeneration() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 		logModelProbabilitiesVal();
 	}
 
@@ -541,7 +564,14 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	}
 
 	@Override
-	public final void setIntermediates() {}
+	public final void setIntermediates() {
+		double[] inner = bias[0];
+		if(fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(fixedFlag$sample16)
+			var28[1] = t;
+	}
 
 	@Override
 	public String modelCode() {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$MultiThreadCPU_modelSingle.java
@@ -700,7 +700,6 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		double[] var28 = bias[0];
 		if(!fixedFlag$sample16)
 			var28[1] = t;
-		inner[0] = q;
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, samples, 1,
@@ -720,6 +719,14 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationDistributionsNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -728,6 +735,14 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationValuesNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -850,6 +865,14 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		// Generate sample values for every call to sample in the model.
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 		
 		// Calculate the probabilities for every sample task in the model. These values are
 		// then used to calculate the probabilities of random variables and the model as a
@@ -873,7 +896,14 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// through the model. Any non-fixed sample values may be sampled to random variables
 	// as part of this process.
 	@Override
-	public final void setIntermediates() {}
+	public final void setIntermediates() {
+		double[] inner = bias[0];
+		if(fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(fixedFlag$sample16)
+			var28[1] = t;
+	}
 
 	@Override
 	public String modelCode() {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$MultiThreadCPU_optimisedModel.java
@@ -639,9 +639,10 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample16)
 			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
 		if(!fixedFlag$sample16)
 			bias[0][1] = t;
-		inner[0] = q;
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, samples, 1,
@@ -661,6 +662,13 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationDistributionsNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -669,6 +677,13 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationValuesNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -791,6 +806,13 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		// Generate sample values for every call to sample in the model.
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 		
 		// Calculate the probabilities for every sample task in the model. These values are
 		// then used to calculate the probabilities of random variables and the model as a
@@ -814,7 +836,13 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// through the model. Any non-fixed sample values may be sampled to random variables
 	// as part of this process.
 	@Override
-	public final void setIntermediates() {}
+	public final void setIntermediates() {
+		if(fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(fixedFlag$sample16)
+			bias[0][1] = t;
+	}
 
 	@Override
 	public String modelCode() {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$MultiThreadCPU_optimisedModelNoComments.java
@@ -273,9 +273,10 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample16)
 			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
 		if(!fixedFlag$sample16)
 			bias[0][1] = t;
-		inner[0] = q;
 		parallelFor(RNG$, 0, samples, 1,
 			(int forStart$var46, int forEnd$var46, int threadID$var46, org.sandwood.random.internal.Rng RNG$1) -> { 
 				for(int var46 = forStart$var46; var46 < forEnd$var46; var46 += 1)
@@ -288,12 +289,24 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationDistributionsNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 	}
 
 	@Override
@@ -366,6 +379,12 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void logProbabilityGeneration() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 		logModelProbabilitiesVal();
 	}
 
@@ -377,7 +396,12 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	}
 
 	@Override
-	public final void setIntermediates() {}
+	public final void setIntermediates() {
+		if(fixedFlag$sample10)
+			bias[0][0] = q;
+		if(fixedFlag$sample16)
+			bias[0][1] = t;
+	}
 
 	@Override
 	public String modelCode() {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$MultiThreadCPU_optimisedModelSingle.java
@@ -639,9 +639,10 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample16)
 			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
 		if(!fixedFlag$sample16)
 			bias[0][1] = t;
-		inner[0] = q;
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, samples, 1,
@@ -661,6 +662,13 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationDistributionsNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -669,6 +677,13 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationValuesNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -791,6 +806,13 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		// Generate sample values for every call to sample in the model.
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 		
 		// Calculate the probabilities for every sample task in the model. These values are
 		// then used to calculate the probabilities of random variables and the model as a
@@ -814,7 +836,13 @@ class Flip1CoinMK19$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// through the model. Any non-fixed sample values may be sampled to random variables
 	// as part of this process.
 	@Override
-	public final void setIntermediates() {}
+	public final void setIntermediates() {
+		if(fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(fixedFlag$sample16)
+			bias[0][1] = t;
+	}
 
 	@Override
 	public String modelCode() {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$SingleThreadCPU_model.java
@@ -700,7 +700,6 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		double[] var28 = bias[0];
 		if(!fixedFlag$sample16)
 			var28[1] = t;
-		inner[0] = q;
 		for(int var46 = 0; var46 < samples; var46 += 1)
 			flips[var46] = DistributionSampling.sampleBernoulli(RNG$, inner[b]);
 	}
@@ -711,6 +710,14 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationDistributionsNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -719,6 +726,14 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationValuesNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -841,6 +856,14 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		// Generate sample values for every call to sample in the model.
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 		
 		// Calculate the probabilities for every sample task in the model. These values are
 		// then used to calculate the probabilities of random variables and the model as a
@@ -864,7 +887,14 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// through the model. Any non-fixed sample values may be sampled to random variables
 	// as part of this process.
 	@Override
-	public final void setIntermediates() {}
+	public final void setIntermediates() {
+		double[] inner = bias[0];
+		if(fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(fixedFlag$sample16)
+			var28[1] = t;
+	}
 
 	@Override
 	public String modelCode() {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$SingleThreadCPU_modelNoComments.java
@@ -437,7 +437,6 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		double[] var28 = bias[0];
 		if(!fixedFlag$sample16)
 			var28[1] = t;
-		inner[0] = q;
 		for(int var46 = 0; var46 < samples; var46 += 1)
 			flips[var46] = DistributionSampling.sampleBernoulli(RNG$, inner[b]);
 	}
@@ -446,12 +445,28 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationDistributionsNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 	}
 
 	@Override
@@ -524,6 +539,14 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void logProbabilityGeneration() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 		logModelProbabilitiesVal();
 	}
 
@@ -537,7 +560,14 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	}
 
 	@Override
-	public final void setIntermediates() {}
+	public final void setIntermediates() {
+		double[] inner = bias[0];
+		if(fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(fixedFlag$sample16)
+			var28[1] = t;
+	}
 
 	@Override
 	public String modelCode() {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$SingleThreadCPU_modelSingle.java
@@ -700,7 +700,6 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		double[] var28 = bias[0];
 		if(!fixedFlag$sample16)
 			var28[1] = t;
-		inner[0] = q;
 		for(int var46 = 0; var46 < samples; var46 += 1)
 			flips[var46] = DistributionSampling.sampleBernoulli(RNG$, inner[b]);
 	}
@@ -711,6 +710,14 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationDistributionsNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -719,6 +726,14 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationValuesNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -841,6 +856,14 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		// Generate sample values for every call to sample in the model.
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(!fixedFlag$sample16)
+			var28[1] = t;
 		
 		// Calculate the probabilities for every sample task in the model. These values are
 		// then used to calculate the probabilities of random variables and the model as a
@@ -864,7 +887,14 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// through the model. Any non-fixed sample values may be sampled to random variables
 	// as part of this process.
 	@Override
-	public final void setIntermediates() {}
+	public final void setIntermediates() {
+		double[] inner = bias[0];
+		if(fixedFlag$sample10)
+			inner[0] = q;
+		double[] var28 = bias[0];
+		if(fixedFlag$sample16)
+			var28[1] = t;
+	}
 
 	@Override
 	public String modelCode() {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$SingleThreadCPU_optimisedModel.java
@@ -639,9 +639,10 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		if(!fixedFlag$sample16)
 			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
 		if(!fixedFlag$sample16)
 			bias[0][1] = t;
-		inner[0] = q;
 		for(int var46 = 0; var46 < samples; var46 += 1)
 			flips[var46] = DistributionSampling.sampleBernoulli(RNG$, inner[b]);
 	}
@@ -652,6 +653,13 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationDistributionsNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -660,6 +668,13 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationValuesNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -782,6 +797,13 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		// Generate sample values for every call to sample in the model.
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 		
 		// Calculate the probabilities for every sample task in the model. These values are
 		// then used to calculate the probabilities of random variables and the model as a
@@ -805,7 +827,13 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// through the model. Any non-fixed sample values may be sampled to random variables
 	// as part of this process.
 	@Override
-	public final void setIntermediates() {}
+	public final void setIntermediates() {
+		if(fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(fixedFlag$sample16)
+			bias[0][1] = t;
+	}
 
 	@Override
 	public String modelCode() {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$SingleThreadCPU_optimisedModelNoComments.java
@@ -273,9 +273,10 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		if(!fixedFlag$sample16)
 			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
 		if(!fixedFlag$sample16)
 			bias[0][1] = t;
-		inner[0] = q;
 		for(int var46 = 0; var46 < samples; var46 += 1)
 			flips[var46] = DistributionSampling.sampleBernoulli(RNG$, inner[b]);
 	}
@@ -284,12 +285,24 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationDistributionsNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 	}
 
 	@Override
@@ -362,6 +375,12 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void logProbabilityGeneration() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 		logModelProbabilitiesVal();
 	}
 
@@ -373,7 +392,12 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	}
 
 	@Override
-	public final void setIntermediates() {}
+	public final void setIntermediates() {
+		if(fixedFlag$sample10)
+			bias[0][0] = q;
+		if(fixedFlag$sample16)
+			bias[0][1] = t;
+	}
 
 	@Override
 	public String modelCode() {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19$SingleThreadCPU_optimisedModelSingle.java
@@ -639,9 +639,10 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		if(!fixedFlag$sample16)
 			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 		double[] inner = bias[0];
+		if(!fixedFlag$sample10)
+			inner[0] = q;
 		if(!fixedFlag$sample16)
 			bias[0][1] = t;
-		inner[0] = q;
 		for(int var46 = 0; var46 < samples; var46 += 1)
 			flips[var46] = DistributionSampling.sampleBernoulli(RNG$, inner[b]);
 	}
@@ -652,6 +653,13 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationDistributionsNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -660,6 +668,13 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationValuesNoOutputs() {
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -782,6 +797,13 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		// Generate sample values for every call to sample in the model.
 		if(!fixedFlag$sample10)
 			q = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample16)
+			t = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+		if(!fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(!fixedFlag$sample16)
+			bias[0][1] = t;
 		
 		// Calculate the probabilities for every sample task in the model. These values are
 		// then used to calculate the probabilities of random variables and the model as a
@@ -805,7 +827,13 @@ class Flip1CoinMK19$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// through the model. Any non-fixed sample values may be sampled to random variables
 	// as part of this process.
 	@Override
-	public final void setIntermediates() {}
+	public final void setIntermediates() {
+		if(fixedFlag$sample10)
+			// Substituted "inner" with its value "bias[0]".
+			bias[0][0] = q;
+		if(fixedFlag$sample16)
+			bias[0][1] = t;
+	}
 
 	@Override
 	public String modelCode() {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_model.java
@@ -9746,7 +9746,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 									// generator.
 									for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
-										if(metric_valid_g[sample][timeStep$var136]) {
+										if(metric_valid_1d[timeStep$var136]) {
 											var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 										}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_modelNoComments.java
@@ -6850,7 +6850,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 							(int forStart$timeStep$var136, int forEnd$timeStep$var136, int threadID$timeStep$var136, org.sandwood.random.internal.Rng RNG$2) -> { 
 								for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
-										if(metric_valid_g[sample][timeStep$var136]) {
+										if(metric_valid_1d[timeStep$var136]) {
 											var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 										}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_modelSingle.java
@@ -9649,7 +9649,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 									// generator.
 									for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
-										if(metric_valid_g[sample][timeStep$var136]) {
+										if(metric_valid_1d[timeStep$var136]) {
 											var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 										}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_optimisedModel.java
@@ -5208,7 +5208,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 									// generator.
 									for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
-										if(metric_valid_g[sample][timeStep$var136]) {
+										if(metric_valid_1d[timeStep$var136]) {
 											var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 										}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_optimisedModelNoComments.java
@@ -2091,7 +2091,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 							(int forStart$timeStep$var136, int forEnd$timeStep$var136, int threadID$timeStep$var136, org.sandwood.random.internal.Rng RNG$2) -> { 
 								for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
-										if(metric_valid_g[sample][timeStep$var136]) {
+										if(metric_valid_1d[timeStep$var136]) {
 											var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 										}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_optimisedModelSingle.java
@@ -5190,7 +5190,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 									// generator.
 									for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
-										if(metric_valid_g[sample][timeStep$var136]) {
+										if(metric_valid_1d[timeStep$var136]) {
 											var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 										}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_model.java
@@ -9633,7 +9633,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			double[] metric_1d = metric_g[sample];
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
-				if(metric_valid_g[sample][timeStep$var136]) {
+				if(metric_valid_1d[timeStep$var136]) {
 					var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 				}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_modelNoComments.java
@@ -6797,7 +6797,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			double[] metric_1d = metric_g[sample];
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
-				if(metric_valid_g[sample][timeStep$var136]) {
+				if(metric_valid_1d[timeStep$var136]) {
 					var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 				}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_modelSingle.java
@@ -9536,7 +9536,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			double[] metric_1d = metric_g[sample];
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
-				if(metric_valid_g[sample][timeStep$var136]) {
+				if(metric_valid_1d[timeStep$var136]) {
 					var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 				}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_optimisedModel.java
@@ -5108,7 +5108,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			double[] metric_1d = metric_g[sample];
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
-				if(metric_valid_g[sample][timeStep$var136]) {
+				if(metric_valid_1d[timeStep$var136]) {
 					var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 				}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_optimisedModelNoComments.java
@@ -2031,7 +2031,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			double[] metric_1d = metric_g[sample];
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
-				if(metric_valid_g[sample][timeStep$var136]) {
+				if(metric_valid_1d[timeStep$var136]) {
 					var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 				}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_optimisedModelSingle.java
@@ -5090,7 +5090,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			double[] metric_1d = metric_g[sample];
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
-				if(metric_valid_g[sample][timeStep$var136]) {
+				if(metric_valid_1d[timeStep$var136]) {
 					var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 				}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$MultiThreadCPU_model.java
@@ -10500,7 +10500,7 @@ class HMMMetrics4$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 													// generator.
 													for(int timeStep$var226 = forStart$timeStep$var226; timeStep$var226 < forEnd$timeStep$var226; timeStep$var226 += 1) {
 														metric_valid_inner[timeStep$var226] = DistributionSampling.sampleBernoulli(RNG$3, current_metric_valid_bias[server][st[sample$var196][timeStep$var226]]);
-														if(var215[server][timeStep$var226]) {
+														if(metric_valid_inner[timeStep$var226]) {
 															var245[((sample$var196 - 0) / 1)][((server - 0) / 1)][((timeStep$var226 - 0) / 1)] = ((Math.sqrt(current_metric_var[server][st[sample$var196][timeStep$var226]]) * DistributionSampling.sampleGaussian(RNG$3)) + current_metric_mean[server][st[sample$var196][timeStep$var226]]);
 															metric_inner[timeStep$var226] = var245[((sample$var196 - 0) / 1)][((server - 0) / 1)][((timeStep$var226 - 0) / 1)];
 														}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$MultiThreadCPU_modelNoComments.java
@@ -7570,7 +7570,7 @@ class HMMMetrics4$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 											(int forStart$timeStep$var226, int forEnd$timeStep$var226, int threadID$timeStep$var226, org.sandwood.random.internal.Rng RNG$3) -> { 
 												for(int timeStep$var226 = forStart$timeStep$var226; timeStep$var226 < forEnd$timeStep$var226; timeStep$var226 += 1) {
 														metric_valid_inner[timeStep$var226] = DistributionSampling.sampleBernoulli(RNG$3, current_metric_valid_bias[server][st[sample$var196][timeStep$var226]]);
-														if(var215[server][timeStep$var226]) {
+														if(metric_valid_inner[timeStep$var226]) {
 															var245[((sample$var196 - 0) / 1)][((server - 0) / 1)][((timeStep$var226 - 0) / 1)] = ((Math.sqrt(current_metric_var[server][st[sample$var196][timeStep$var226]]) * DistributionSampling.sampleGaussian(RNG$3)) + current_metric_mean[server][st[sample$var196][timeStep$var226]]);
 															metric_inner[timeStep$var226] = var245[((sample$var196 - 0) / 1)][((server - 0) / 1)][((timeStep$var226 - 0) / 1)];
 														}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$MultiThreadCPU_modelSingle.java
@@ -10379,7 +10379,7 @@ class HMMMetrics4$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 													// generator.
 													for(int timeStep$var226 = forStart$timeStep$var226; timeStep$var226 < forEnd$timeStep$var226; timeStep$var226 += 1) {
 														metric_valid_inner[timeStep$var226] = DistributionSampling.sampleBernoulli(RNG$3, current_metric_valid_bias[server][st[sample$var196][timeStep$var226]]);
-														if(var215[server][timeStep$var226]) {
+														if(metric_valid_inner[timeStep$var226]) {
 															var245[((sample$var196 - 0) / 1)][((server - 0) / 1)][((timeStep$var226 - 0) / 1)] = ((Math.sqrt(current_metric_var[server][st[sample$var196][timeStep$var226]]) * DistributionSampling.sampleGaussian(RNG$3)) + current_metric_mean[server][st[sample$var196][timeStep$var226]]);
 															metric_inner[timeStep$var226] = var245[((sample$var196 - 0) / 1)][((server - 0) / 1)][((timeStep$var226 - 0) / 1)];
 														}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$MultiThreadCPU_optimisedModel.java
@@ -5399,7 +5399,6 @@ class HMMMetrics4$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 					for(int index$sample$var196 = forStart$index$sample$var196; index$sample$var196 < forEnd$index$sample$var196; index$sample$var196 += 1) {
 						int sample$var196 = index$sample$var196;
 						int threadID$sample$var196 = threadID$index$sample$var196;
-						boolean[][] var215 = metric_valid_g[sample$var196];
 						double[][] var211 = metric_g[sample$var196];
 						
 						//  Outer loop for dispatching multiple batches of iterations to execute in parallel
@@ -5422,7 +5421,7 @@ class HMMMetrics4$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 													// generator.
 													for(int timeStep$var226 = forStart$timeStep$var226; timeStep$var226 < forEnd$timeStep$var226; timeStep$var226 += 1) {
 														metric_valid_inner[timeStep$var226] = DistributionSampling.sampleBernoulli(RNG$3, current_metric_valid_bias[server][st[sample$var196][timeStep$var226]]);
-														if(var215[server][timeStep$var226]) {
+														if(metric_valid_inner[timeStep$var226]) {
 															var245[sample$var196][server][timeStep$var226] = ((Math.sqrt(current_metric_var[server][st[sample$var196][timeStep$var226]]) * DistributionSampling.sampleGaussian(RNG$3)) + current_metric_mean[server][st[sample$var196][timeStep$var226]]);
 															metric_inner[timeStep$var226] = var245[sample$var196][server][timeStep$var226];
 														}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$MultiThreadCPU_optimisedModelNoComments.java
@@ -2232,7 +2232,6 @@ class HMMMetrics4$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 				for(int index$sample$var196 = forStart$index$sample$var196; index$sample$var196 < forEnd$index$sample$var196; index$sample$var196 += 1) {
 						int sample$var196 = index$sample$var196;
 						int threadID$sample$var196 = threadID$index$sample$var196;
-						boolean[][] var215 = metric_valid_g[sample$var196];
 						double[][] var211 = metric_g[sample$var196];
 						parallelFor(RNG$1, 0, noServers, 1,
 							(int forStart$index$server, int forEnd$index$server, int threadID$index$server, org.sandwood.random.internal.Rng RNG$2) -> { 
@@ -2245,7 +2244,7 @@ class HMMMetrics4$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 											(int forStart$timeStep$var226, int forEnd$timeStep$var226, int threadID$timeStep$var226, org.sandwood.random.internal.Rng RNG$3) -> { 
 												for(int timeStep$var226 = forStart$timeStep$var226; timeStep$var226 < forEnd$timeStep$var226; timeStep$var226 += 1) {
 														metric_valid_inner[timeStep$var226] = DistributionSampling.sampleBernoulli(RNG$3, current_metric_valid_bias[server][st[sample$var196][timeStep$var226]]);
-														if(var215[server][timeStep$var226]) {
+														if(metric_valid_inner[timeStep$var226]) {
 															var245[sample$var196][server][timeStep$var226] = ((Math.sqrt(current_metric_var[server][st[sample$var196][timeStep$var226]]) * DistributionSampling.sampleGaussian(RNG$3)) + current_metric_mean[server][st[sample$var196][timeStep$var226]]);
 															metric_inner[timeStep$var226] = var245[sample$var196][server][timeStep$var226];
 														}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$MultiThreadCPU_optimisedModelSingle.java
@@ -5357,7 +5357,6 @@ class HMMMetrics4$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 					for(int index$sample$var196 = forStart$index$sample$var196; index$sample$var196 < forEnd$index$sample$var196; index$sample$var196 += 1) {
 						int sample$var196 = index$sample$var196;
 						int threadID$sample$var196 = threadID$index$sample$var196;
-						boolean[][] var215 = metric_valid_g[sample$var196];
 						double[][] var211 = metric_g[sample$var196];
 						
 						//  Outer loop for dispatching multiple batches of iterations to execute in parallel
@@ -5380,7 +5379,7 @@ class HMMMetrics4$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 													// generator.
 													for(int timeStep$var226 = forStart$timeStep$var226; timeStep$var226 < forEnd$timeStep$var226; timeStep$var226 += 1) {
 														metric_valid_inner[timeStep$var226] = DistributionSampling.sampleBernoulli(RNG$3, current_metric_valid_bias[server][st[sample$var196][timeStep$var226]]);
-														if(var215[server][timeStep$var226]) {
+														if(metric_valid_inner[timeStep$var226]) {
 															var245[sample$var196][server][timeStep$var226] = ((Math.sqrt(current_metric_var[server][st[sample$var196][timeStep$var226]]) * DistributionSampling.sampleGaussian(RNG$3)) + current_metric_mean[server][st[sample$var196][timeStep$var226]]);
 															metric_inner[timeStep$var226] = var245[sample$var196][server][timeStep$var226];
 														}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$SingleThreadCPU_model.java
@@ -10342,7 +10342,7 @@ class HMMMetrics4$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 				double[] metric_inner = var211[server];
 				for(int timeStep$var226 = 0; timeStep$var226 < length$metric[sample$var196][0]; timeStep$var226 += 1) {
 					metric_valid_inner[timeStep$var226] = DistributionSampling.sampleBernoulli(RNG$, current_metric_valid_bias[server][st[sample$var196][timeStep$var226]]);
-					if(var215[server][timeStep$var226]) {
+					if(metric_valid_inner[timeStep$var226]) {
 						var245[((sample$var196 - 0) / 1)][((server - 0) / 1)][((timeStep$var226 - 0) / 1)] = ((Math.sqrt(current_metric_var[server][st[sample$var196][timeStep$var226]]) * DistributionSampling.sampleGaussian(RNG$)) + current_metric_mean[server][st[sample$var196][timeStep$var226]]);
 						metric_inner[timeStep$var226] = var245[((sample$var196 - 0) / 1)][((server - 0) / 1)][((timeStep$var226 - 0) / 1)];
 					}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$SingleThreadCPU_modelNoComments.java
@@ -7497,7 +7497,7 @@ class HMMMetrics4$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 				double[] metric_inner = var211[server];
 				for(int timeStep$var226 = 0; timeStep$var226 < length$metric[sample$var196][0]; timeStep$var226 += 1) {
 					metric_valid_inner[timeStep$var226] = DistributionSampling.sampleBernoulli(RNG$, current_metric_valid_bias[server][st[sample$var196][timeStep$var226]]);
-					if(var215[server][timeStep$var226]) {
+					if(metric_valid_inner[timeStep$var226]) {
 						var245[((sample$var196 - 0) / 1)][((server - 0) / 1)][((timeStep$var226 - 0) / 1)] = ((Math.sqrt(current_metric_var[server][st[sample$var196][timeStep$var226]]) * DistributionSampling.sampleGaussian(RNG$)) + current_metric_mean[server][st[sample$var196][timeStep$var226]]);
 						metric_inner[timeStep$var226] = var245[((sample$var196 - 0) / 1)][((server - 0) / 1)][((timeStep$var226 - 0) / 1)];
 					}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$SingleThreadCPU_modelSingle.java
@@ -10221,7 +10221,7 @@ class HMMMetrics4$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 				double[] metric_inner = var211[server];
 				for(int timeStep$var226 = 0; timeStep$var226 < length$metric[sample$var196][0]; timeStep$var226 += 1) {
 					metric_valid_inner[timeStep$var226] = DistributionSampling.sampleBernoulli(RNG$, current_metric_valid_bias[server][st[sample$var196][timeStep$var226]]);
-					if(var215[server][timeStep$var226]) {
+					if(metric_valid_inner[timeStep$var226]) {
 						var245[((sample$var196 - 0) / 1)][((server - 0) / 1)][((timeStep$var226 - 0) / 1)] = ((Math.sqrt(current_metric_var[server][st[sample$var196][timeStep$var226]]) * DistributionSampling.sampleGaussian(RNG$)) + current_metric_mean[server][st[sample$var196][timeStep$var226]]);
 						metric_inner[timeStep$var226] = var245[((sample$var196 - 0) / 1)][((server - 0) / 1)][((timeStep$var226 - 0) / 1)];
 					}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$SingleThreadCPU_optimisedModel.java
@@ -5258,14 +5258,13 @@ class HMMMetrics4$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			}
 		}
 		for(int sample$var196 = 0; sample$var196 < noSamples; sample$var196 += 1) {
-			boolean[][] var215 = metric_valid_g[sample$var196];
 			double[][] var211 = metric_g[sample$var196];
 			for(int server = 0; server < noServers; server += 1) {
 				boolean[] metric_valid_inner = metric_valid_g[sample$var196][server];
 				double[] metric_inner = var211[server];
 				for(int timeStep$var226 = 0; timeStep$var226 < length$metric[sample$var196][0]; timeStep$var226 += 1) {
 					metric_valid_inner[timeStep$var226] = DistributionSampling.sampleBernoulli(RNG$, current_metric_valid_bias[server][st[sample$var196][timeStep$var226]]);
-					if(var215[server][timeStep$var226]) {
+					if(metric_valid_inner[timeStep$var226]) {
 						var245[sample$var196][server][timeStep$var226] = ((Math.sqrt(current_metric_var[server][st[sample$var196][timeStep$var226]]) * DistributionSampling.sampleGaussian(RNG$)) + current_metric_mean[server][st[sample$var196][timeStep$var226]]);
 						metric_inner[timeStep$var226] = var245[sample$var196][server][timeStep$var226];
 					}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$SingleThreadCPU_optimisedModelNoComments.java
@@ -2158,14 +2158,13 @@ class HMMMetrics4$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			}
 		}
 		for(int sample$var196 = 0; sample$var196 < noSamples; sample$var196 += 1) {
-			boolean[][] var215 = metric_valid_g[sample$var196];
 			double[][] var211 = metric_g[sample$var196];
 			for(int server = 0; server < noServers; server += 1) {
 				boolean[] metric_valid_inner = metric_valid_g[sample$var196][server];
 				double[] metric_inner = var211[server];
 				for(int timeStep$var226 = 0; timeStep$var226 < length$metric[sample$var196][0]; timeStep$var226 += 1) {
 					metric_valid_inner[timeStep$var226] = DistributionSampling.sampleBernoulli(RNG$, current_metric_valid_bias[server][st[sample$var196][timeStep$var226]]);
-					if(var215[server][timeStep$var226]) {
+					if(metric_valid_inner[timeStep$var226]) {
 						var245[sample$var196][server][timeStep$var226] = ((Math.sqrt(current_metric_var[server][st[sample$var196][timeStep$var226]]) * DistributionSampling.sampleGaussian(RNG$)) + current_metric_mean[server][st[sample$var196][timeStep$var226]]);
 						metric_inner[timeStep$var226] = var245[sample$var196][server][timeStep$var226];
 					}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4$SingleThreadCPU_optimisedModelSingle.java
@@ -5216,14 +5216,13 @@ class HMMMetrics4$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			}
 		}
 		for(int sample$var196 = 0; sample$var196 < noSamples; sample$var196 += 1) {
-			boolean[][] var215 = metric_valid_g[sample$var196];
 			double[][] var211 = metric_g[sample$var196];
 			for(int server = 0; server < noServers; server += 1) {
 				boolean[] metric_valid_inner = metric_valid_g[sample$var196][server];
 				double[] metric_inner = var211[server];
 				for(int timeStep$var226 = 0; timeStep$var226 < length$metric[sample$var196][0]; timeStep$var226 += 1) {
 					metric_valid_inner[timeStep$var226] = DistributionSampling.sampleBernoulli(RNG$, current_metric_valid_bias[server][st[sample$var196][timeStep$var226]]);
-					if(var215[server][timeStep$var226]) {
+					if(metric_valid_inner[timeStep$var226]) {
 						var245[sample$var196][server][timeStep$var226] = ((Math.sqrt(current_metric_var[server][st[sample$var196][timeStep$var226]]) * DistributionSampling.sampleGaussian(RNG$)) + current_metric_mean[server][st[sample$var196][timeStep$var226]]);
 						metric_inner[timeStep$var226] = var245[sample$var196][server][timeStep$var226];
 					}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan$MultiThreadCPU_optimisedModel.java
@@ -917,6 +917,13 @@ class HMMTestFromStan$MultiThreadCPU extends org.sandwood.runtime.internal.model
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestFromStan$MultiThreadCPU extends org.sandwood.runtime.internal.model
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan$MultiThreadCPU_optimisedModelNoComments.java
@@ -348,6 +348,7 @@ class HMMTestFromStan$MultiThreadCPU extends org.sandwood.runtime.internal.model
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[0][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -357,6 +358,7 @@ class HMMTestFromStan$MultiThreadCPU extends org.sandwood.runtime.internal.model
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 1;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[1][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan$MultiThreadCPU_optimisedModelSingle.java
@@ -917,6 +917,13 @@ class HMMTestFromStan$MultiThreadCPU extends org.sandwood.runtime.internal.model
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestFromStan$MultiThreadCPU extends org.sandwood.runtime.internal.model
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan$SingleThreadCPU_optimisedModel.java
@@ -921,6 +921,13 @@ class HMMTestFromStan$SingleThreadCPU extends org.sandwood.runtime.internal.mode
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestFromStan$SingleThreadCPU extends org.sandwood.runtime.internal.mode
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan$SingleThreadCPU_optimisedModelNoComments.java
@@ -346,6 +346,7 @@ class HMMTestFromStan$SingleThreadCPU extends org.sandwood.runtime.internal.mode
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[0][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -355,6 +356,7 @@ class HMMTestFromStan$SingleThreadCPU extends org.sandwood.runtime.internal.mode
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 1;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[1][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan$SingleThreadCPU_optimisedModelSingle.java
@@ -921,6 +921,13 @@ class HMMTestFromStan$SingleThreadCPU extends org.sandwood.runtime.internal.mode
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestFromStan$SingleThreadCPU extends org.sandwood.runtime.internal.mode
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3$MultiThreadCPU_optimisedModel.java
@@ -917,6 +917,13 @@ class HMMTestPart3$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestPart3$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3$MultiThreadCPU_optimisedModelNoComments.java
@@ -348,6 +348,7 @@ class HMMTestPart3$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[0][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -357,6 +358,7 @@ class HMMTestPart3$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 1;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[1][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3$MultiThreadCPU_optimisedModelSingle.java
@@ -917,6 +917,13 @@ class HMMTestPart3$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestPart3$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3$SingleThreadCPU_optimisedModel.java
@@ -921,6 +921,13 @@ class HMMTestPart3$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestPart3$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3$SingleThreadCPU_optimisedModelNoComments.java
@@ -346,6 +346,7 @@ class HMMTestPart3$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[0][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -355,6 +356,7 @@ class HMMTestPart3$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 1;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[1][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3$SingleThreadCPU_optimisedModelSingle.java
@@ -921,6 +921,13 @@ class HMMTestPart3$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestPart3$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b$MultiThreadCPU_optimisedModel.java
@@ -917,6 +917,13 @@ class HMMTestPart3b$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestPart3b$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b$MultiThreadCPU_optimisedModelNoComments.java
@@ -348,6 +348,7 @@ class HMMTestPart3b$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[0][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -357,6 +358,7 @@ class HMMTestPart3b$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 1;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[1][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b$MultiThreadCPU_optimisedModelSingle.java
@@ -917,6 +917,13 @@ class HMMTestPart3b$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestPart3b$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b$SingleThreadCPU_optimisedModel.java
@@ -921,6 +921,13 @@ class HMMTestPart3b$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestPart3b$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b$SingleThreadCPU_optimisedModelNoComments.java
@@ -346,6 +346,7 @@ class HMMTestPart3b$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[0][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -355,6 +356,7 @@ class HMMTestPart3b$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 1;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[1][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b$SingleThreadCPU_optimisedModelSingle.java
@@ -921,6 +921,13 @@ class HMMTestPart3b$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestPart3b$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c$MultiThreadCPU_optimisedModel.java
@@ -917,6 +917,13 @@ class HMMTestPart3c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestPart3c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c$MultiThreadCPU_optimisedModelNoComments.java
@@ -348,6 +348,7 @@ class HMMTestPart3c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[0][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -357,6 +358,7 @@ class HMMTestPart3c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 1;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[1][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c$MultiThreadCPU_optimisedModelSingle.java
@@ -917,6 +917,13 @@ class HMMTestPart3c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestPart3c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c$SingleThreadCPU_optimisedModel.java
@@ -921,6 +921,13 @@ class HMMTestPart3c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestPart3c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c$SingleThreadCPU_optimisedModelNoComments.java
@@ -346,6 +346,7 @@ class HMMTestPart3c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[0][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -355,6 +356,7 @@ class HMMTestPart3c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 1;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[1][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c$SingleThreadCPU_optimisedModelSingle.java
@@ -921,6 +921,13 @@ class HMMTestPart3c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestPart3c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5$MultiThreadCPU_optimisedModel.java
@@ -917,6 +917,13 @@ class HMMTestPart5$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestPart5$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 2;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5$MultiThreadCPU_optimisedModelNoComments.java
@@ -348,6 +348,7 @@ class HMMTestPart5$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= (st[1] / 2)) && ((st[1] / 2) < 2))?Math.log(m[0][(st[1] / 2)]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -357,6 +358,7 @@ class HMMTestPart5$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 2;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= (st[1] / 2)) && ((st[1] / 2) < 2))?Math.log(m[2][(st[1] / 2)]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5$MultiThreadCPU_optimisedModelSingle.java
@@ -917,6 +917,13 @@ class HMMTestPart5$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestPart5$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 2;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5$SingleThreadCPU_optimisedModel.java
@@ -921,6 +921,13 @@ class HMMTestPart5$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestPart5$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 2;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5$SingleThreadCPU_optimisedModelNoComments.java
@@ -346,6 +346,7 @@ class HMMTestPart5$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= (st[1] / 2)) && ((st[1] / 2) < 2))?Math.log(m[0][(st[1] / 2)]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -355,6 +356,7 @@ class HMMTestPart5$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 2;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= (st[1] / 2)) && ((st[1] / 2) < 2))?Math.log(m[2][(st[1] / 2)]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5$SingleThreadCPU_optimisedModelSingle.java
@@ -921,6 +921,13 @@ class HMMTestPart5$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestPart5$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 2;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b$MultiThreadCPU_optimisedModel.java
@@ -917,6 +917,13 @@ class HMMTestPart5b$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestPart5b$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 2;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b$MultiThreadCPU_optimisedModelNoComments.java
@@ -348,6 +348,7 @@ class HMMTestPart5b$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= (st[1] / 2)) && ((st[1] / 2) < 2))?Math.log(m[0][(st[1] / 2)]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -357,6 +358,7 @@ class HMMTestPart5b$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 2;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= (st[1] / 2)) && ((st[1] / 2) < 2))?Math.log(m[2][(st[1] / 2)]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b$MultiThreadCPU_optimisedModelSingle.java
@@ -917,6 +917,13 @@ class HMMTestPart5b$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestPart5b$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 2;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b$SingleThreadCPU_optimisedModel.java
@@ -921,6 +921,13 @@ class HMMTestPart5b$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestPart5b$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 2;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b$SingleThreadCPU_optimisedModelNoComments.java
@@ -346,6 +346,7 @@ class HMMTestPart5b$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= (st[1] / 2)) && ((st[1] / 2) < 2))?Math.log(m[0][(st[1] / 2)]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -355,6 +356,7 @@ class HMMTestPart5b$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 2;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= (st[1] / 2)) && ((st[1] / 2) < 2))?Math.log(m[2][(st[1] / 2)]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b$SingleThreadCPU_optimisedModelSingle.java
@@ -921,6 +921,13 @@ class HMMTestPart5b$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestPart5b$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 2;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6$MultiThreadCPU_optimisedModel.java
@@ -917,6 +917,13 @@ class HMMTestPart6$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestPart6$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6$MultiThreadCPU_optimisedModelNoComments.java
@@ -348,6 +348,7 @@ class HMMTestPart6$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[1][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -357,6 +358,7 @@ class HMMTestPart6$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 1;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[0][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6$MultiThreadCPU_optimisedModelSingle.java
@@ -917,6 +917,13 @@ class HMMTestPart6$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -999,6 +1006,13 @@ class HMMTestPart6$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6$SingleThreadCPU_optimisedModel.java
@@ -921,6 +921,13 @@ class HMMTestPart6$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestPart6$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6$SingleThreadCPU_optimisedModelNoComments.java
@@ -346,6 +346,7 @@ class HMMTestPart6$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	private final void sample53() {
 		{
+			st[0] = 0;
 			double cv$accumulatedProbabilities = Math.log(m[0][0]);
 			if((1 < samples))
 				cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[1][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
@@ -355,6 +356,7 @@ class HMMTestPart6$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			}
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		st[0] = 1;
 		double cv$accumulatedProbabilities = Math.log(m[0][1]);
 		if((1 < samples))
 			cv$accumulatedProbabilities = ((((0.0 <= st[1]) && (st[1] < 2))?Math.log(m[0][st[1]]):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6$SingleThreadCPU_optimisedModelSingle.java
@@ -921,6 +921,13 @@ class HMMTestPart6$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	private final void sample53() {
 		// Unrolled loop
 		{
+			// Guards to ensure that st is only updated when there is a valid path.
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			st[0] = 0;
+			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
@@ -1003,6 +1010,13 @@ class HMMTestPart6$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Initialize a counter to track the reached distributions.
 			cv$var52$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
 		}
+		
+		// Guards to ensure that st is only updated when there is a valid path.
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		st[0] = 1;
 		
 		// An accumulator to allow the value for each distribution to be constructed before
 		// it is added to the index probabilities.


### PR DESCRIPTION
### Description
A set of fixes to the way arrays are handled including:
* Modification to prevent references to arrays being constructed multiple times.

* Extending the get all inputs method so that it also gets updates to array variables that may occur after the get that recovered a sub-array, but before the recovered array is read.

* Adding in protection so that arrays from different branches of a conditional are not returned when all instances of the array that could be used are recovered.
