### PR TITLE
Adding detection of which variables can be fixed at compile time, so that values that can never change are known

### DIFF
--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/APICompile.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/APICompile.java
@@ -283,11 +283,9 @@ public class APICompile {
         }
 
         // Fixed sample flags
-        for(SampleTask<?, ?> s:compilationCtx.traces.getAllSampleTasks()) {
-            if(!s.getOutput().isFixed()) {
-                VariableDescription<BooleanVariable> flagName = VariableNames.fixedFlagName(s);
-                compilationCtx.addFlagClassField(flagName, constant(false));
-            }
+        for(SampleTask<?, ?> s:compilationCtx.traces.getFixableTasks()) {
+            VariableDescription<BooleanVariable> flagName = VariableNames.fixedFlagName(s);
+            compilationCtx.addFlagClassField(flagName, constant(false));
         }
 
         // Inputs
@@ -657,8 +655,10 @@ public class APICompile {
 
         IRTreeReturn<?>[] argsArray = args.toArray(new IRTreeReturn<?>[args.size()]);
         IRTreeVoid functionCall = functionCall(f.name, Tree.NoComment, argsArray);
-        IRTreeReturn<BooleanVariable> valueFixed = negateBoolean(load(VariableNames.fixedFlagName(sampleTask)));
-        functionCall = ifElse(valueFixed, functionCall, Tree.NoComment);
+        if(compilationCtx.traces.getFixableTasks().contains(sampleTask)) {
+            IRTreeReturn<BooleanVariable> valueFixed = negateBoolean(load(VariableNames.fixedFlagName(sampleTask)));
+            functionCall = ifElse(valueFixed, functionCall, Tree.NoComment);
+        }
 
         // Add the function to the tree of values to execute.
         compilationCtx.addTreeToScope(scope, functionCall);
@@ -807,23 +807,22 @@ public class APICompile {
 
         // List of function calls needed to generate probabilities in the model for the
         // evidence pass.
-        IRTreeVoid[] probabilityCalls = new IRTreeVoid[p.size() + 1];
-        probabilityCalls[0] = functionCall(AuxFunctionType.INITIALIZE_LOG_PROBABILITY_FIELDS.functionName,
-                "Reset all the non-fixed probabilities ready to calculate the new values.");
+        List<IRTreeVoid> probabilityCalls = new ArrayList<>();
+        probabilityCalls.add(functionCall(AuxFunctionType.INITIALIZE_LOG_PROBABILITY_FIELDS.functionName,
+                "Reset all the non-fixed probabilities ready to calculate the new values."));
 
-        int i = 1;
         while(!p.isEmpty()) {
             SampleTask<?, ?> sampleTask = p.poll();
             IRFunction<?> f = evidenceFunctions.get(sampleTask);
             if(observedSamples.contains(sampleTask))
-                probabilityCalls[i++] = functionCall(f.name, Tree.NoComment);
-            else
-                probabilityCalls[i++] = ifElse(load(VariableNames.fixedFlagName(sampleTask)),
-                        functionCall(f.name, Tree.NoComment), Tree.NoComment);
+                probabilityCalls.add(functionCall(f.name, Tree.NoComment));
+            else if(compilationCtx.traces.getFixableTasks().contains(sampleTask))
+                probabilityCalls.add(ifElse(load(VariableNames.fixedFlagName(sampleTask)),
+                        functionCall(f.name, Tree.NoComment), Tree.NoComment));
         }
 
-        if(i > 1)
-            probabilityCalls[1].prefixComment("Call each method in turn to generate the new probability values.");
+        if(probabilityCalls.size() > 1)
+            probabilityCalls.get(1).prefixComment("Call each method in turn to generate the new probability values.");
 
         // Construct a method to generate the probabilities.
         compilationCtx.addFunction(AuxFunctionType.LOG_EVIDENCE_PROBABILITIES, Visibility.PUBLIC, new ArgDesc[0],

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ForwardExecutionBuilder.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ForwardExecutionBuilder.java
@@ -86,22 +86,22 @@ public class ForwardExecutionBuilder {
 
     public enum PrimingStatus {
         /**
-         *  Fixed intermediate variables need setting
+         * Fixed intermediate variables need setting
          */
         PRIMING,
         /**
-         *  Fixed intermediate variables will not be set.
+         * Fixed intermediate variables will not be set.
          */
         NOT_PRIMING
     }
 
     public enum Distributions {
         /**
-         *  Distributions should be used
+         * Distributions should be used
          */
         USE_DISTRIBUTIONS,
         /**
-         *  Distributions should not be used
+         * Distributions should not be used
          */
         NO_DISTRIBUTIONS
     }
@@ -131,7 +131,7 @@ public class ForwardExecutionBuilder {
                     SampleTask<?, ?> sTask = (SampleTask<?, ?>) task;
                     sTasks.add(sTask);
                 }
-                guard = constructGuard(sTasks, guardStatus);
+                guard = constructGuard(sTasks, guardStatus, compilationCtx);
                 compilationCtx.setCodeGuard(guard);
 
                 constructForwardRVDistribution((DistributableRandomVariable<?, ?>) rv, compilationCtx);
@@ -525,22 +525,25 @@ public class ForwardExecutionBuilder {
         Set<SampleTask<?, ?>> sampleTasks = new HashSet<>();
         for(Variable<?> v:vs)
             sampleTasks.addAll(getSourceSampleTasks(v, compilationCtx));
-        return constructGuard(sampleTasks, guardStatus);
+        return constructGuard(sampleTasks, guardStatus, compilationCtx);
     }
 
-    private static IRTreeReturn<BooleanVariable> constructGuard(Set<SampleTask<?, ?>> sTasks, GuardStatus guardStatus) {
+    private static IRTreeReturn<BooleanVariable> constructGuard(Set<SampleTask<?, ?>> sTasks, GuardStatus guardStatus,
+            CompilationContext compilationCtx) {
         return switch(guardStatus) {
             case FIXED, FREE -> {
-                IRTreeReturn<BooleanVariable> guard = null;
-
                 PriorityQueue<SampleTask<?, ?>> p = new PriorityQueue<>();
+                Set<SampleTask<?, ?>> fixable = compilationCtx.traces.getFixableTasks();
                 for(SampleTask<?, ?> s:sTasks) {
-                    if(!s.getOutput().isFixed()) // TODO add in a test to see if this fixed value can be fixed when
-                                                 // doing forward execution. If it can be add a guard, look at
-                                                 // Vulcano2012 for an example.
+                    if(fixable.contains(s))
                         p.add(s);
+                    else if(guardStatus == GuardStatus.FREE)
+                        yield null;
+                    else
+                        yield constant(false);
                 }
 
+                IRTreeReturn<BooleanVariable> guard = null;
                 if(!p.isEmpty()) {
                     VariableDescription<BooleanVariable> flagName = VariableNames.fixedFlagName(p.poll());
                     guard = load(flagName);

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ObservedValuePropagationBuilder.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ObservedValuePropagationBuilder.java
@@ -8,11 +8,13 @@
 
 package org.sandwood.compiler.compilation;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
@@ -33,11 +35,14 @@ import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.rvConstructor.RandomVariableConstructorTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.IfElseAssignmentTask;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
+import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
 import org.sandwood.compiler.dataflowGraph.variables.auxillary.DataflowTaskArgDesc;
+import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.BooleanVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
 import org.sandwood.compiler.exceptions.CompilerException;
 import org.sandwood.compiler.exceptions.SandwoodModelException;
+import org.sandwood.compiler.names.VariableNames;
 import org.sandwood.compiler.traces.Trace;
 import org.sandwood.compiler.traces.TraceHandle;
 import org.sandwood.compiler.traces.guards.BackTraceInfo;
@@ -194,6 +199,8 @@ public class ObservedValuePropagationBuilder {
     }
 
     public static void constructPropagateObservedValues(CompilationContext compilationCtx) {
+        // Reset any fixed flags
+        IRTreeVoid t0 = initialiseFixedFlags(compilationCtx);
 
         // Set any observed variables required as input to the observation task.
         IRTreeVoid t1 = initialiseConstants(compilationCtx);
@@ -207,9 +214,20 @@ public class ObservedValuePropagationBuilder {
         // Set any intermediates that are fixed as their parents are fixed.
         IRTreeVoid t3 = forwardPropagateObservedVariables(setIntermediates, compilationCtx);
 
-        IRTreeVoid funcBody = IRTree.sequential(Tree.NoComment, t1, t2, t3);
+        IRTreeVoid funcBody = IRTree.sequential(Tree.NoComment, t0, t1, t2, t3);
         compilationCtx.addFunction(AuxFunctionType.OBSERVATION_PROPAGATION, Visibility.PUBLIC, new ArgDesc[0], funcBody,
                 true, "Method to propagate observed values back into the model.");
+    }
+
+    private static IRTreeVoid initialiseFixedFlags(CompilationContext compilationCtx) {
+        List<IRTreeVoid> l = new ArrayList<>();
+        for(SampleTask<?, ?> s:compilationCtx.traces.getFixableTasks()) {
+            if(s.getOutput().isFixed()) {
+                VariableDescription<BooleanVariable> fixedName = VariableNames.fixedFlagName(s);
+                l.add(IRTree.store(fixedName, IRTree.constant(false), Tree.NoComment));
+            }
+        }
+        return IRTree.sequential(l, "Reset any fixed flags on observed values");
     }
 
     private static IRTreeVoid initialiseConstants(CompilationContext compilationCtx) {

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ProbabilityFunction.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ProbabilityFunction.java
@@ -343,6 +343,10 @@ public class ProbabilityFunction {
 
         final Map<ProducingDataflowTask<?>, Set<TraceHandle>> conditionalTraces;
 
+        final Set<SampleTask<?, ?>> inputSamples = new HashSet<>();
+
+        final Set<SampleTask<?, ?>> fixable;
+        final boolean fixableProb;
         final VariableDescription<BooleanVariable> fixedFlagName;
         final VariableDescription<BooleanVariable> fixedProbFlagName;
 
@@ -368,6 +372,32 @@ public class ProbabilityFunction {
             this.compilationCtx = compilationCtx;
 
             singleSample = !compilationCtx.calculateIndividualProbabilities();
+
+            // Get all the input sample tasks
+            for(Variable<?> v:randomVariable.getParent().getInputs()) {
+                for(SampleTask<?, ?> s:compilationCtx.traces.getSourceSampleTasks(v)) {
+                    if(!s.getOutput().isFixed())
+                        inputSamples.add(s);
+                }
+            }
+
+            for(SampleTask<?, ?> s:compilationCtx.traces.getSourceSampleTasks(sampleTaskScope.getScopeCondition())) {
+                if(!s.getOutput().isFixed())
+                    inputSamples.add(s);
+            }
+
+            // Test if we should set a fixed flag.
+            // First check all sample tasks can be fixed
+            fixable = compilationCtx.traces.getFixableTasks();
+            boolean fixableProb = fixable.contains(sampleTask) || sampleTask.getOutput().isFixed();
+
+            for(SampleTask<?, ?> s:inputSamples) {
+                if(!fixable.contains(s) && !s.getOutput().isFixed()) {
+                    fixableProb = false;
+                    break;
+                }
+            }
+            this.fixableProb = fixableProb;
 
             // Find traces to any distributions that will need to be covered.
             if(useDistributions) {
@@ -558,11 +588,17 @@ public class ProbabilityFunction {
                 funcData.compilationCtx);
 
         // Construct a flag to determine if this probability is already calculated.
-        funcData.compilationCtx.addConstructedClassField(funcData.fixedProbFlagName, constant(false));
+        if(funcData.fixableProb) {
+            funcData.compilationCtx.addConstructedClassField(funcData.fixedProbFlagName, constant(false));
 
-        // Set the initialisation
-        IRTreeReturn<BooleanVariable> guard = negateBoolean(load(funcData.fixedProbFlagName));
-        funcData.toInitialize.add(new WrappedTree<IRTree, IRTreeVoid>(ifElse(guard, sampleAllocation, Tree.NoComment)));
+            // Set the initialisation
+            IRTreeReturn<BooleanVariable> guard = negateBoolean(load(funcData.fixedProbFlagName));
+            funcData.toInitialize
+                    .add(new WrappedTree<IRTree, IRTreeVoid>(ifElse(guard, sampleAllocation, Tree.NoComment)));
+        } else {
+            // Set the initialisation
+            funcData.toInitialize.add(new WrappedTree<IRTree, IRTreeVoid>(sampleAllocation));
+        }
 
         getInverseIR(funcData);
 
@@ -573,128 +609,130 @@ public class ProbabilityFunction {
         subtrees.add(funcData.compilationCtx.getOutermostScopeTree());
 
         // Test if we should set a fixed flag.
-        IRTreeReturn<BooleanVariable> fixed;
-        if(funcData.sampleVariable.isFixed()) {
-            fixed = IRTree.constant(true);
-        } else {
-            fixed = load(funcData.fixedFlagName);
-            // Add side effect to clear the flag if a dependency given the ability to changed
-            IRTreeVoid restFixed = store(funcData.fixedProbFlagName,
-                    and(load(funcData.fixedFlagName), load(funcData.fixedProbFlagName)),
-                    "Should the probability of sample " + funcData.sampleTask.id()
-                            + " be set to fixed. This will only every change the flag to false.");
-            funcData.compilationCtx.addSetSideEffect(funcData.fixedFlagName, restFixed);
-
-            // Add side effect to clear the flag if a dependency is changed.
-            VariableDescription<?> sampleName = funcData.sampleVariable.getUniqueVarDesc();
-            restFixed = store(funcData.fixedProbFlagName, constant(false),
-                    "Unset the fixed probability flag for sample " + funcData.sampleTask.id() + " as it depends on "
-                            + sampleName.name + ".");
-            funcData.compilationCtx.addSetSideEffect(sampleName, restFixed);
-        }
-
-        // Gather all the sample tasks that are used as inputs.
-        Set<SampleTask<?, ?>> inputSamples = new HashSet<>();
-        for(Variable<?> v:funcData.randomVariable.getParent().getInputs()) {
-            for(SampleTask<?, ?> s:funcData.compilationCtx.traces.getSourceSampleTasks(v)) {
-                if(!s.getOutput().isFixed())
-                    inputSamples.add(s);
-            }
-        }
-
-        for(SampleTask<?, ?> s:funcData.compilationCtx.traces
-                .getSourceSampleTasks(funcData.sampleTaskScope.getScopeCondition())) {
-            if(!s.getOutput().isFixed())
-                inputSamples.add(s);
-        }
-        
-        // Construct an expression to determine if the flag should be set.
-        if(!inputSamples.isEmpty()) {
-            // Priority queue for fixed ordering of assignments.
-            PriorityQueue<SampleTask<?, ?>> p = new PriorityQueue<>(inputSamples);
-            while(!p.isEmpty()) {
-                SampleTask<?, ?> s = p.poll();
-                VariableDescription<BooleanVariable> sampleFixedName = VariableNames.fixedFlagName(s);
-                fixed = IRTree.and(fixed, load(sampleFixedName));
-
+        IRTreeVoid generateValues;
+        // TODO restructure the guards here.
+        if(funcData.fixableProb) {
+            IRTreeReturn<BooleanVariable> fixed;
+            if(funcData.sampleVariable.isFixed()) {
+                fixed = IRTree.constant(true);
+            } else {
+                fixed = load(funcData.fixedFlagName);
                 // Add side effect to clear the flag if a dependency given the ability to changed
                 IRTreeVoid restFixed = store(funcData.fixedProbFlagName,
-                        and(load(sampleFixedName), load(funcData.fixedProbFlagName)),
+                        and(load(funcData.fixedFlagName), load(funcData.fixedProbFlagName)),
                         "Should the probability of sample " + funcData.sampleTask.id()
                                 + " be set to fixed. This will only every change the flag to false.");
-                funcData.compilationCtx.addSetSideEffect(sampleFixedName, restFixed);
+                funcData.compilationCtx.addSetSideEffect(funcData.fixedFlagName, restFixed);
 
                 // Add side effect to clear the flag if a dependency is changed.
-                SampleTraceDesc sampleDesc = funcData.compilationCtx.traces.getSampleTrace(s);
-                VariableDescription<?> sampleName = sampleDesc.sampleVariable.getUniqueVarDesc();
+                VariableDescription<?> sampleName = funcData.sampleVariable.getUniqueVarDesc();
                 restFixed = store(funcData.fixedProbFlagName, constant(false),
                         "Unset the fixed probability flag for sample " + funcData.sampleTask.id() + " as it depends on "
                                 + sampleName.name + ".");
                 funcData.compilationCtx.addSetSideEffect(sampleName, restFixed);
             }
-        }
-        subtrees.add(store(funcData.fixedProbFlagName, fixed,
-                "Now the probability is calculated store if it can be cached or if it needs to be recalculated next time."));
 
-        // Join all the subtrees with a sequential block
-        IRTreeVoid generateValues = sequential(subtrees, "Generating probabilities for sample task");
-        if(funcData.sampleTask.isDistribution() && funcData.useDistributions)
-            generateValues = ifElse(load(funcData.fixedFlagName), generateValues,
-                    "Update the probability if the distribution is fixed to a specific value."
-                            + " If it is not the value is implicitly log(1.0) so has no effect.");
+            // Construct an expression to determine if the flag should be set.
+            if(!funcData.inputSamples.isEmpty()) {
+                // Priority queue for fixed ordering of assignments.
+                PriorityQueue<SampleTask<?, ?>> p = new PriorityQueue<>(funcData.inputSamples);
+                while(!p.isEmpty()) {
+                    SampleTask<?, ?> s = p.poll();
+                    if(funcData.fixable.contains(s)) {
+                        VariableDescription<BooleanVariable> sampleFixedName = VariableNames.fixedFlagName(s);
+                        fixed = IRTree.and(fixed, load(sampleFixedName));
 
-        // Populate the behaviour if we just need to copy the pre-calculated results
-        // back out.
-        funcData.compilationCtx.pushScope();
+                        // Add side effect to clear the flag if a dependency given the ability to changed
+                        IRTreeVoid restFixed = store(funcData.fixedProbFlagName,
+                                and(load(sampleFixedName), load(funcData.fixedProbFlagName)),
+                                "Should the probability of sample " + funcData.sampleTask.id()
+                                        + " be set to fixed. This will only every change the flag to false.");
+                        funcData.compilationCtx.addSetSideEffect(sampleFixedName, restFixed);
 
-        // Initialize variables
-        funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
-                initializeVariable(accumulatorName, constant(0.0), Tree.NoComment));
+                        // Add side effect to clear the flag if a dependency is changed.
+                        SampleTraceDesc sampleDesc = funcData.compilationCtx.traces.getSampleTrace(s);
+                        VariableDescription<?> sampleName = sampleDesc.sampleVariable.getUniqueVarDesc();
+                        restFixed = store(funcData.fixedProbFlagName, constant(false),
+                                "Unset the fixed probability flag for sample " + funcData.sampleTask.id()
+                                        + " as it depends on " + sampleName.name + ".");
+                        funcData.compilationCtx.addSetSideEffect(sampleName, restFixed);
+                    }
+                }
+            }
 
-        funcData.compilationCtx.addTreeToScope(funcData.randomStoreScope,
-                initializeVariable(rvProbabilityName, constant(0.0), Tree.NoComment));
+            subtrees.add(store(funcData.fixedProbFlagName, fixed,
+                    "Now the probability is calculated store if it can be cached or if it needs to be recalculated next time."));
 
-        if(funcData.sampleSkippable) {
-            funcData.compilationCtx.enterScope(funcData.sampleTaskScope);
-            funcData.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(guardName,
-                    IRTree.constant(false), "A guard to check if the sample value is ever reached."));
-            funcData.compilationCtx.leaveScope(funcData.sampleTaskScope);
-        }
+            // Join all the subtrees with a sequential block
+            generateValues = sequential(subtrees, "Generating probabilities for sample task");
+            if(funcData.sampleTask.isDistribution() && funcData.useDistributions) {
+                generateValues = ifElse(load(funcData.fixedFlagName), generateValues,
+                        "Update the probability if the distribution is fixed to a specific value."
+                                + " If it is not the value is implicitly log(1.0) so has no effect.");
+            }
+            // Populate the behaviour if we just need to copy the pre-calculated results
+            // back out.
+            funcData.compilationCtx.pushScope();
 
-        if(funcData.storeArgTrees.isEmpty()) // We are not in a loop.
+            // Initialize variables
+            funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
+                    initializeVariable(accumulatorName, constant(0.0), Tree.NoComment));
+
+            funcData.compilationCtx.addTreeToScope(funcData.randomStoreScope,
+                    initializeVariable(rvProbabilityName, constant(0.0), Tree.NoComment));
+
+            if(funcData.sampleSkippable) {
+                funcData.compilationCtx.enterScope(funcData.sampleTaskScope);
+                funcData.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(guardName,
+                        IRTree.constant(false), "A guard to check if the sample value is ever reached."));
+                funcData.compilationCtx.leaveScope(funcData.sampleTaskScope);
+            }
+
+            if(funcData.storeArgTrees.isEmpty()) // We are not in a loop.
+                funcData.compilationCtx.addTreeToScope(funcData.sampleStoreScope,
+                        initializeVariable(sampleValueName, load(funcData.storedName), Tree.NoComment));
+            else
+                funcData.compilationCtx.addTreeToScope(funcData.sampleStoreScope, initializeVariable(sampleValueName,
+                        TreeUtils.getIndirectValue(funcData.storedName, funcData.storeArgTrees), Tree.NoComment));
+
+            // Accumulate values
             funcData.compilationCtx.addTreeToScope(funcData.sampleStoreScope,
-                    initializeVariable(sampleValueName, load(funcData.storedName), Tree.NoComment));
-        else
-            funcData.compilationCtx.addTreeToScope(funcData.sampleStoreScope, initializeVariable(sampleValueName,
-                    TreeUtils.getIndirectValue(funcData.storedName, funcData.storeArgTrees), Tree.NoComment));
+                    store(rvProbabilityName, addDD(load(rvProbabilityName), load(sampleValueName)), Tree.NoComment));
+            if(funcData.sampleSkippable)
+                funcData.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
+                        store(guardName, constant(true), "Record that the sample was reached."));
+            funcData.compilationCtx.addTreeToScope(funcData.randomStoreScope,
+                    store(accumulatorName, addDD(load(accumulatorName), load(rvProbabilityName)), Tree.NoComment));
 
-        // Accumulate values
-        funcData.compilationCtx.addTreeToScope(funcData.sampleStoreScope,
-                store(rvProbabilityName, addDD(load(rvProbabilityName), load(sampleValueName)), Tree.NoComment));
-        if(funcData.sampleSkippable)
-            funcData.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
-                    store(guardName, constant(true), "Record that the sample was reached."));
-        funcData.compilationCtx.addTreeToScope(funcData.randomStoreScope,
-                store(accumulatorName, addDD(load(accumulatorName), load(rvProbabilityName)), Tree.NoComment));
+            // Update the values for the random variables
+            updateRVProbabilities(funcData, load(rvProbabilityName));
 
-        // Update the values for the random variables
-        updateRVProbabilities(funcData, load(rvProbabilityName));
-        // If we are tracking individual values, embed in the correct set of for loops.
+            // Update the values for the variables
+            updateVarProbabilities(funcData, load(accumulatorName), load(sampleValueName));
 
-        // Update the values for the variables
-        updateVarProbabilities(funcData, load(accumulatorName), load(sampleValueName));
+            IRTreeVoid repopulateValues = funcData.compilationCtx.getOutermostScopeTree();
+            repopulateValues.prefixComment(
+                    "Updating random variable and model probabilities using cached probabilities for this sample");
+            funcData.compilationCtx.popScope();
 
-        IRTreeVoid repopulateValues = funcData.compilationCtx.getOutermostScopeTree();
-        repopulateValues.prefixComment(
-                "Updating random variable and model probabilities using cached probabilities for this sample");
-        funcData.compilationCtx.popScope();
-
-        // Merge the values in a conditional
-        IRTreeReturn<BooleanVariable> mergeGuard = negateBoolean(load(funcData.fixedProbFlagName));
-        IRTreeVoid mergeResult = ifElse(
-                mergeGuard, generateValues, "Determine if we need to calculate the values for sample task "
-                        + funcData.sampleTask.id() + " or if we should just use cached values.",
-                repopulateValues, "Using cached values.");
+            // Merge the values in a conditional
+            IRTreeReturn<BooleanVariable> mergeGuard = negateBoolean(load(funcData.fixedProbFlagName));
+            generateValues = ifElse(
+                    mergeGuard, generateValues, "Determine if we need to calculate the values for sample task "
+                            + funcData.sampleTask.id() + " or if we should just use cached values.",
+                    repopulateValues, "Using cached values.");
+        } else {
+            // Join all the subtrees with a sequential block
+            generateValues = sequential(subtrees, "Generating probabilities for sample task");
+            if(funcData.sampleTask.isDistribution() && funcData.useDistributions) {
+                if(funcData.fixable.contains(funcData.sampleTask)) {
+                    generateValues = ifElse(load(funcData.fixedFlagName), generateValues,
+                            "Update the probability if the distribution is fixed to a specific value."
+                                    + " If it is not the value is implicitly log(1.0) so has no effect.");
+                } else
+                    generateValues = IRTree.nop();
+            }
+        }
 
         // And place the subtree in a void function.
         FunctionName functionName = FunctionName.createFunctionName(
@@ -706,7 +744,7 @@ public class ProbabilityFunction {
                 ? SampleFunctionClass.LOG_PROBABILITY_DISTRIBUTIONS
                 : SampleFunctionClass.LOG_PROBABILITY_VALUE;
         funcData.compilationCtx.addFunction(functionClass, funcData.sampleTask,
-                voidFunction(Visibility.PRIVATE, functionName, new ArgDesc<?>[0], mergeResult, comment));
+                voidFunction(Visibility.PRIVATE, functionName, new ArgDesc<?>[0], generateValues, comment));
     }
 
     private static void getInverseIR(FunctionData<?> funcData) {
@@ -979,8 +1017,8 @@ public class ProbabilityFunction {
             // Set sample value
             Variable<?> sampleVariable = funcData.dependentVariables.getSampleVariable();
             if(sampleVariable != null) {
-                funcData.compilationCtx.addTreeToScope(GlobalScope.scope, setValueProbability(accumulatedProbability,
-                        sampleVariable, null, funcData.useDistributions, funcData.compilationCtx));
+                funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
+                        setValueProbability(accumulatedProbability, sampleVariable, null, funcData));
             }
 
             // Reset the priority queue.
@@ -997,9 +1035,9 @@ public class ProbabilityFunction {
 
                     // Add variables that require per variable values
                     ScopeConstructor perVarScopes = sPerSample.addConstraints(traces, NO_GUARDS);
-                    perVarScopes.addTree((TreeBuilderInfo info) -> funcData.compilationCtx
-                            .addTreeToScope(GlobalScope.scope, setValueProbability(sampleProbability, v, guardName,
-                                    funcData.useDistributions, funcData.compilationCtx)));
+                    perVarScopes
+                            .addTree((TreeBuilderInfo info) -> funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
+                                    setValueProbability(sampleProbability, v, guardName, funcData)));
                 }
             }
 
@@ -1016,9 +1054,9 @@ public class ProbabilityFunction {
 
                     // Add variables that require per variable values
                     ScopeConstructor perVarScopes = sAccumulator.addConstraints(traces, NO_GUARDS);
-                    perVarScopes.addTree((TreeBuilderInfo info) -> funcData.compilationCtx
-                            .addTreeToScope(GlobalScope.scope, setValueProbability(accumulatedProbability, v, guardName,
-                                    funcData.useDistributions, funcData.compilationCtx)));
+                    perVarScopes
+                            .addTree((TreeBuilderInfo info) -> funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
+                                    setValueProbability(accumulatedProbability, v, guardName, funcData)));
 
                 }
             }
@@ -1039,17 +1077,19 @@ public class ProbabilityFunction {
             IRTreeVoid t = store(evidenceProbName, mergedValue, Tree.NoComment);
 
             if(!funcData.compilationCtx.traces.isObserved(funcData.sampleTask)) {
-                IRTreeReturn<BooleanVariable> guard = load(funcData.fixedFlagName);
-                t = IRTree.ifElse(guard, t,
-                        "If this value is fixed, add it to the probability of this model producing the fixed values");
+                if(funcData.fixable.contains(funcData.sampleTask)) {
+                    IRTreeReturn<BooleanVariable> guard = load(funcData.fixedFlagName);
+                    t = IRTree.ifElse(guard, t,
+                            "If this value is fixed, add it to the probability of this model producing the fixed values");
+                } else
+                    t = IRTree.nop();
             }
             funcData.compilationCtx.addTreeToScope(GlobalScope.scope, t);
         }
     }
 
     private static IRTreeVoid setValueProbability(IRTreeReturn<DoubleVariable> sampleProbability, Variable<?> v,
-            VariableDescription<BooleanVariable> guardName, boolean useDistributions,
-            CompilationContext compilationCtx) {
+            VariableDescription<BooleanVariable> guardName, FunctionData<?> funcData) {
         VariableDescription<DoubleVariable> varName = VariableNames.logProbabilityName(v.getUniqueVarDesc());
         IRTreeReturn<DoubleVariable> outputValue = load(varName);
         IRTreeReturn<DoubleVariable> mergedValue = addDD(outputValue, sampleProbability);
@@ -1067,14 +1107,17 @@ public class ProbabilityFunction {
 
         // If we are using distributions test if all the inputs are fixed before
         // updating the probability.
-        if(useDistributions && v.isDistribution()) {
-            IRTreeReturn<BooleanVariable> fixedGuard = constant(true);
-            for(SampleTask<?, ?> sTask:compilationCtx.traces.getSourceSampleTasks(v)) {
-                if(!sTask.getOutput().isFixed())
-                    fixedGuard = and(fixedGuard, load(VariableNames.fixedFlagName(sTask)));
-            }
-            guardedTree = ifElse(fixedGuard, guardedTree,
-                    "Make sure all the inputs have been fixed so the variable is not a distribution.");
+        if(funcData.useDistributions && v.isDistribution()) {
+            if(funcData.fixableProb) {
+                IRTreeReturn<BooleanVariable> fixedGuard = constant(true);
+                for(SampleTask<?, ?> sTask:funcData.compilationCtx.traces.getSourceSampleTasks(v)) {
+                    if(!sTask.getOutput().isFixed())
+                        fixedGuard = and(fixedGuard, load(VariableNames.fixedFlagName(sTask)));
+                }
+                guardedTree = ifElse(fixedGuard, guardedTree,
+                        "Make sure all the inputs have been fixed so the variable is not a distribution.");
+            } else
+                guardedTree = IRTree.nop();
         }
 
         return guardedTree;

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorBase.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorBase.java
@@ -10,8 +10,13 @@ package org.sandwood.compiler.compilation.inference;
 
 import static org.sandwood.compiler.traces.guards.ScopeConstructor.Values.IGNORE_VALUES;
 import static org.sandwood.compiler.traces.guards.ScopeConstructor.Values.PASS_VALUES;
+import static org.sandwood.compiler.trees.irTree.IRTree.addDD;
+import static org.sandwood.compiler.trees.irTree.IRTree.constant;
+import static org.sandwood.compiler.trees.irTree.IRTree.initializeVariable;
 import static org.sandwood.compiler.trees.irTree.IRTree.load;
 import static org.sandwood.compiler.trees.irTree.IRTree.negateBoolean;
+import static org.sandwood.compiler.trees.irTree.IRTree.store;
+import static org.sandwood.compiler.trees.irTree.IRTree.subtractII;
 import static org.sandwood.compiler.trees.irTree.IRTree.voidFunction;
 
 import java.util.ArrayList;
@@ -63,7 +68,6 @@ import org.sandwood.compiler.traces.guards.TreeBuilderInfo;
 import org.sandwood.compiler.trees.ArgDesc;
 import org.sandwood.compiler.trees.Tree;
 import org.sandwood.compiler.trees.Visibility;
-import org.sandwood.compiler.trees.irTree.IRTree;
 import org.sandwood.compiler.trees.irTree.IRTreeReturn;
 import org.sandwood.compiler.trees.irTree.IRTreeVoid;
 import org.sandwood.compiler.trees.irTree.IRVoidFunction;
@@ -215,7 +219,11 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                     if(s.isDistribution()) {
                         // We know that the "sample" value is not fixed because we are calculating it.
                         if(s != sample) {
-                            IRTreeReturn<BooleanVariable> ifGuard = load(VariableNames.fixedFlagName(s));
+                            IRTreeReturn<BooleanVariable> ifGuard;
+                            if(compilationCtx.traces.getFixableTasks().contains(s))
+                                ifGuard = load(VariableNames.fixedFlagName(s));
+                            else
+                                ifGuard = constant(false);
                             IfElseScopeConstructors ifsc = b.addCondition(ifGuard);
                             processSample(s, consumingRV, ifsc.ifScopeConstructor, groupedTraces.get(s), funcData,
                                     compilationCtx);
@@ -277,7 +285,11 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                                 if(s.isDistribution()) {
                                     // We know that the "sample" value is not fixed because we are calculating it.
                                     if(s != sample) {
-                                        IRTreeReturn<BooleanVariable> ifGuard = load(VariableNames.fixedFlagName(s));
+                                        IRTreeReturn<BooleanVariable> ifGuard;
+                                        if(compilationCtx.traces.getFixableTasks().contains(s))
+                                            ifGuard = load(VariableNames.fixedFlagName(s));
+                                        else
+                                            ifGuard = constant(false);
                                         IfElseScopeConstructors ifsc = consumerSC.addCondition(ifGuard);
                                         processSample(s, consumingRV, ifsc.ifScopeConstructor, groupedTraces.get(s),
                                                 funcData, compilationCtx);
@@ -395,8 +407,11 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                             // fixed, otherwise we have to test.
                             processDistributionSample(ds, consumingRV, b, funcData, compilationCtx);
                         else {
-                            IRTreeReturn<BooleanVariable> ifGuard = negateBoolean(
-                                    load(VariableNames.fixedFlagName(ds)));
+                            IRTreeReturn<BooleanVariable> ifGuard;
+                            if(compilationCtx.traces.getFixableTasks().contains(ds))
+                                ifGuard = negateBoolean(load(VariableNames.fixedFlagName(ds)));
+                            else
+                                ifGuard = constant(true);
                             IfElseScopeConstructors ifsc = b.addCondition(ifGuard);
                             processDistributionSample(ds, consumingRV, ifsc.ifScopeConstructor, funcData,
                                     compilationCtx);
@@ -473,7 +488,7 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
 
     @SuppressWarnings("unused")
     protected IRTreeReturn<BooleanVariable> inferenceSampleGuard(FuncData funcData, CompilationContext compilationCtx) {
-        return IRTree.constant(true);
+        return constant(true);
     }
 
     /**
@@ -497,8 +512,8 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
         // Otherwise create a flag to record if the observed variables are reachable
         VariableDescription<BooleanVariable> observationGuard = VariableNames.calcVarName("varObserved",
                 VariableType.BooleanVariable, true);
-        compilationCtx.addTreeToScope(targetScope, IRTree.initializeVariable(observationGuard, IRTree.constant(false),
-                "A guard to record if the variable is observed"));
+        compilationCtx.addTreeToScope(targetScope,
+                initializeVariable(observationGuard, constant(false), "A guard to record if the variable is observed"));
 
         // Attempt to reach each of the observed variables
         ScopeConstructor a = ScopeConstructor.construct(s, targetScope, "Look for a valid path to an observed variable",
@@ -507,12 +522,12 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
             for(TraceHandle t:ts) {
                 ScopeConstructor b = a.addConstraint(t);
                 b.addTree((TreeBuilderInfo info) -> compilationCtx.addTreeToScope(GlobalScope.scope,
-                        IRTree.store(observationGuard, IRTree.constant(true), "Record that this sample is observed")));
+                        store(observationGuard, constant(true), "Record that this sample is observed")));
             }
         }
 
         // Construct a new target scope that will only execute if none of the observed variables are reachable.
-        targetScope = new IfScope(targetScope, IRTree.negateBoolean(IRTree.load(observationGuard)));
+        targetScope = new IfScope(targetScope, negateBoolean(load(observationGuard)));
         return targetScope;
     }
 
@@ -560,7 +575,7 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                 IRTreeReturn<IntVariable> start = f.getStart().getForwardIR(compilationCtx);
                 IRTreeReturn<IntVariable> end = f.getEnd().getForwardIR(compilationCtx);
                 if(f.incrementing)
-                    args.add(new ArgDesc<>(indexName, start, IRTree.subtractII(end, IRTree.constant(1))));
+                    args.add(new ArgDesc<>(indexName, start, subtractII(end, constant(1))));
                 else
                     args.add(new ArgDesc<>(indexName, end, start));
 
@@ -663,12 +678,12 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
         VariableDescription<DoubleVariable> reachedSourceName = VariableNames.scopeVarName("reachedSourceProbability",
                 VariableType.DoubleVariable);
         dConsumerAllArgs.addTree((TreeBuilderInfo info) -> compilationCtx.addTreeToScope(GlobalScope.scope,
-                IRTree.initializeVariable(reachedSourceName, IRTree.constant(0.0),
+                initializeVariable(reachedSourceName, constant(0.0),
                         "Declare and zero an accumulator for tracking the reached source probability space.")));
 
         ScopeConstructor dSourceAllArgs = dConsumerAllArgs.resetProbabilities().applyDistributedArguments(0);
         dSourceAllArgs.addTree((TreeBuilderInfo info) -> compilationCtx.addTreeToScope(GlobalScope.scope,
-                IRTree.store(reachedSourceName, IRTree.addDD(IRTree.load(reachedSourceName), info.probability),
+                store(reachedSourceName, addDD(load(reachedSourceName), info.probability),
                         "Add the probability of this argument configuration.")));
 
         int constraintCount = c.getConstraintCount();
@@ -683,7 +698,7 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
              */
             getConsumerRVInputIR(info, consumer, funcData, compilationCtx);
             info.changeSubstitutions(constraintCount - 1, compilationCtx);
-            getDistributionSampleIR(s, IRTree.load(reachedSourceName), funcData, info, compilationCtx);
+            getDistributionSampleIR(s, load(reachedSourceName), funcData, info, compilationCtx);
         });
 
         c.addTree((TreeBuilderInfo info) -> getPerDistributedSampleEndIR(funcData, s, info, compilationCtx));

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/Traces.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/Traces.java
@@ -411,6 +411,20 @@ public abstract class Traces {
     public abstract Set<Variable<?>> getRequiredIntermediates(Variable<?> v);
 
     /**
+     * Method to return a set containing all the fix-able intermediate variables.
+     * 
+     * @return
+     */
+    public abstract Set<Variable<?>> getFixableIntermediates();
+
+    /**
+     * Mathod returning all the sample tasks that can be fixed.
+     * 
+     * @return
+     */
+    public abstract Set<SampleTask<?, ?>> getFixableTasks();
+
+    /**
      * Method to get all the sample tasks that a variable depends on without a trace going via a random variable or
      * observed variable.
      * 

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/TracesImplementation.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/TracesImplementation.java
@@ -81,6 +81,10 @@ public class TracesImplementation extends Traces {
     private final Set<Variable<?>> allVariables = new HashSet<>();
     // Set of all sample tasks
     private final Set<SampleTask<?, ?>> allSampleTasks = new HashSet<>();
+    // A set containing all the intermediate variables that will have a fix value method.
+    private final Set<Variable<?>> fixableIntermediates = new HashSet<>();
+    // Set containing all the fix-able sample tasks.
+    private final Set<SampleTask<?, ?>> fixableTasks = new HashSet<>();
     // Map of top names to variables for top level variables. For Variables such as
     // arrays that might appear multiple times it is the instance variable that is
     // held.
@@ -234,8 +238,16 @@ public class TracesImplementation extends Traces {
         for(TraceSinkPair p:dagInfo.allTraces())
             setFlags(p);
 
-        // Now the determinisitic variables are know propagate the variables whose value is determined by observations
+        // Now the deterministic variables are know propagate the variables whose value is determined by observations
         propagateObservations(compDesc);
+
+        for(TraceSinkPair p:dagInfo.randomVarTraces())
+            addFixableVars(p.handle);
+        for(TraceSinkPair p:dagInfo.observedVarTraces())
+            // Replace this call with a call to addFixableVars if fixed methods are required for all observed samples.
+            addFixableObservedVars(p.handle);
+        for(TraceSinkPair p:dagInfo.terminalVarTraces())
+            addFixableVars(p.handle);
 
         // Truncate any traces that go via a variable that is fixed by an observation that was not fixing the source of
         // the trace.
@@ -246,7 +258,7 @@ public class TracesImplementation extends Traces {
 
         setIntermediates();
 
-        // ingest traces
+        // Ingest traces
         for(TraceSinkPair p:dagInfo.observedSourceTraces())
             addObservedSource(p);
         for(TraceSinkPair p:dagInfo.observedVarTraces())
@@ -260,11 +272,42 @@ public class TracesImplementation extends Traces {
 
         constructDependencies(dagInfo);
 
+        constructFixableSampleTasks();
+
         constructArrayLengthTraces(dagInfo);
 
         constructInputSets();
 
         setUniqueNames();
+    }
+
+    private void constructFixableSampleTasks() {
+        Set<Variable<?>> vs = new HashSet<>();
+        for(Variable<?> v:fixableIntermediates) {
+            vs.add(v.instanceHandle());
+            Set<SampleTask<?, ?>> s = intermediateSampleTaskDependencies.get(v);
+            if(s != null)
+                fixableTasks.addAll(s);
+        }
+
+        // The instance handles to the fix-able intermediates.
+        fixableIntermediates.addAll(vs);
+    }
+
+    private void addFixableVars(TraceHandle handle) {
+        for(DataflowTaskArgDesc d:handle) {
+            Variable<?> v = d.task.getOutput();
+            if(!v.isDeterministic() && !v.isPrivate())
+                fixableIntermediates.add(v);
+        }
+    }
+
+    private void addFixableObservedVars(TraceHandle handle) {
+        for(DataflowTaskArgDesc d:handle) {
+            Variable<?> v = d.task.getOutput();
+            if(!v.isDeterministic() && !v.isFixed() && !v.isPrivate())
+                fixableIntermediates.add(v);
+        }
     }
 
     private class ObservationTracking {
@@ -2341,5 +2384,15 @@ public class TracesImplementation extends Traces {
     @Override
     public Set<Variable<?>> getEvidenceVariables() {
         return evidenceVariables;
+    }
+
+    @Override
+    public Set<Variable<?>> getFixableIntermediates() {
+        return fixableIntermediates;
+    }
+
+    @Override
+    public Set<SampleTask<?, ?>> getFixableTasks() {
+        return fixableTasks;
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/guards/ScopeConstructor.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/guards/ScopeConstructor.java
@@ -100,15 +100,18 @@ public class ScopeConstructor {
 
     public enum Direction {
         FORWARDS,
-        BACKWARDS; }
+        BACKWARDS;
+    }
 
     public enum Guards {
         GUARDS,
-        NO_GUARDS; }
+        NO_GUARDS;
+    }
 
     public enum Values {
         PASS_VALUES,
-        IGNORE_VALUES; }
+        IGNORE_VALUES;
+    }
 
     private static class GuardDesc {
         // Name for the guard that will ensure the body of this code is only executed once. If there is only 1 trace
@@ -587,28 +590,33 @@ public class ScopeConstructor {
 
                 // If we have not met this sample task before.
                 if(flagValue == null) {
-                    // Construct a conditional so that distributions are only explored if the values are not fixed.
-                    IRTreeReturn<BooleanVariable> ifGuard = load(VariableNames.fixedFlagName(disSampleTask));
-                    IfScope ifScope = new IfScope(d.innerScope, ifGuard);
+                    if(compilationCtx.traces.getFixableTasks().contains(disSampleTask)) {
+                        // Construct a conditional so that distributions are only explored if the values are not fixed.
+                        IRTreeReturn<BooleanVariable> ifGuard = load(VariableNames.fixedFlagName(disSampleTask));
+                        IfScope ifScope = new IfScope(d.innerScope, ifGuard);
 
-                    // Create a distribution based on this scope with the flag set to true
-                    ScopeDescription fixedGuardDistribution = d.addFixedFlagScope(ifScope, disSampleTask, true,
-                            compilationCtx);
-                    // Construct a distribution that ensure that the trace is satisfied, but no values are changed as
-                    // this distribution is fixed.
-                    ScopeDescription fixedTrace = TraceArrayRestrictions.constructRestriction(trace,
-                            Collections.emptyMap(),
-                            constructScopeSubstitutions(endScopes, fixedGuardDistribution, position),
-                            fixedGuardDistribution, id.get().next(), PASS_VALUES, position, compilationCtx);
-                    toReturn.add(fixedTrace);
+                        // Create a distribution based on this scope with the flag set to true
+                        ScopeDescription fixedGuardDistribution = d.addFixedFlagScope(ifScope, disSampleTask, true,
+                                compilationCtx);
+                        // Construct a distribution that ensure that the trace is satisfied, but no values are changed
+                        // as this distribution is fixed.
+                        ScopeDescription fixedTrace = TraceArrayRestrictions.constructRestriction(trace,
+                                Collections.emptyMap(),
+                                constructScopeSubstitutions(endScopes, fixedGuardDistribution, position),
+                                fixedGuardDistribution, id.get().next(), PASS_VALUES, position, compilationCtx);
+                        toReturn.add(fixedTrace);
 
-                    // Construct a distribution with the flag set to false.
-                    ScopeDescription elseGuardDistribution = d.addFixedFlagScope(ifScope.elseScope, disSampleTask,
-                            false, compilationCtx);
-                    // Construct a distribution here the output of the sample task is explored and add it to the list of
-                    // distributions.
-                    toReturn.add(
-                            constructNonFixedValues(trace, endScopes, elseGuardDistribution, disSampleTask, position));
+                        // Construct a distribution with the flag set to false.
+                        ScopeDescription elseGuardDistribution = d.addFixedFlagScope(ifScope.elseScope, disSampleTask,
+                                false, compilationCtx);
+                        // Construct a distribution here the output of the sample task is explored and add it to the
+                        // list of distributions.
+                        toReturn.add(constructNonFixedValues(trace, endScopes, elseGuardDistribution, disSampleTask,
+                                position));
+                    } else {
+                        // We know the value is not fixed.
+                        toReturn.add(constructNonFixedValues(trace, endScopes, d, disSampleTask, position));
+                    }
                 } else
                 // If the sample value is fixed.
                 if(flagValue)

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/outputTree/OutputSandwoodClassWrapper.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/outputTree/OutputSandwoodClassWrapper.java
@@ -192,6 +192,7 @@ public class OutputSandwoodClassWrapper extends OutputSandwoodClass {
         sb.append("import org.sandwood.runtime.model.variables.*;\n");
         sb.append("import org.sandwood.runtime.internal.model.variables.*;\n");
         sb.append("import org.sandwood.common.exceptions.SandwoodException;\n");
+        sb.append("import org.sandwood.runtime.exceptions.SandwoodRuntimeException;\n");
         sb.append("\n");
         sb.append("import java.util.Map;\n");
         sb.append("import java.util.HashMap;\n");
@@ -365,26 +366,38 @@ public class OutputSandwoodClassWrapper extends OutputSandwoodClass {
             }
         }
 
-        sb.append("\n        //ComputedVariables\n");
+        boolean valuesToCopy = false;
         for(VariableName name:computedVariables) {
             if(fieldDescs.get(name).fieldType.setter) {
-                sb.append("        if($" + name + ".isSet())\n");
-                sb.append("            newCore" + setMethod(name) + "(oldCore" + getMethod(name) + "());\n");
+                valuesToCopy = true;
+                break;
             }
         }
 
-        sb.append("\n        //Set fixed flags\n");
+        if(valuesToCopy) {
+            sb.append("\n        //ComputedVariables\n");
+            for(VariableName name:computedVariables) {
+                if(fieldDescs.get(name).fieldType.setter) {
+                    sb.append("        if($" + name + ".isSet())\n");
+                    sb.append("            newCore" + setMethod(name) + "(oldCore" + getMethod(name) + "());\n");
+                }
+            }
+        }
+
         Set<VariableDescription<BooleanVariable>> flags = new HashSet<>();
         for(VariableName name:computedVariables) {
             FieldDesc<?> f = fieldDescs.get(name);
-            if(f.fieldType.isSample && f.fieldType.observed == Observed.FREE)
+            if(f.fieldType.isSample && !f.fieldType.isPrivate)
                 flags.addAll(getFlags(traces, name));
         }
 
-        PriorityQueue<VariableDescription<BooleanVariable>> p = new PriorityQueue<>(flags);
-        while(!p.isEmpty()) {
-            VariableDescription<BooleanVariable> flag = p.poll();
-            sb.append("        newCore" + setMethod(flag.name) + "(oldCore" + getMethod(flag.name) + "());\n");
+        if(!flags.isEmpty()) {
+            sb.append("\n        //Set fixed flags\n");
+            PriorityQueue<VariableDescription<BooleanVariable>> p = new PriorityQueue<>(flags);
+            while(!p.isEmpty()) {
+                VariableDescription<BooleanVariable> flag = p.poll();
+                sb.append("        newCore" + setMethod(flag.name) + "(oldCore" + getMethod(flag.name) + "());\n");
+            }
         }
 
         sb.append("    }\n");
@@ -1124,7 +1137,8 @@ public class OutputSandwoodClassWrapper extends OutputSandwoodClass {
                     + getMethod(probFieldName.name) + "(); }\n");
         else
             sb.append(
-                    "        public double getCurrentLogProbability() { throw new SandwoodException(\"Log probabilities are not available for this value.\"); }\n");
+                    "        public double getCurrentLogProbability() { throw new SandwoodException(\"Log probabilities"
+                            + " are not available for this value.\"); }\n");
 
         if(generic) {
             sb.append("\n        @Override\n");
@@ -1141,9 +1155,12 @@ public class OutputSandwoodClassWrapper extends OutputSandwoodClass {
         // Construct set and query methods.
         sb.append("        @Override\n");
         sb.append("        public void setFixed(boolean fixed) {\n");
-        if(flags.isEmpty()) {
-            sb.append(
-                    "            throw new SandwoodException(\"Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.\");\n");
+        if(ft.isPrivate) {
+            sb.append("            throw new SandwoodRuntimeException(\"This method should never be called on a private"
+                    + " variable.\");\n");
+        } else if(flags.isEmpty()) {
+            sb.append("            throw new SandwoodException(\"An observed variable can only have the"
+                    + " value fixed to the observed value if the value is consumed by another random variable.\");\n");
         } else {
             sb.append("            synchronized(model) {\n");
             for(VariableDescription<BooleanVariable> flag:flags)
@@ -1154,11 +1171,16 @@ public class OutputSandwoodClassWrapper extends OutputSandwoodClass {
 
         sb.append("        @Override\n");
         sb.append("        public Immutability isFixed() {\n");
-        if(flags.isEmpty()) {
+        if(ft.isPrivate) {
+            sb.append(
+                    "            throw new SandwoodRuntimeException(\"This method should never be called on a private variable.\");\n");
+        } else if(flags.isEmpty()) {
             if(ft.observed == Observed.FREE)
                 sb.append("            return Immutability.DETERMINISTIC;\n");
             else
                 sb.append("            return Immutability.OBSERVED;\n");
+        } else if(ft.observed == Observed.OBSERVED) {
+            sb.append("            return Immutability.OBSERVED_FIXABLE;\n");
         } else if(flags.size() == 1) {
             VariableDescription<BooleanVariable> flag = flags.iterator().next();
             // construct the outputs.
@@ -1228,7 +1250,7 @@ public class OutputSandwoodClassWrapper extends OutputSandwoodClass {
 
     private List<VariableDescription<BooleanVariable>> getFlags(Traces traces, VariableName uniqueName) {
         Variable<?> v = traces.getVariable(uniqueName);
-        if(v.isFixed()) {
+        if(!traces.getFixableIntermediates().contains(v)) {
             return Collections.emptyList();
         } else {
             Set<SampleTask<?, ?>> s = new HashSet<>(traces.getSourceSampleTasks(v));

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK0/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK0/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -66,7 +67,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK1/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK1/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -66,7 +67,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK1b/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK1b/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -66,7 +67,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK2/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK2/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -66,7 +67,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK2b/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK2b/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -66,7 +67,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK3/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK3/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -66,7 +67,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK4/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK4/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -66,7 +67,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK5/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip1CoinMK5/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -66,7 +67,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,7 +98,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip2CoinsMK1/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip2CoinsMK1/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -71,7 +72,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip2CoinsMK2/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip2CoinsMK2/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -71,7 +72,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip2CoinsMK3/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip2CoinsMK3/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -71,7 +72,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip2CoinsMK4/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip2CoinsMK4/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -71,7 +72,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip2CoinsMK5/ClassName.txt
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/basicCompileAndRun/basicCompileAndRun/Flip2CoinsMK5/ClassName.txt
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -71,7 +72,7 @@ public class ClassName extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK2/AlternativeModelMK2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK2/AlternativeModelMK2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class AlternativeModelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK2/AlternativeModelMK2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK2/AlternativeModelMK2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class AlternativeModelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK2/AlternativeModelMK2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK2/AlternativeModelMK2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class AlternativeModelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK2/AlternativeModelMK2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK2/AlternativeModelMK2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class AlternativeModelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK2/AlternativeModelMK2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK2/AlternativeModelMK2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class AlternativeModelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK2/AlternativeModelMK2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK2/AlternativeModelMK2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class AlternativeModelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK3/AlternativeModelMK3_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK3/AlternativeModelMK3_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class AlternativeModelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK3/AlternativeModelMK3_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK3/AlternativeModelMK3_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class AlternativeModelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK3/AlternativeModelMK3_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK3/AlternativeModelMK3_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class AlternativeModelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK3/AlternativeModelMK3_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK3/AlternativeModelMK3_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class AlternativeModelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK3/AlternativeModelMK3_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK3/AlternativeModelMK3_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class AlternativeModelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK3/AlternativeModelMK3_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AlternativeModelMK3/AlternativeModelMK3_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class AlternativeModelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AnonymousSample/AnonymousSample_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AnonymousSample/AnonymousSample_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class AnonymousSample extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -65,7 +66,7 @@ public class AnonymousSample extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AnonymousSample/AnonymousSample_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AnonymousSample/AnonymousSample_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class AnonymousSample extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -65,7 +66,7 @@ public class AnonymousSample extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AnonymousSample/AnonymousSample_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AnonymousSample/AnonymousSample_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class AnonymousSample extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -65,7 +66,7 @@ public class AnonymousSample extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AnonymousSample/AnonymousSample_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AnonymousSample/AnonymousSample_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class AnonymousSample extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -65,7 +66,7 @@ public class AnonymousSample extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AnonymousSample/AnonymousSample_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AnonymousSample/AnonymousSample_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class AnonymousSample extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -65,7 +66,7 @@ public class AnonymousSample extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AnonymousSample/AnonymousSample_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/AnonymousSample/AnonymousSample_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class AnonymousSample extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -65,7 +66,7 @@ public class AnonymousSample extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional1b/Conditional1b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional1b/Conditional1b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional1b/Conditional1b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional1b/Conditional1b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional1b/Conditional1b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional1b/Conditional1b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional1b/Conditional1b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional1b/Conditional1b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional1b/Conditional1b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional1b/Conditional1b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional1b/Conditional1b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional1b/Conditional1b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$CoreInterface_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$CoreInterface_model.java
@@ -2,12 +2,6 @@ package org.sandwood.compiler.tests.parser;
 
 interface Conditional2$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
 
-	// Getter for fixedFlag$sample21.
-	public boolean get$fixedFlag$sample21();
-
-	// Setter for fixedFlag$sample21.
-	public void set$fixedFlag$sample21(boolean cv$value);
-
 	// Getter for fixedFlag$sample4.
 	public boolean get$fixedFlag$sample4();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$CoreInterface_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$CoreInterface_modelNoComments.java
@@ -1,8 +1,6 @@
 package org.sandwood.compiler.tests.parser;
 
 interface Conditional2$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
-	public boolean get$fixedFlag$sample21();
-	public void set$fixedFlag$sample21(boolean cv$value);
 	public boolean get$fixedFlag$sample4();
 	public void set$fixedFlag$sample4(boolean cv$value);
 	public boolean get$guard();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$CoreInterface_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$CoreInterface_modelSingle.java
@@ -2,12 +2,6 @@ package org.sandwood.compiler.tests.parser;
 
 interface Conditional2$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
 
-	// Getter for fixedFlag$sample21.
-	public boolean get$fixedFlag$sample21();
-
-	// Setter for fixedFlag$sample21.
-	public void set$fixedFlag$sample21(boolean cv$value);
-
 	// Getter for fixedFlag$sample4.
 	public boolean get$fixedFlag$sample4();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$CoreInterface_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$CoreInterface_optimisedModel.java
@@ -2,12 +2,6 @@ package org.sandwood.compiler.tests.parser;
 
 interface Conditional2$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
 
-	// Getter for fixedFlag$sample21.
-	public boolean get$fixedFlag$sample21();
-
-	// Setter for fixedFlag$sample21.
-	public void set$fixedFlag$sample21(boolean cv$value);
-
 	// Getter for fixedFlag$sample4.
 	public boolean get$fixedFlag$sample4();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$CoreInterface_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$CoreInterface_optimisedModelNoComments.java
@@ -1,8 +1,6 @@
 package org.sandwood.compiler.tests.parser;
 
 interface Conditional2$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
-	public boolean get$fixedFlag$sample21();
-	public void set$fixedFlag$sample21(boolean cv$value);
 	public boolean get$fixedFlag$sample4();
 	public void set$fixedFlag$sample4(boolean cv$value);
 	public boolean get$guard();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$CoreInterface_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$CoreInterface_optimisedModelSingle.java
@@ -2,12 +2,6 @@ package org.sandwood.compiler.tests.parser;
 
 interface Conditional2$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
 
-	// Getter for fixedFlag$sample21.
-	public boolean get$fixedFlag$sample21();
-
-	// Setter for fixedFlag$sample21.
-	public void set$fixedFlag$sample21(boolean cv$value);
-
 	// Getter for fixedFlag$sample4.
 	public boolean get$fixedFlag$sample4();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$MultiThreadCPU_model.java
@@ -7,9 +7,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample21 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample21 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -31,24 +29,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		super(target);
 	}
 
-	// Getter for fixedFlag$sample21.
-	@Override
-	public final boolean get$fixedFlag$sample21() {
-		return fixedFlag$sample21;
-	}
-
-	// Setter for fixedFlag$sample21.
-	@Override
-	public final void set$fixedFlag$sample21(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample21 including if probabilities
-		// need to be updated.
-		fixedFlag$sample21 = cv$value;
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedProbFlag$sample21);
-	}
-
 	// Getter for fixedFlag$sample4.
 	@Override
 	public final boolean get$fixedFlag$sample4() {
@@ -65,10 +45,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// Should the probability of sample 4 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample4 = (fixedFlag$sample4 && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample21 = (fixedFlag$sample4 && fixedProbFlag$sample21);
 	}
 
 	// Getter for guard.
@@ -86,9 +62,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on guard.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -161,186 +134,115 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	// Setter for var19.
 	@Override
 	public final void set$var19(double cv$value) {
-		// Set flags for all the side effects of var19 including if probabilities need to
-		// be updated.
 		var19 = cv$value;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on var19.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample21 using sampled
 	// values.
 	private final void logProbabilityValue$sample21() {
-		// Determine if we need to calculate the values for sample task 21 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample21) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = var19;
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = var19;
 					{
-						{
-							double var16 = 0.0;
-							double var17 = 1.0;
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((var16 <= cv$sampleValue) && (cv$sampleValue < var17))?(-Math.log((var17 - var16))):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var16 = 0.0;
+						double var17 = 1.0;
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((var16 <= cv$sampleValue) && (cv$sampleValue < var17))?(-Math.log((var17 - var16))):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var18 = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample21 = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Guard to ensure that value is only updated once for this probability.
-			boolean cv$guard$value = false;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Guard to ensure that value2 is only updated once for this probability.
-			boolean cv$guard$value2 = false;
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// Update the variable probability
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var18 = cv$sampleAccumulator;
 			
-			// Add probability to constructed variables from the combined probability
-			{
+			// Store the sample task probability
+			logProbability$sample21 = cv$sampleProbability;
+		}
+		
+		// Guard to ensure that value is only updated once for this probability.
+		boolean cv$guard$value = false;
+		
+		// Guard to ensure that value2 is only updated once for this probability.
+		boolean cv$guard$value2 = false;
+		
+		// Update the variable probability
+		logProbability$var19 = (logProbability$var19 + cv$accumulator);
+		
+		// Add probability to constructed variables from the combined probability
+		{
+			// If the probability of the variable has not already been updated
+			if(!cv$guard$value) {
+				// Set the guard so the update is only applied once.
+				cv$guard$value = true;
+				
+				// Update the variable probability
+				logProbability$value = (logProbability$value + cv$accumulator);
+			}
+		}
+		
+		// Looking for a path between Sample 21 and consumer double[] 27.
+		{
+			if((0 == 0)) {
 				// If the probability of the variable has not already been updated
-				if(!cv$guard$value) {
+				if(!cv$guard$value2) {
 					// Set the guard so the update is only applied once.
-					cv$guard$value = true;
+					cv$guard$value2 = true;
 					
 					// Update the variable probability
-					logProbability$value = (logProbability$value + cv$accumulator);
+					logProbability$value2 = (logProbability$value2 + cv$accumulator);
 				}
 			}
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
-			{
-				if((0 == 0)) {
-					// If the probability of the variable has not already been updated
-					if(!cv$guard$value2) {
-						// Set the guard so the update is only applied once.
-						cv$guard$value2 = true;
-						
-						// Update the variable probability
-						logProbability$value2 = (logProbability$value2 + cv$accumulator);
-					}
-				}
-			}
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedFlag$sample4);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample21;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var18 = cv$rvAccumulator;
-			}
-			
-			// Guard to ensure that value is only updated once for this probability.
-			boolean cv$guard$value = false;
-			
-			// Guard to ensure that value2 is only updated once for this probability.
-			boolean cv$guard$value2 = false;
-			
-			// Update the variable probability
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			
-			// Add probability to constructed variables from the combined probability
-			{
-				// If the probability of the variable has not already been updated
-				if(!cv$guard$value) {
-					// Set the guard so the update is only applied once.
-					cv$guard$value = true;
-					
-					// Update the variable probability
-					logProbability$value = (logProbability$value + cv$accumulator);
-				}
-			}
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
-			{
-				if((0 == 0)) {
-					// If the probability of the variable has not already been updated
-					if(!cv$guard$value2) {
-						// Set the guard so the update is only applied once.
-						cv$guard$value2 = true;
-						
-						// Update the variable probability
-						logProbability$value2 = (logProbability$value2 + cv$accumulator);
-					}
-				}
-			}
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -692,13 +594,10 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample21))
-				value[0] = var19;
+			var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value[0] = var19;
 		}
-		if(!(fixedFlag$sample4 && fixedFlag$sample21))
-			value2[0] = value[0];
+		value2[0] = value[0];
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -709,16 +608,14 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var19 = false;
-				{
-					// Observation reached
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var19 = false;
+			{
+				// Observation reached
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -731,8 +628,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 			value[0] = var19;
 		}
 		value2[0] = value[0];
@@ -745,16 +641,14 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var19 = false;
-				{
-					// Observation reached
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var19 = false;
+			{
+				// Observation reached
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -766,16 +660,14 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var19 = false;
-				{
-					// Observation reached
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var19 = false;
+			{
+				// Observation reached
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -819,8 +711,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		logProbability$var19 = 0.0;
 		logProbability$value = 0.0;
 		logProbability$value2 = 0.0;
-		if(!fixedProbFlag$sample21)
-			logProbability$sample21 = Double.NaN;
+		logProbability$sample21 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$MultiThreadCPU_modelNoComments.java
@@ -5,9 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 
 class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements Conditional2$CoreInterface {
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample21 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample21 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -30,17 +28,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	}
 
 	@Override
-	public final boolean get$fixedFlag$sample21() {
-		return fixedFlag$sample21;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample21(boolean cv$value) {
-		fixedFlag$sample21 = cv$value;
-		fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedProbFlag$sample21);
-	}
-
-	@Override
 	public final boolean get$fixedFlag$sample4() {
 		return fixedFlag$sample4;
 	}
@@ -49,7 +36,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	public final void set$fixedFlag$sample4(boolean cv$value) {
 		fixedFlag$sample4 = cv$value;
 		fixedProbFlag$sample4 = (fixedFlag$sample4 && fixedProbFlag$sample4);
-		fixedProbFlag$sample21 = (fixedFlag$sample4 && fixedProbFlag$sample21);
 	}
 
 	@Override
@@ -61,7 +47,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	public final void set$guard(boolean cv$value) {
 		guard = cv$value;
 		fixedProbFlag$sample4 = false;
-		fixedProbFlag$sample21 = false;
 	}
 
 	@Override
@@ -122,98 +107,64 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	@Override
 	public final void set$var19(double cv$value) {
 		var19 = cv$value;
-		fixedProbFlag$sample21 = false;
 	}
 
 	private final void logProbabilityValue$sample21() {
-		if(!fixedProbFlag$sample21) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				double cv$sampleValue = var19;
 				{
-					double cv$sampleValue = var19;
 					{
-						{
-							double var16 = 0.0;
-							double var17 = 1.0;
-							double cv$weightedProbability = (Math.log(1.0) + (((var16 <= cv$sampleValue) && (cv$sampleValue < var17))?(-Math.log((var17 - var16))):Double.NEGATIVE_INFINITY));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var16 = 0.0;
+						double var17 = 1.0;
+						double cv$weightedProbability = (Math.log(1.0) + (((var16 <= cv$sampleValue) && (cv$sampleValue < var17))?(-Math.log((var17 - var16))):Double.NEGATIVE_INFINITY));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var18 = cv$sampleAccumulator;
-				logProbability$sample21 = cv$sampleProbability;
-			}
-			boolean cv$guard$value = false;
-			boolean cv$guard$value2 = false;
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			{
-				if(!cv$guard$value) {
-					cv$guard$value = true;
-					logProbability$value = (logProbability$value + cv$accumulator);
-				}
-			}
-			{
-				if((0 == 0)) {
-					if(!cv$guard$value2) {
-						cv$guard$value2 = true;
-						logProbability$value2 = (logProbability$value2 + cv$accumulator);
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
 			}
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedFlag$sample4);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample21;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var18 = cv$rvAccumulator;
-			}
-			boolean cv$guard$value = false;
-			boolean cv$guard$value2 = false;
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			{
-				if(!cv$guard$value) {
-					cv$guard$value = true;
-					logProbability$value = (logProbability$value + cv$accumulator);
-				}
-			}
-			{
-				if((0 == 0)) {
-					if(!cv$guard$value2) {
-						cv$guard$value2 = true;
-						logProbability$value2 = (logProbability$value2 + cv$accumulator);
-					}
-				}
-			}
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var18 = cv$sampleAccumulator;
+			logProbability$sample21 = cv$sampleProbability;
 		}
+		boolean cv$guard$value = false;
+		boolean cv$guard$value2 = false;
+		logProbability$var19 = (logProbability$var19 + cv$accumulator);
+		{
+			if(!cv$guard$value) {
+				cv$guard$value = true;
+				logProbability$value = (logProbability$value + cv$accumulator);
+			}
+		}
+		{
+			if((0 == 0)) {
+				if(!cv$guard$value2) {
+					cv$guard$value2 = true;
+					logProbability$value2 = (logProbability$value2 + cv$accumulator);
+				}
+			}
+		}
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample4() {
@@ -418,13 +369,10 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample21))
-				value[0] = var19;
+			var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value[0] = var19;
 		}
-		if(!(fixedFlag$sample4 && fixedFlag$sample21))
-			value2[0] = value[0];
+		value2[0] = value[0];
 	}
 
 	@Override
@@ -432,14 +380,12 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				boolean observationGuard$var19 = false;
-				{
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			boolean observationGuard$var19 = false;
+			{
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -450,8 +396,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 			value[0] = var19;
 		}
 		value2[0] = value[0];
@@ -462,14 +407,12 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				boolean observationGuard$var19 = false;
-				{
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			boolean observationGuard$var19 = false;
+			{
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -478,14 +421,12 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				boolean observationGuard$var19 = false;
-				{
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			boolean observationGuard$var19 = false;
+			{
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -514,8 +455,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		logProbability$var19 = 0.0;
 		logProbability$value = 0.0;
 		logProbability$value2 = 0.0;
-		if(!fixedProbFlag$sample21)
-			logProbability$sample21 = Double.NaN;
+		logProbability$sample21 = Double.NaN;
 	}
 
 	@Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$MultiThreadCPU_modelSingle.java
@@ -7,9 +7,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample21 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample21 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -30,24 +28,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		super(target);
 	}
 
-	// Getter for fixedFlag$sample21.
-	@Override
-	public final boolean get$fixedFlag$sample21() {
-		return fixedFlag$sample21;
-	}
-
-	// Setter for fixedFlag$sample21.
-	@Override
-	public final void set$fixedFlag$sample21(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample21 including if probabilities
-		// need to be updated.
-		fixedFlag$sample21 = cv$value;
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedProbFlag$sample21);
-	}
-
 	// Getter for fixedFlag$sample4.
 	@Override
 	public final boolean get$fixedFlag$sample4() {
@@ -64,10 +44,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// Should the probability of sample 4 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample4 = (fixedFlag$sample4 && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample21 = (fixedFlag$sample4 && fixedProbFlag$sample21);
 	}
 
 	// Getter for guard.
@@ -85,9 +61,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on guard.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -160,183 +133,116 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	// Setter for var19.
 	@Override
 	public final void set$var19(double cv$value) {
-		// Set flags for all the side effects of var19 including if probabilities need to
-		// be updated.
 		var19 = cv$value;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on var19.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample21 using sampled
 	// values.
 	private final void logProbabilityValue$sample21() {
-		// Determine if we need to calculate the values for sample task 21 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample21) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = var19;
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = var19;
 					{
-						{
-							double var16 = 0.0;
-							double var17 = 1.0;
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((var16 <= cv$sampleValue) && (cv$sampleValue < var17))?(-Math.log((var17 - var16))):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var16 = 0.0;
+						double var17 = 1.0;
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((var16 <= cv$sampleValue) && (cv$sampleValue < var17))?(-Math.log((var17 - var16))):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var18 = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$var19 = cv$accumulator;
-			
-			// Guard to ensure that value is only updated once for this probability.
-			boolean cv$guard$value = false;
-			
-			// Guard to ensure that value2 is only updated once for this probability.
-			boolean cv$guard$value2 = false;
-			
-			// Add probability to constructed variables from the combined probability
-			{
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var18 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$var19 = cv$accumulator;
+		
+		// Guard to ensure that value is only updated once for this probability.
+		boolean cv$guard$value = false;
+		
+		// Guard to ensure that value2 is only updated once for this probability.
+		boolean cv$guard$value2 = false;
+		
+		// Add probability to constructed variables from the combined probability
+		{
+			// If the probability of the variable has not already been updated
+			if(!cv$guard$value) {
+				// Set the guard so the update is only applied once.
+				cv$guard$value = true;
+				
+				// Update the variable probability
+				logProbability$value = (logProbability$value + cv$accumulator);
+			}
+		}
+		
+		// Looking for a path between Sample 21 and consumer double[] 27.
+		{
+			if((0 == 0)) {
 				// If the probability of the variable has not already been updated
-				if(!cv$guard$value) {
+				if(!cv$guard$value2) {
 					// Set the guard so the update is only applied once.
-					cv$guard$value = true;
+					cv$guard$value2 = true;
 					
 					// Update the variable probability
-					logProbability$value = (logProbability$value + cv$accumulator);
+					logProbability$value2 = (logProbability$value2 + cv$accumulator);
 				}
 			}
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
-			{
-				if((0 == 0)) {
-					// If the probability of the variable has not already been updated
-					if(!cv$guard$value2) {
-						// Set the guard so the update is only applied once.
-						cv$guard$value2 = true;
-						
-						// Update the variable probability
-						logProbability$value2 = (logProbability$value2 + cv$accumulator);
-					}
-				}
-			}
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedFlag$sample4);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var19;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var18 = cv$rvAccumulator;
-			
-			// Guard to ensure that value is only updated once for this probability.
-			boolean cv$guard$value = false;
-			
-			// Guard to ensure that value2 is only updated once for this probability.
-			boolean cv$guard$value2 = false;
-			
-			// Add probability to constructed variables from the combined probability
-			{
-				// If the probability of the variable has not already been updated
-				if(!cv$guard$value) {
-					// Set the guard so the update is only applied once.
-					cv$guard$value = true;
-					
-					// Update the variable probability
-					logProbability$value = (logProbability$value + cv$accumulator);
-				}
-			}
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
-			{
-				if((0 == 0)) {
-					// If the probability of the variable has not already been updated
-					if(!cv$guard$value2) {
-						// Set the guard so the update is only applied once.
-						cv$guard$value2 = true;
-						
-						// Update the variable probability
-						logProbability$value2 = (logProbability$value2 + cv$accumulator);
-					}
-				}
-			}
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -688,13 +594,10 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample21))
-				value[0] = var19;
+			var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value[0] = var19;
 		}
-		if(!(fixedFlag$sample4 && fixedFlag$sample21))
-			value2[0] = value[0];
+		value2[0] = value[0];
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -705,16 +608,14 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var19 = false;
-				{
-					// Observation reached
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var19 = false;
+			{
+				// Observation reached
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -727,8 +628,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 			value[0] = var19;
 		}
 		value2[0] = value[0];
@@ -741,16 +641,14 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var19 = false;
-				{
-					// Observation reached
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var19 = false;
+			{
+				// Observation reached
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -762,16 +660,14 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var19 = false;
-				{
-					// Observation reached
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var19 = false;
+			{
+				// Observation reached
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -814,8 +710,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		logProbability$var18 = Double.NaN;
 		logProbability$value = 0.0;
 		logProbability$value2 = 0.0;
-		if(!fixedProbFlag$sample21)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$MultiThreadCPU_optimisedModel.java
@@ -7,9 +7,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample21 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample21 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -31,26 +29,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		super(target);
 	}
 
-	// Getter for fixedFlag$sample21.
-	@Override
-	public final boolean get$fixedFlag$sample21() {
-		return fixedFlag$sample21;
-	}
-
-	// Setter for fixedFlag$sample21.
-	@Override
-	public final void set$fixedFlag$sample21(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample21 including if probabilities
-		// need to be updated.
-		fixedFlag$sample21 = cv$value;
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample21" with its value "cv$value".
-		fixedProbFlag$sample21 = (cv$value && fixedProbFlag$sample21);
-	}
-
 	// Getter for fixedFlag$sample4.
 	@Override
 	public final boolean get$fixedFlag$sample4() {
@@ -69,12 +47,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// 
 		// Substituted "fixedFlag$sample4" with its value "cv$value".
 		fixedProbFlag$sample4 = (cv$value && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample4" with its value "cv$value".
-		fixedProbFlag$sample21 = (cv$value && fixedProbFlag$sample21);
 	}
 
 	// Getter for guard.
@@ -92,9 +64,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on guard.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -167,116 +136,76 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	// Setter for var19.
 	@Override
 	public final void set$var19(double cv$value) {
-		// Set flags for all the side effects of var19 including if probabilities need to
-		// be updated.
 		var19 = cv$value;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on var19.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample21 using sampled
 	// values.
 	private final void logProbabilityValue$sample21() {
-		// Determine if we need to calculate the values for sample task 21 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample21) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		if(!guard) {
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = (((0.0 <= var19) && (var19 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
 			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = (((0.0 <= var19) && (var19 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = cv$distributionAccumulator;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var18 = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample21 = cv$distributionAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			
-			// Add probability to constructed variables from the combined probability
 			// 
-			// Update the variable probability
-			logProbability$value = (logProbability$value + cv$accumulator);
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
-			// Update the variable probability
-			logProbability$value2 = (logProbability$value2 + cv$accumulator);
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = cv$distributionAccumulator;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var18 = cv$distributionAccumulator;
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedFlag$sample4);
+			// Store the sample task probability
+			logProbability$sample21 = cv$distributionAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				cv$accumulator = logProbability$sample21;
-				logProbability$var18 = logProbability$sample21;
-			}
-			
-			// Update the variable probability
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			
-			// Add probability to constructed variables from the combined probability
-			// 
-			// Update the variable probability
-			logProbability$value = (logProbability$value + cv$accumulator);
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
-			// 
-			// Update the variable probability
-			logProbability$value2 = (logProbability$value2 + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$var19 = (logProbability$var19 + cv$accumulator);
+		
+		// Add probability to constructed variables from the combined probability
+		// 
+		// Update the variable probability
+		logProbability$value = (logProbability$value + cv$accumulator);
+		
+		// Looking for a path between Sample 21 and consumer double[] 27.
+		// 
+		// Update the variable probability
+		logProbability$value2 = (logProbability$value2 + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -555,13 +484,10 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample21))
-				value[0] = var19;
+			var19 = DistributionSampling.sampleUniform(RNG$);
+			value[0] = var19;
 		}
-		if((!fixedFlag$sample4 || !fixedFlag$sample21))
-			value2[0] = value[0];
+		value2[0] = value[0];
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -582,8 +508,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = DistributionSampling.sampleUniform(RNG$);
+			var19 = DistributionSampling.sampleUniform(RNG$);
 			value[0] = var19;
 		}
 		value2[0] = value[0];
@@ -639,8 +564,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		logProbability$var19 = 0.0;
 		logProbability$value = 0.0;
 		logProbability$value2 = 0.0;
-		if(!fixedProbFlag$sample21)
-			logProbability$sample21 = Double.NaN;
+		logProbability$sample21 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$MultiThreadCPU_optimisedModelNoComments.java
@@ -5,9 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 
 class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements Conditional2$CoreInterface {
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample21 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample21 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -30,17 +28,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	}
 
 	@Override
-	public final boolean get$fixedFlag$sample21() {
-		return fixedFlag$sample21;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample21(boolean cv$value) {
-		fixedFlag$sample21 = cv$value;
-		fixedProbFlag$sample21 = (cv$value && fixedProbFlag$sample21);
-	}
-
-	@Override
 	public final boolean get$fixedFlag$sample4() {
 		return fixedFlag$sample4;
 	}
@@ -49,7 +36,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	public final void set$fixedFlag$sample4(boolean cv$value) {
 		fixedFlag$sample4 = cv$value;
 		fixedProbFlag$sample4 = (cv$value && fixedProbFlag$sample4);
-		fixedProbFlag$sample21 = (cv$value && fixedProbFlag$sample21);
 	}
 
 	@Override
@@ -61,7 +47,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	public final void set$guard(boolean cv$value) {
 		guard = cv$value;
 		fixedProbFlag$sample4 = false;
-		fixedProbFlag$sample21 = false;
 	}
 
 	@Override
@@ -122,36 +107,21 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	@Override
 	public final void set$var19(double cv$value) {
 		var19 = cv$value;
-		fixedProbFlag$sample21 = false;
 	}
 
 	private final void logProbabilityValue$sample21() {
-		if(!fixedProbFlag$sample21) {
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				double cv$distributionAccumulator = (((0.0 <= var19) && (var19 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
-				cv$accumulator = cv$distributionAccumulator;
-				logProbability$var18 = cv$distributionAccumulator;
-				logProbability$sample21 = cv$distributionAccumulator;
-			}
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			logProbability$value = (logProbability$value + cv$accumulator);
-			logProbability$value2 = (logProbability$value2 + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedFlag$sample4);
-		} else {
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				cv$accumulator = logProbability$sample21;
-				logProbability$var18 = logProbability$sample21;
-			}
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			logProbability$value = (logProbability$value + cv$accumulator);
-			logProbability$value2 = (logProbability$value2 + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		if(!guard) {
+			double cv$distributionAccumulator = (((0.0 <= var19) && (var19 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
+			cv$accumulator = cv$distributionAccumulator;
+			logProbability$var18 = cv$distributionAccumulator;
+			logProbability$sample21 = cv$distributionAccumulator;
 		}
+		logProbability$var19 = (logProbability$var19 + cv$accumulator);
+		logProbability$value = (logProbability$value + cv$accumulator);
+		logProbability$value2 = (logProbability$value2 + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample4() {
@@ -221,13 +191,10 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample21))
-				value[0] = var19;
+			var19 = DistributionSampling.sampleUniform(RNG$);
+			value[0] = var19;
 		}
-		if((!fixedFlag$sample4 || !fixedFlag$sample21))
-			value2[0] = value[0];
+		value2[0] = value[0];
 	}
 
 	@Override
@@ -243,8 +210,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = DistributionSampling.sampleUniform(RNG$);
+			var19 = DistributionSampling.sampleUniform(RNG$);
 			value[0] = var19;
 		}
 		value2[0] = value[0];
@@ -282,8 +248,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		logProbability$var19 = 0.0;
 		logProbability$value = 0.0;
 		logProbability$value2 = 0.0;
-		if(!fixedProbFlag$sample21)
-			logProbability$sample21 = Double.NaN;
+		logProbability$sample21 = Double.NaN;
 	}
 
 	@Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$MultiThreadCPU_optimisedModelSingle.java
@@ -7,9 +7,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample21 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample21 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -30,26 +28,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		super(target);
 	}
 
-	// Getter for fixedFlag$sample21.
-	@Override
-	public final boolean get$fixedFlag$sample21() {
-		return fixedFlag$sample21;
-	}
-
-	// Setter for fixedFlag$sample21.
-	@Override
-	public final void set$fixedFlag$sample21(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample21 including if probabilities
-		// need to be updated.
-		fixedFlag$sample21 = cv$value;
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample21" with its value "cv$value".
-		fixedProbFlag$sample21 = (cv$value && fixedProbFlag$sample21);
-	}
-
 	// Getter for fixedFlag$sample4.
 	@Override
 	public final boolean get$fixedFlag$sample4() {
@@ -68,12 +46,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// 
 		// Substituted "fixedFlag$sample4" with its value "cv$value".
 		fixedProbFlag$sample4 = (cv$value && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample4" with its value "cv$value".
-		fixedProbFlag$sample21 = (cv$value && fixedProbFlag$sample21);
 	}
 
 	// Getter for guard.
@@ -91,9 +63,6 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on guard.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -166,131 +135,84 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	// Setter for var19.
 	@Override
 	public final void set$var19(double cv$value) {
-		// Set flags for all the side effects of var19 including if probabilities need to
-		// be updated.
 		var19 = cv$value;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on var19.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample21 using sampled
 	// values.
 	private final void logProbabilityValue$sample21() {
-		// Determine if we need to calculate the values for sample task 21 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample21) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
 			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = (((0.0 <= var19) && (var19 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
-			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var18 = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$var19 = cv$sampleAccumulator;
-			}
-			
-			// Update the variable probability
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Scale the probability relative to the observed distribution space.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$value = (logProbability$value + cv$sampleAccumulator);
-			
-			// Update the variable probability
+			// Add the probability of this distribution configuration to the accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// An accumulator for the distributed probability space covered.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$value2 = (logProbability$value2 + cv$sampleAccumulator);
-			
-			// Add probability to model
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Store the value of the function call, so the function call is only made once.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedFlag$sample4);
+			// The sample value to calculate the probability of generating
+			cv$sampleAccumulator = (((0.0 <= var19) && (var19 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$var18 = logProbability$var19;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var18 = cv$sampleAccumulator;
 			
-			// Add probability to constructed variables from the combined probability
+			// Store the random variable instance probability
 			// 
-			// Update the variable probability
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$value = (logProbability$value + logProbability$var19);
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
-			// 
-			// Update the variable probability
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$value2 = (logProbability$value2 + logProbability$var19);
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var19);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var19);
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$var19 = cv$sampleAccumulator;
 		}
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$value = (logProbability$value + cv$sampleAccumulator);
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$value2 = (logProbability$value2 + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -569,13 +491,10 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample21))
-				value[0] = var19;
+			var19 = DistributionSampling.sampleUniform(RNG$);
+			value[0] = var19;
 		}
-		if((!fixedFlag$sample4 || !fixedFlag$sample21))
-			value2[0] = value[0];
+		value2[0] = value[0];
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -596,8 +515,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = DistributionSampling.sampleUniform(RNG$);
+			var19 = DistributionSampling.sampleUniform(RNG$);
 			value[0] = var19;
 		}
 		value2[0] = value[0];
@@ -652,8 +570,7 @@ class Conditional2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		logProbability$var18 = Double.NaN;
 		logProbability$value = 0.0;
 		logProbability$value2 = 0.0;
-		if(!fixedProbFlag$sample21)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$SingleThreadCPU_model.java
@@ -7,9 +7,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample21 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample21 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -31,24 +29,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		super(target);
 	}
 
-	// Getter for fixedFlag$sample21.
-	@Override
-	public final boolean get$fixedFlag$sample21() {
-		return fixedFlag$sample21;
-	}
-
-	// Setter for fixedFlag$sample21.
-	@Override
-	public final void set$fixedFlag$sample21(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample21 including if probabilities
-		// need to be updated.
-		fixedFlag$sample21 = cv$value;
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedProbFlag$sample21);
-	}
-
 	// Getter for fixedFlag$sample4.
 	@Override
 	public final boolean get$fixedFlag$sample4() {
@@ -65,10 +45,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		// Should the probability of sample 4 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample4 = (fixedFlag$sample4 && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample21 = (fixedFlag$sample4 && fixedProbFlag$sample21);
 	}
 
 	// Getter for guard.
@@ -86,9 +62,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on guard.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -161,186 +134,115 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for var19.
 	@Override
 	public final void set$var19(double cv$value) {
-		// Set flags for all the side effects of var19 including if probabilities need to
-		// be updated.
 		var19 = cv$value;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on var19.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample21 using sampled
 	// values.
 	private final void logProbabilityValue$sample21() {
-		// Determine if we need to calculate the values for sample task 21 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample21) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = var19;
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = var19;
 					{
-						{
-							double var16 = 0.0;
-							double var17 = 1.0;
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((var16 <= cv$sampleValue) && (cv$sampleValue < var17))?(-Math.log((var17 - var16))):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var16 = 0.0;
+						double var17 = 1.0;
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((var16 <= cv$sampleValue) && (cv$sampleValue < var17))?(-Math.log((var17 - var16))):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var18 = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample21 = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Guard to ensure that value is only updated once for this probability.
-			boolean cv$guard$value = false;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Guard to ensure that value2 is only updated once for this probability.
-			boolean cv$guard$value2 = false;
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// Update the variable probability
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var18 = cv$sampleAccumulator;
 			
-			// Add probability to constructed variables from the combined probability
-			{
+			// Store the sample task probability
+			logProbability$sample21 = cv$sampleProbability;
+		}
+		
+		// Guard to ensure that value is only updated once for this probability.
+		boolean cv$guard$value = false;
+		
+		// Guard to ensure that value2 is only updated once for this probability.
+		boolean cv$guard$value2 = false;
+		
+		// Update the variable probability
+		logProbability$var19 = (logProbability$var19 + cv$accumulator);
+		
+		// Add probability to constructed variables from the combined probability
+		{
+			// If the probability of the variable has not already been updated
+			if(!cv$guard$value) {
+				// Set the guard so the update is only applied once.
+				cv$guard$value = true;
+				
+				// Update the variable probability
+				logProbability$value = (logProbability$value + cv$accumulator);
+			}
+		}
+		
+		// Looking for a path between Sample 21 and consumer double[] 27.
+		{
+			if((0 == 0)) {
 				// If the probability of the variable has not already been updated
-				if(!cv$guard$value) {
+				if(!cv$guard$value2) {
 					// Set the guard so the update is only applied once.
-					cv$guard$value = true;
+					cv$guard$value2 = true;
 					
 					// Update the variable probability
-					logProbability$value = (logProbability$value + cv$accumulator);
+					logProbability$value2 = (logProbability$value2 + cv$accumulator);
 				}
 			}
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
-			{
-				if((0 == 0)) {
-					// If the probability of the variable has not already been updated
-					if(!cv$guard$value2) {
-						// Set the guard so the update is only applied once.
-						cv$guard$value2 = true;
-						
-						// Update the variable probability
-						logProbability$value2 = (logProbability$value2 + cv$accumulator);
-					}
-				}
-			}
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedFlag$sample4);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample21;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var18 = cv$rvAccumulator;
-			}
-			
-			// Guard to ensure that value is only updated once for this probability.
-			boolean cv$guard$value = false;
-			
-			// Guard to ensure that value2 is only updated once for this probability.
-			boolean cv$guard$value2 = false;
-			
-			// Update the variable probability
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			
-			// Add probability to constructed variables from the combined probability
-			{
-				// If the probability of the variable has not already been updated
-				if(!cv$guard$value) {
-					// Set the guard so the update is only applied once.
-					cv$guard$value = true;
-					
-					// Update the variable probability
-					logProbability$value = (logProbability$value + cv$accumulator);
-				}
-			}
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
-			{
-				if((0 == 0)) {
-					// If the probability of the variable has not already been updated
-					if(!cv$guard$value2) {
-						// Set the guard so the update is only applied once.
-						cv$guard$value2 = true;
-						
-						// Update the variable probability
-						logProbability$value2 = (logProbability$value2 + cv$accumulator);
-					}
-				}
-			}
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -692,13 +594,10 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample21))
-				value[0] = var19;
+			var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value[0] = var19;
 		}
-		if(!(fixedFlag$sample4 && fixedFlag$sample21))
-			value2[0] = value[0];
+		value2[0] = value[0];
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -709,16 +608,14 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var19 = false;
-				{
-					// Observation reached
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var19 = false;
+			{
+				// Observation reached
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -731,8 +628,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 			value[0] = var19;
 		}
 		value2[0] = value[0];
@@ -745,16 +641,14 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var19 = false;
-				{
-					// Observation reached
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var19 = false;
+			{
+				// Observation reached
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -766,16 +660,14 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var19 = false;
-				{
-					// Observation reached
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var19 = false;
+			{
+				// Observation reached
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -819,8 +711,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$var19 = 0.0;
 		logProbability$value = 0.0;
 		logProbability$value2 = 0.0;
-		if(!fixedProbFlag$sample21)
-			logProbability$sample21 = Double.NaN;
+		logProbability$sample21 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$SingleThreadCPU_modelNoComments.java
@@ -5,9 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 
 class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements Conditional2$CoreInterface {
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample21 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample21 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -30,17 +28,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	}
 
 	@Override
-	public final boolean get$fixedFlag$sample21() {
-		return fixedFlag$sample21;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample21(boolean cv$value) {
-		fixedFlag$sample21 = cv$value;
-		fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedProbFlag$sample21);
-	}
-
-	@Override
 	public final boolean get$fixedFlag$sample4() {
 		return fixedFlag$sample4;
 	}
@@ -49,7 +36,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void set$fixedFlag$sample4(boolean cv$value) {
 		fixedFlag$sample4 = cv$value;
 		fixedProbFlag$sample4 = (fixedFlag$sample4 && fixedProbFlag$sample4);
-		fixedProbFlag$sample21 = (fixedFlag$sample4 && fixedProbFlag$sample21);
 	}
 
 	@Override
@@ -61,7 +47,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void set$guard(boolean cv$value) {
 		guard = cv$value;
 		fixedProbFlag$sample4 = false;
-		fixedProbFlag$sample21 = false;
 	}
 
 	@Override
@@ -122,98 +107,64 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$var19(double cv$value) {
 		var19 = cv$value;
-		fixedProbFlag$sample21 = false;
 	}
 
 	private final void logProbabilityValue$sample21() {
-		if(!fixedProbFlag$sample21) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				double cv$sampleValue = var19;
 				{
-					double cv$sampleValue = var19;
 					{
-						{
-							double var16 = 0.0;
-							double var17 = 1.0;
-							double cv$weightedProbability = (Math.log(1.0) + (((var16 <= cv$sampleValue) && (cv$sampleValue < var17))?(-Math.log((var17 - var16))):Double.NEGATIVE_INFINITY));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var16 = 0.0;
+						double var17 = 1.0;
+						double cv$weightedProbability = (Math.log(1.0) + (((var16 <= cv$sampleValue) && (cv$sampleValue < var17))?(-Math.log((var17 - var16))):Double.NEGATIVE_INFINITY));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var18 = cv$sampleAccumulator;
-				logProbability$sample21 = cv$sampleProbability;
-			}
-			boolean cv$guard$value = false;
-			boolean cv$guard$value2 = false;
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			{
-				if(!cv$guard$value) {
-					cv$guard$value = true;
-					logProbability$value = (logProbability$value + cv$accumulator);
-				}
-			}
-			{
-				if((0 == 0)) {
-					if(!cv$guard$value2) {
-						cv$guard$value2 = true;
-						logProbability$value2 = (logProbability$value2 + cv$accumulator);
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
 			}
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedFlag$sample4);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample21;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var18 = cv$rvAccumulator;
-			}
-			boolean cv$guard$value = false;
-			boolean cv$guard$value2 = false;
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			{
-				if(!cv$guard$value) {
-					cv$guard$value = true;
-					logProbability$value = (logProbability$value + cv$accumulator);
-				}
-			}
-			{
-				if((0 == 0)) {
-					if(!cv$guard$value2) {
-						cv$guard$value2 = true;
-						logProbability$value2 = (logProbability$value2 + cv$accumulator);
-					}
-				}
-			}
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var18 = cv$sampleAccumulator;
+			logProbability$sample21 = cv$sampleProbability;
 		}
+		boolean cv$guard$value = false;
+		boolean cv$guard$value2 = false;
+		logProbability$var19 = (logProbability$var19 + cv$accumulator);
+		{
+			if(!cv$guard$value) {
+				cv$guard$value = true;
+				logProbability$value = (logProbability$value + cv$accumulator);
+			}
+		}
+		{
+			if((0 == 0)) {
+				if(!cv$guard$value2) {
+					cv$guard$value2 = true;
+					logProbability$value2 = (logProbability$value2 + cv$accumulator);
+				}
+			}
+		}
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample4() {
@@ -418,13 +369,10 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample21))
-				value[0] = var19;
+			var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value[0] = var19;
 		}
-		if(!(fixedFlag$sample4 && fixedFlag$sample21))
-			value2[0] = value[0];
+		value2[0] = value[0];
 	}
 
 	@Override
@@ -432,14 +380,12 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				boolean observationGuard$var19 = false;
-				{
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			boolean observationGuard$var19 = false;
+			{
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -450,8 +396,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 			value[0] = var19;
 		}
 		value2[0] = value[0];
@@ -462,14 +407,12 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				boolean observationGuard$var19 = false;
-				{
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			boolean observationGuard$var19 = false;
+			{
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -478,14 +421,12 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				boolean observationGuard$var19 = false;
-				{
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			boolean observationGuard$var19 = false;
+			{
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -514,8 +455,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$var19 = 0.0;
 		logProbability$value = 0.0;
 		logProbability$value2 = 0.0;
-		if(!fixedProbFlag$sample21)
-			logProbability$sample21 = Double.NaN;
+		logProbability$sample21 = Double.NaN;
 	}
 
 	@Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$SingleThreadCPU_modelSingle.java
@@ -7,9 +7,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample21 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample21 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -30,24 +28,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		super(target);
 	}
 
-	// Getter for fixedFlag$sample21.
-	@Override
-	public final boolean get$fixedFlag$sample21() {
-		return fixedFlag$sample21;
-	}
-
-	// Setter for fixedFlag$sample21.
-	@Override
-	public final void set$fixedFlag$sample21(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample21 including if probabilities
-		// need to be updated.
-		fixedFlag$sample21 = cv$value;
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedProbFlag$sample21);
-	}
-
 	// Getter for fixedFlag$sample4.
 	@Override
 	public final boolean get$fixedFlag$sample4() {
@@ -64,10 +44,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		// Should the probability of sample 4 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample4 = (fixedFlag$sample4 && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample21 = (fixedFlag$sample4 && fixedProbFlag$sample21);
 	}
 
 	// Getter for guard.
@@ -85,9 +61,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on guard.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -160,183 +133,116 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for var19.
 	@Override
 	public final void set$var19(double cv$value) {
-		// Set flags for all the side effects of var19 including if probabilities need to
-		// be updated.
 		var19 = cv$value;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on var19.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample21 using sampled
 	// values.
 	private final void logProbabilityValue$sample21() {
-		// Determine if we need to calculate the values for sample task 21 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample21) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = var19;
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = var19;
 					{
-						{
-							double var16 = 0.0;
-							double var17 = 1.0;
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((var16 <= cv$sampleValue) && (cv$sampleValue < var17))?(-Math.log((var17 - var16))):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var16 = 0.0;
+						double var17 = 1.0;
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((var16 <= cv$sampleValue) && (cv$sampleValue < var17))?(-Math.log((var17 - var16))):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var18 = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$var19 = cv$accumulator;
-			
-			// Guard to ensure that value is only updated once for this probability.
-			boolean cv$guard$value = false;
-			
-			// Guard to ensure that value2 is only updated once for this probability.
-			boolean cv$guard$value2 = false;
-			
-			// Add probability to constructed variables from the combined probability
-			{
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var18 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$var19 = cv$accumulator;
+		
+		// Guard to ensure that value is only updated once for this probability.
+		boolean cv$guard$value = false;
+		
+		// Guard to ensure that value2 is only updated once for this probability.
+		boolean cv$guard$value2 = false;
+		
+		// Add probability to constructed variables from the combined probability
+		{
+			// If the probability of the variable has not already been updated
+			if(!cv$guard$value) {
+				// Set the guard so the update is only applied once.
+				cv$guard$value = true;
+				
+				// Update the variable probability
+				logProbability$value = (logProbability$value + cv$accumulator);
+			}
+		}
+		
+		// Looking for a path between Sample 21 and consumer double[] 27.
+		{
+			if((0 == 0)) {
 				// If the probability of the variable has not already been updated
-				if(!cv$guard$value) {
+				if(!cv$guard$value2) {
 					// Set the guard so the update is only applied once.
-					cv$guard$value = true;
+					cv$guard$value2 = true;
 					
 					// Update the variable probability
-					logProbability$value = (logProbability$value + cv$accumulator);
+					logProbability$value2 = (logProbability$value2 + cv$accumulator);
 				}
 			}
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
-			{
-				if((0 == 0)) {
-					// If the probability of the variable has not already been updated
-					if(!cv$guard$value2) {
-						// Set the guard so the update is only applied once.
-						cv$guard$value2 = true;
-						
-						// Update the variable probability
-						logProbability$value2 = (logProbability$value2 + cv$accumulator);
-					}
-				}
-			}
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedFlag$sample4);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var19;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var18 = cv$rvAccumulator;
-			
-			// Guard to ensure that value is only updated once for this probability.
-			boolean cv$guard$value = false;
-			
-			// Guard to ensure that value2 is only updated once for this probability.
-			boolean cv$guard$value2 = false;
-			
-			// Add probability to constructed variables from the combined probability
-			{
-				// If the probability of the variable has not already been updated
-				if(!cv$guard$value) {
-					// Set the guard so the update is only applied once.
-					cv$guard$value = true;
-					
-					// Update the variable probability
-					logProbability$value = (logProbability$value + cv$accumulator);
-				}
-			}
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
-			{
-				if((0 == 0)) {
-					// If the probability of the variable has not already been updated
-					if(!cv$guard$value2) {
-						// Set the guard so the update is only applied once.
-						cv$guard$value2 = true;
-						
-						// Update the variable probability
-						logProbability$value2 = (logProbability$value2 + cv$accumulator);
-					}
-				}
-			}
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -688,13 +594,10 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample21))
-				value[0] = var19;
+			var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value[0] = var19;
 		}
-		if(!(fixedFlag$sample4 && fixedFlag$sample21))
-			value2[0] = value[0];
+		value2[0] = value[0];
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -705,16 +608,14 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var19 = false;
-				{
-					// Observation reached
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var19 = false;
+			{
+				// Observation reached
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -727,8 +628,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 			value[0] = var19;
 		}
 		value2[0] = value[0];
@@ -741,16 +641,14 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var19 = false;
-				{
-					// Observation reached
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var19 = false;
+			{
+				// Observation reached
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -762,16 +660,14 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample21) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var19 = false;
-				{
-					// Observation reached
-					observationGuard$var19 = true;
-				}
-				if(!observationGuard$var19)
-					var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var19 = false;
+			{
+				// Observation reached
+				observationGuard$var19 = true;
 			}
+			if(!observationGuard$var19)
+				var19 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -814,8 +710,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$var18 = Double.NaN;
 		logProbability$value = 0.0;
 		logProbability$value2 = 0.0;
-		if(!fixedProbFlag$sample21)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$SingleThreadCPU_optimisedModel.java
@@ -7,9 +7,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample21 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample21 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -31,26 +29,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		super(target);
 	}
 
-	// Getter for fixedFlag$sample21.
-	@Override
-	public final boolean get$fixedFlag$sample21() {
-		return fixedFlag$sample21;
-	}
-
-	// Setter for fixedFlag$sample21.
-	@Override
-	public final void set$fixedFlag$sample21(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample21 including if probabilities
-		// need to be updated.
-		fixedFlag$sample21 = cv$value;
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample21" with its value "cv$value".
-		fixedProbFlag$sample21 = (cv$value && fixedProbFlag$sample21);
-	}
-
 	// Getter for fixedFlag$sample4.
 	@Override
 	public final boolean get$fixedFlag$sample4() {
@@ -69,12 +47,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		// 
 		// Substituted "fixedFlag$sample4" with its value "cv$value".
 		fixedProbFlag$sample4 = (cv$value && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample4" with its value "cv$value".
-		fixedProbFlag$sample21 = (cv$value && fixedProbFlag$sample21);
 	}
 
 	// Getter for guard.
@@ -92,9 +64,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on guard.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -167,116 +136,76 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for var19.
 	@Override
 	public final void set$var19(double cv$value) {
-		// Set flags for all the side effects of var19 including if probabilities need to
-		// be updated.
 		var19 = cv$value;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on var19.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample21 using sampled
 	// values.
 	private final void logProbabilityValue$sample21() {
-		// Determine if we need to calculate the values for sample task 21 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample21) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		if(!guard) {
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = (((0.0 <= var19) && (var19 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
 			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = (((0.0 <= var19) && (var19 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = cv$distributionAccumulator;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var18 = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample21 = cv$distributionAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			
-			// Add probability to constructed variables from the combined probability
 			// 
-			// Update the variable probability
-			logProbability$value = (logProbability$value + cv$accumulator);
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
-			// Update the variable probability
-			logProbability$value2 = (logProbability$value2 + cv$accumulator);
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = cv$distributionAccumulator;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var18 = cv$distributionAccumulator;
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedFlag$sample4);
+			// Store the sample task probability
+			logProbability$sample21 = cv$distributionAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				cv$accumulator = logProbability$sample21;
-				logProbability$var18 = logProbability$sample21;
-			}
-			
-			// Update the variable probability
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			
-			// Add probability to constructed variables from the combined probability
-			// 
-			// Update the variable probability
-			logProbability$value = (logProbability$value + cv$accumulator);
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
-			// 
-			// Update the variable probability
-			logProbability$value2 = (logProbability$value2 + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$var19 = (logProbability$var19 + cv$accumulator);
+		
+		// Add probability to constructed variables from the combined probability
+		// 
+		// Update the variable probability
+		logProbability$value = (logProbability$value + cv$accumulator);
+		
+		// Looking for a path between Sample 21 and consumer double[] 27.
+		// 
+		// Update the variable probability
+		logProbability$value2 = (logProbability$value2 + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -555,13 +484,10 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample21))
-				value[0] = var19;
+			var19 = DistributionSampling.sampleUniform(RNG$);
+			value[0] = var19;
 		}
-		if((!fixedFlag$sample4 || !fixedFlag$sample21))
-			value2[0] = value[0];
+		value2[0] = value[0];
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -582,8 +508,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = DistributionSampling.sampleUniform(RNG$);
+			var19 = DistributionSampling.sampleUniform(RNG$);
 			value[0] = var19;
 		}
 		value2[0] = value[0];
@@ -639,8 +564,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$var19 = 0.0;
 		logProbability$value = 0.0;
 		logProbability$value2 = 0.0;
-		if(!fixedProbFlag$sample21)
-			logProbability$sample21 = Double.NaN;
+		logProbability$sample21 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$SingleThreadCPU_optimisedModelNoComments.java
@@ -5,9 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 
 class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements Conditional2$CoreInterface {
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample21 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample21 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -30,17 +28,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	}
 
 	@Override
-	public final boolean get$fixedFlag$sample21() {
-		return fixedFlag$sample21;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample21(boolean cv$value) {
-		fixedFlag$sample21 = cv$value;
-		fixedProbFlag$sample21 = (cv$value && fixedProbFlag$sample21);
-	}
-
-	@Override
 	public final boolean get$fixedFlag$sample4() {
 		return fixedFlag$sample4;
 	}
@@ -49,7 +36,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void set$fixedFlag$sample4(boolean cv$value) {
 		fixedFlag$sample4 = cv$value;
 		fixedProbFlag$sample4 = (cv$value && fixedProbFlag$sample4);
-		fixedProbFlag$sample21 = (cv$value && fixedProbFlag$sample21);
 	}
 
 	@Override
@@ -61,7 +47,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void set$guard(boolean cv$value) {
 		guard = cv$value;
 		fixedProbFlag$sample4 = false;
-		fixedProbFlag$sample21 = false;
 	}
 
 	@Override
@@ -122,36 +107,21 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$var19(double cv$value) {
 		var19 = cv$value;
-		fixedProbFlag$sample21 = false;
 	}
 
 	private final void logProbabilityValue$sample21() {
-		if(!fixedProbFlag$sample21) {
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				double cv$distributionAccumulator = (((0.0 <= var19) && (var19 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
-				cv$accumulator = cv$distributionAccumulator;
-				logProbability$var18 = cv$distributionAccumulator;
-				logProbability$sample21 = cv$distributionAccumulator;
-			}
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			logProbability$value = (logProbability$value + cv$accumulator);
-			logProbability$value2 = (logProbability$value2 + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedFlag$sample4);
-		} else {
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				cv$accumulator = logProbability$sample21;
-				logProbability$var18 = logProbability$sample21;
-			}
-			logProbability$var19 = (logProbability$var19 + cv$accumulator);
-			logProbability$value = (logProbability$value + cv$accumulator);
-			logProbability$value2 = (logProbability$value2 + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		if(!guard) {
+			double cv$distributionAccumulator = (((0.0 <= var19) && (var19 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
+			cv$accumulator = cv$distributionAccumulator;
+			logProbability$var18 = cv$distributionAccumulator;
+			logProbability$sample21 = cv$distributionAccumulator;
 		}
+		logProbability$var19 = (logProbability$var19 + cv$accumulator);
+		logProbability$value = (logProbability$value + cv$accumulator);
+		logProbability$value2 = (logProbability$value2 + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample4() {
@@ -221,13 +191,10 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample21))
-				value[0] = var19;
+			var19 = DistributionSampling.sampleUniform(RNG$);
+			value[0] = var19;
 		}
-		if((!fixedFlag$sample4 || !fixedFlag$sample21))
-			value2[0] = value[0];
+		value2[0] = value[0];
 	}
 
 	@Override
@@ -243,8 +210,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = DistributionSampling.sampleUniform(RNG$);
+			var19 = DistributionSampling.sampleUniform(RNG$);
 			value[0] = var19;
 		}
 		value2[0] = value[0];
@@ -282,8 +248,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$var19 = 0.0;
 		logProbability$value = 0.0;
 		logProbability$value2 = 0.0;
-		if(!fixedProbFlag$sample21)
-			logProbability$sample21 = Double.NaN;
+		logProbability$sample21 = Double.NaN;
 	}
 
 	@Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2$SingleThreadCPU_optimisedModelSingle.java
@@ -7,9 +7,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample21 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample21 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -30,26 +28,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		super(target);
 	}
 
-	// Getter for fixedFlag$sample21.
-	@Override
-	public final boolean get$fixedFlag$sample21() {
-		return fixedFlag$sample21;
-	}
-
-	// Setter for fixedFlag$sample21.
-	@Override
-	public final void set$fixedFlag$sample21(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample21 including if probabilities
-		// need to be updated.
-		fixedFlag$sample21 = cv$value;
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample21" with its value "cv$value".
-		fixedProbFlag$sample21 = (cv$value && fixedProbFlag$sample21);
-	}
-
 	// Getter for fixedFlag$sample4.
 	@Override
 	public final boolean get$fixedFlag$sample4() {
@@ -68,12 +46,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		// 
 		// Substituted "fixedFlag$sample4" with its value "cv$value".
 		fixedProbFlag$sample4 = (cv$value && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 21 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample4" with its value "cv$value".
-		fixedProbFlag$sample21 = (cv$value && fixedProbFlag$sample21);
 	}
 
 	// Getter for guard.
@@ -91,9 +63,6 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on guard.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -166,131 +135,84 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for var19.
 	@Override
 	public final void set$var19(double cv$value) {
-		// Set flags for all the side effects of var19 including if probabilities need to
-		// be updated.
 		var19 = cv$value;
-		
-		// Unset the fixed probability flag for sample 21 as it depends on var19.
-		fixedProbFlag$sample21 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample21 using sampled
 	// values.
 	private final void logProbabilityValue$sample21() {
-		// Determine if we need to calculate the values for sample task 21 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample21) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
 			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = (((0.0 <= var19) && (var19 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
-			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var18 = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$var19 = cv$sampleAccumulator;
-			}
-			
-			// Update the variable probability
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Scale the probability relative to the observed distribution space.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$value = (logProbability$value + cv$sampleAccumulator);
-			
-			// Update the variable probability
+			// Add the probability of this distribution configuration to the accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// An accumulator for the distributed probability space covered.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$value2 = (logProbability$value2 + cv$sampleAccumulator);
-			
-			// Add probability to model
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Store the value of the function call, so the function call is only made once.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample21 = (fixedFlag$sample21 && fixedFlag$sample4);
+			// The sample value to calculate the probability of generating
+			cv$sampleAccumulator = (((0.0 <= var19) && (var19 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$var18 = logProbability$var19;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var18 = cv$sampleAccumulator;
 			
-			// Add probability to constructed variables from the combined probability
+			// Store the random variable instance probability
 			// 
-			// Update the variable probability
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$value = (logProbability$value + logProbability$var19);
-			
-			// Looking for a path between Sample 21 and consumer double[] 27.
-			// 
-			// Update the variable probability
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$value2 = (logProbability$value2 + logProbability$var19);
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var19);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var19);
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$var19 = cv$sampleAccumulator;
 		}
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$value = (logProbability$value + cv$sampleAccumulator);
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$value2 = (logProbability$value2 + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -569,13 +491,10 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample21))
-				value[0] = var19;
+			var19 = DistributionSampling.sampleUniform(RNG$);
+			value[0] = var19;
 		}
-		if((!fixedFlag$sample4 || !fixedFlag$sample21))
-			value2[0] = value[0];
+		value2[0] = value[0];
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -596,8 +515,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value[0] = 1.0;
 		else {
-			if(!fixedFlag$sample21)
-				var19 = DistributionSampling.sampleUniform(RNG$);
+			var19 = DistributionSampling.sampleUniform(RNG$);
 			value[0] = var19;
 		}
 		value2[0] = value[0];
@@ -652,8 +570,7 @@ class Conditional2$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$var18 = Double.NaN;
 		logProbability$value = 0.0;
 		logProbability$value2 = 0.0;
-		if(!fixedProbFlag$sample21)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -128,17 +129,12 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample21(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample21())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -236,7 +232,6 @@ public class Conditional2 extends Model {
             newCore.set$var19(oldCore.get$var19());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample21(oldCore.get$fixedFlag$sample21());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -128,17 +129,12 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample21(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample21())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -236,7 +232,6 @@ public class Conditional2 extends Model {
             newCore.set$var19(oldCore.get$var19());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample21(oldCore.get$fixedFlag$sample21());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -128,17 +129,12 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample21(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample21())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -236,7 +232,6 @@ public class Conditional2 extends Model {
             newCore.set$var19(oldCore.get$var19());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample21(oldCore.get$fixedFlag$sample21());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -128,17 +129,12 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample21(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample21())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -236,7 +232,6 @@ public class Conditional2 extends Model {
             newCore.set$var19(oldCore.get$var19());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample21(oldCore.get$fixedFlag$sample21());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -128,17 +129,12 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample21(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample21())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -236,7 +232,6 @@ public class Conditional2 extends Model {
             newCore.set$var19(oldCore.get$var19());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample21(oldCore.get$fixedFlag$sample21());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2/Conditional2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -128,17 +129,12 @@ public class Conditional2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample21(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample21())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -236,7 +232,6 @@ public class Conditional2 extends Model {
             newCore.set$var19(oldCore.get$var19());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample21(oldCore.get$fixedFlag$sample21());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2b/Conditional2b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2b/Conditional2b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -133,7 +134,7 @@ public class Conditional2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2b/Conditional2b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2b/Conditional2b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -133,7 +134,7 @@ public class Conditional2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2b/Conditional2b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2b/Conditional2b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -133,7 +134,7 @@ public class Conditional2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2b/Conditional2b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2b/Conditional2b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -133,7 +134,7 @@ public class Conditional2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2b/Conditional2b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2b/Conditional2b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -133,7 +134,7 @@ public class Conditional2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2b/Conditional2b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2b/Conditional2b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -133,7 +134,7 @@ public class Conditional2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2c/Conditional2c_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2c/Conditional2c_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ public class Conditional2c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -169,7 +170,7 @@ public class Conditional2c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2c/Conditional2c_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2c/Conditional2c_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ public class Conditional2c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -169,7 +170,7 @@ public class Conditional2c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2c/Conditional2c_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2c/Conditional2c_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ public class Conditional2c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -169,7 +170,7 @@ public class Conditional2c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2c/Conditional2c_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2c/Conditional2c_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ public class Conditional2c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -169,7 +170,7 @@ public class Conditional2c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2c/Conditional2c_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2c/Conditional2c_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ public class Conditional2c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -169,7 +170,7 @@ public class Conditional2c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2c/Conditional2c_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2c/Conditional2c_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ public class Conditional2c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -169,7 +170,7 @@ public class Conditional2c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2d/Conditional2d_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2d/Conditional2d_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional2d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -133,7 +134,7 @@ public class Conditional2d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2d/Conditional2d_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2d/Conditional2d_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional2d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -133,7 +134,7 @@ public class Conditional2d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2d/Conditional2d_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2d/Conditional2d_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional2d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -133,7 +134,7 @@ public class Conditional2d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2d/Conditional2d_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2d/Conditional2d_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional2d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -133,7 +134,7 @@ public class Conditional2d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2d/Conditional2d_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2d/Conditional2d_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional2d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -133,7 +134,7 @@ public class Conditional2d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2d/Conditional2d_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2d/Conditional2d_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class Conditional2d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -133,7 +134,7 @@ public class Conditional2d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2e/Conditional2e_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2e/Conditional2e_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ public class Conditional2e extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -169,7 +170,7 @@ public class Conditional2e extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2e/Conditional2e_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2e/Conditional2e_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ public class Conditional2e extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -169,7 +170,7 @@ public class Conditional2e extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2e/Conditional2e_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2e/Conditional2e_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ public class Conditional2e extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -169,7 +170,7 @@ public class Conditional2e extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2e/Conditional2e_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2e/Conditional2e_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ public class Conditional2e extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -169,7 +170,7 @@ public class Conditional2e extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2e/Conditional2e_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2e/Conditional2e_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ public class Conditional2e extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -169,7 +170,7 @@ public class Conditional2e extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2e/Conditional2e_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional2e/Conditional2e_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ public class Conditional2e extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -169,7 +170,7 @@ public class Conditional2e extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional3/Conditional3_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional3/Conditional3_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -109,7 +110,7 @@ public class Conditional3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -138,17 +139,12 @@ public class Conditional3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -246,7 +242,6 @@ public class Conditional3 extends Model {
             newCore.set$var14(oldCore.get$var14());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional3/Conditional3_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional3/Conditional3_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -109,7 +110,7 @@ public class Conditional3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -138,17 +139,12 @@ public class Conditional3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -246,7 +242,6 @@ public class Conditional3 extends Model {
             newCore.set$var14(oldCore.get$var14());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional3/Conditional3_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional3/Conditional3_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -109,7 +110,7 @@ public class Conditional3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -138,17 +139,12 @@ public class Conditional3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -246,7 +242,6 @@ public class Conditional3 extends Model {
             newCore.set$var14(oldCore.get$var14());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional3/Conditional3_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional3/Conditional3_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -109,7 +110,7 @@ public class Conditional3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -138,17 +139,12 @@ public class Conditional3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -246,7 +242,6 @@ public class Conditional3 extends Model {
             newCore.set$var14(oldCore.get$var14());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional3/Conditional3_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional3/Conditional3_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -109,7 +110,7 @@ public class Conditional3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -138,17 +139,12 @@ public class Conditional3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -246,7 +242,6 @@ public class Conditional3 extends Model {
             newCore.set$var14(oldCore.get$var14());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional3/Conditional3_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional3/Conditional3_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -109,7 +110,7 @@ public class Conditional3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -138,17 +139,12 @@ public class Conditional3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -246,7 +242,6 @@ public class Conditional3 extends Model {
             newCore.set$var14(oldCore.get$var14());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public class Conditional4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -136,17 +137,12 @@ public class Conditional4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample21(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample21())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public class Conditional4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -136,17 +137,12 @@ public class Conditional4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample21(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample21())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public class Conditional4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -136,17 +137,12 @@ public class Conditional4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample21(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample21())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public class Conditional4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -136,17 +137,12 @@ public class Conditional4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample21(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample21())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public class Conditional4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -136,17 +137,12 @@ public class Conditional4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample21(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample21())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional4/Conditional4_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public class Conditional4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -136,17 +137,12 @@ public class Conditional4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample21(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample21())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional5/Conditional5_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional5/Conditional5_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -65,7 +66,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -96,7 +97,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -127,7 +128,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -249,10 +250,6 @@ public class Conditional5 extends Model {
             newCore.set$observedGuard(oldCore.get$observedGuard());
         if(observedValue.isSet())
             newCore.set$observedValue(oldCore.get$observedValue());
-
-        //ComputedVariables
-
-        //Set fixed flags
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional5/Conditional5_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional5/Conditional5_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -65,7 +66,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -96,7 +97,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -127,7 +128,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -249,10 +250,6 @@ public class Conditional5 extends Model {
             newCore.set$observedGuard(oldCore.get$observedGuard());
         if(observedValue.isSet())
             newCore.set$observedValue(oldCore.get$observedValue());
-
-        //ComputedVariables
-
-        //Set fixed flags
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional5/Conditional5_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional5/Conditional5_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -65,7 +66,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -96,7 +97,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -127,7 +128,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -249,10 +250,6 @@ public class Conditional5 extends Model {
             newCore.set$observedGuard(oldCore.get$observedGuard());
         if(observedValue.isSet())
             newCore.set$observedValue(oldCore.get$observedValue());
-
-        //ComputedVariables
-
-        //Set fixed flags
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional5/Conditional5_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional5/Conditional5_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -65,7 +66,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -96,7 +97,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -127,7 +128,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -249,10 +250,6 @@ public class Conditional5 extends Model {
             newCore.set$observedGuard(oldCore.get$observedGuard());
         if(observedValue.isSet())
             newCore.set$observedValue(oldCore.get$observedValue());
-
-        //ComputedVariables
-
-        //Set fixed flags
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional5/Conditional5_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional5/Conditional5_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -65,7 +66,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -96,7 +97,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -127,7 +128,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -249,10 +250,6 @@ public class Conditional5 extends Model {
             newCore.set$observedGuard(oldCore.get$observedGuard());
         if(observedValue.isSet())
             newCore.set$observedValue(oldCore.get$observedValue());
-
-        //ComputedVariables
-
-        //Set fixed flags
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional5/Conditional5_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional5/Conditional5_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -65,7 +66,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -96,7 +97,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -127,7 +128,7 @@ public class Conditional5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -249,10 +250,6 @@ public class Conditional5 extends Model {
             newCore.set$observedGuard(oldCore.get$observedGuard());
         if(observedValue.isSet())
             newCore.set$observedValue(oldCore.get$observedValue());
-
-        //ComputedVariables
-
-        //Set fixed flags
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional6/Conditional6_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional6/Conditional6_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class Conditional6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional6/Conditional6_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional6/Conditional6_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class Conditional6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional6/Conditional6_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional6/Conditional6_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class Conditional6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional6/Conditional6_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional6/Conditional6_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class Conditional6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional6/Conditional6_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional6/Conditional6_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class Conditional6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional6/Conditional6_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Conditional6/Conditional6_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class Conditional6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic/Deterministic_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic/Deterministic_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class Deterministic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic/Deterministic_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic/Deterministic_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class Deterministic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic/Deterministic_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic/Deterministic_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class Deterministic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic/Deterministic_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic/Deterministic_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class Deterministic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic/Deterministic_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic/Deterministic_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class Deterministic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic/Deterministic_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic/Deterministic_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class Deterministic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic2/Deterministic2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic2/Deterministic2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class Deterministic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic2/Deterministic2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic2/Deterministic2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class Deterministic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic2/Deterministic2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic2/Deterministic2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class Deterministic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic2/Deterministic2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic2/Deterministic2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class Deterministic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic2/Deterministic2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic2/Deterministic2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class Deterministic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic2/Deterministic2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Deterministic2/Deterministic2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class Deterministic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DirichletBernoulli/DirichletBernoulli_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DirichletBernoulli/DirichletBernoulli_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DirichletBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DirichletBernoulli/DirichletBernoulli_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DirichletBernoulli/DirichletBernoulli_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DirichletBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DirichletBernoulli/DirichletBernoulli_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DirichletBernoulli/DirichletBernoulli_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DirichletBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DirichletBernoulli/DirichletBernoulli_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DirichletBernoulli/DirichletBernoulli_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DirichletBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DirichletBernoulli/DirichletBernoulli_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DirichletBernoulli/DirichletBernoulli_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DirichletBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DirichletBernoulli/DirichletBernoulli_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DirichletBernoulli/DirichletBernoulli_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DirichletBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoice/DiscreteChoice_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoice/DiscreteChoice_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DiscreteChoice extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoice/DiscreteChoice_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoice/DiscreteChoice_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DiscreteChoice extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoice/DiscreteChoice_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoice/DiscreteChoice_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DiscreteChoice extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoice/DiscreteChoice_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoice/DiscreteChoice_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DiscreteChoice extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoice/DiscreteChoice_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoice/DiscreteChoice_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DiscreteChoice extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoice/DiscreteChoice_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoice/DiscreteChoice_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DiscreteChoice extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceAlt/DiscreteChoiceAlt_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceAlt/DiscreteChoiceAlt_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DiscreteChoiceAlt extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceAlt/DiscreteChoiceAlt_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceAlt/DiscreteChoiceAlt_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DiscreteChoiceAlt extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceAlt/DiscreteChoiceAlt_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceAlt/DiscreteChoiceAlt_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DiscreteChoiceAlt extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceAlt/DiscreteChoiceAlt_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceAlt/DiscreteChoiceAlt_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DiscreteChoiceAlt extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceAlt/DiscreteChoiceAlt_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceAlt/DiscreteChoiceAlt_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DiscreteChoiceAlt extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceAlt/DiscreteChoiceAlt_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceAlt/DiscreteChoiceAlt_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DiscreteChoiceAlt extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceRandCoeff/DiscreteChoiceRandCoeff_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceRandCoeff/DiscreteChoiceRandCoeff_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class DiscreteChoiceRandCoeff extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceRandCoeff/DiscreteChoiceRandCoeff_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceRandCoeff/DiscreteChoiceRandCoeff_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class DiscreteChoiceRandCoeff extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceRandCoeff/DiscreteChoiceRandCoeff_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceRandCoeff/DiscreteChoiceRandCoeff_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class DiscreteChoiceRandCoeff extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceRandCoeff/DiscreteChoiceRandCoeff_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceRandCoeff/DiscreteChoiceRandCoeff_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class DiscreteChoiceRandCoeff extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceRandCoeff/DiscreteChoiceRandCoeff_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceRandCoeff/DiscreteChoiceRandCoeff_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class DiscreteChoiceRandCoeff extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceRandCoeff/DiscreteChoiceRandCoeff_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DiscreteChoiceRandCoeff/DiscreteChoiceRandCoeff_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class DiscreteChoiceRandCoeff extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1/DistributionTest1_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1/DistributionTest1_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1/DistributionTest1_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1/DistributionTest1_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1/DistributionTest1_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1/DistributionTest1_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1/DistributionTest1_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1/DistributionTest1_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1/DistributionTest1_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1/DistributionTest1_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1/DistributionTest1_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1/DistributionTest1_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1b/DistributionTest1b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1b/DistributionTest1b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1b/DistributionTest1b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1b/DistributionTest1b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1b/DistributionTest1b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1b/DistributionTest1b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1b/DistributionTest1b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1b/DistributionTest1b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1b/DistributionTest1b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1b/DistributionTest1b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1b/DistributionTest1b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest1b/DistributionTest1b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2/DistributionTest2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2/DistributionTest2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2/DistributionTest2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2/DistributionTest2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2/DistributionTest2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2/DistributionTest2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2/DistributionTest2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2/DistributionTest2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2/DistributionTest2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2/DistributionTest2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2/DistributionTest2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2/DistributionTest2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$CoreInterface_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$CoreInterface_model.java
@@ -26,12 +26,6 @@ interface DistributionTest2b$CoreInterface extends org.sandwood.runtime.internal
 	// Setter for fixedFlag$sample23.
 	public void set$fixedFlag$sample23(boolean cv$value);
 
-	// Getter for fixedFlag$sample36.
-	public boolean get$fixedFlag$sample36();
-
-	// Setter for fixedFlag$sample36.
-	public void set$fixedFlag$sample36(boolean cv$value);
-
 	// Getter for fixedFlag$sample5.
 	public boolean get$fixedFlag$sample5();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$CoreInterface_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$CoreInterface_modelNoComments.java
@@ -9,8 +9,6 @@ interface DistributionTest2b$CoreInterface extends org.sandwood.runtime.internal
 	public void set$distribution$sample9(double[] cv$value);
 	public boolean get$fixedFlag$sample23();
 	public void set$fixedFlag$sample23(boolean cv$value);
-	public boolean get$fixedFlag$sample36();
-	public void set$fixedFlag$sample36(boolean cv$value);
 	public boolean get$fixedFlag$sample5();
 	public void set$fixedFlag$sample5(boolean cv$value);
 	public boolean get$fixedFlag$sample9();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$CoreInterface_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$CoreInterface_modelSingle.java
@@ -26,12 +26,6 @@ interface DistributionTest2b$CoreInterface extends org.sandwood.runtime.internal
 	// Setter for fixedFlag$sample23.
 	public void set$fixedFlag$sample23(boolean cv$value);
 
-	// Getter for fixedFlag$sample36.
-	public boolean get$fixedFlag$sample36();
-
-	// Setter for fixedFlag$sample36.
-	public void set$fixedFlag$sample36(boolean cv$value);
-
 	// Getter for fixedFlag$sample5.
 	public boolean get$fixedFlag$sample5();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$CoreInterface_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$CoreInterface_optimisedModel.java
@@ -26,12 +26,6 @@ interface DistributionTest2b$CoreInterface extends org.sandwood.runtime.internal
 	// Setter for fixedFlag$sample23.
 	public void set$fixedFlag$sample23(boolean cv$value);
 
-	// Getter for fixedFlag$sample36.
-	public boolean get$fixedFlag$sample36();
-
-	// Setter for fixedFlag$sample36.
-	public void set$fixedFlag$sample36(boolean cv$value);
-
 	// Getter for fixedFlag$sample5.
 	public boolean get$fixedFlag$sample5();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$CoreInterface_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$CoreInterface_optimisedModelNoComments.java
@@ -9,8 +9,6 @@ interface DistributionTest2b$CoreInterface extends org.sandwood.runtime.internal
 	public void set$distribution$sample9(double[] cv$value);
 	public boolean get$fixedFlag$sample23();
 	public void set$fixedFlag$sample23(boolean cv$value);
-	public boolean get$fixedFlag$sample36();
-	public void set$fixedFlag$sample36(boolean cv$value);
 	public boolean get$fixedFlag$sample5();
 	public void set$fixedFlag$sample5(boolean cv$value);
 	public boolean get$fixedFlag$sample9();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$CoreInterface_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$CoreInterface_optimisedModelSingle.java
@@ -26,12 +26,6 @@ interface DistributionTest2b$CoreInterface extends org.sandwood.runtime.internal
 	// Setter for fixedFlag$sample23.
 	public void set$fixedFlag$sample23(boolean cv$value);
 
-	// Getter for fixedFlag$sample36.
-	public boolean get$fixedFlag$sample36();
-
-	// Setter for fixedFlag$sample36.
-	public void set$fixedFlag$sample36(boolean cv$value);
-
 	// Getter for fixedFlag$sample5.
 	public boolean get$fixedFlag$sample5();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$MultiThreadCPU_model.java
@@ -15,12 +15,9 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	private double[] distribution$sample5;
 	private double[] distribution$sample9;
 	private boolean fixedFlag$sample23 = false;
-	private boolean fixedFlag$sample36 = false;
 	private boolean fixedFlag$sample5 = false;
 	private boolean fixedFlag$sample9 = false;
 	private boolean fixedProbFlag$sample23 = false;
-	private boolean fixedProbFlag$sample36 = false;
-	private boolean fixedProbFlag$sample43 = false;
 	private boolean fixedProbFlag$sample5 = false;
 	private boolean fixedProbFlag$sample9 = false;
 	private int length$value;
@@ -105,32 +102,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// Should the probability of sample 23 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample23 = (fixedFlag$sample23 && fixedProbFlag$sample23);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample23 && fixedProbFlag$sample43);
-	}
-
-	// Getter for fixedFlag$sample36.
-	@Override
-	public final boolean get$fixedFlag$sample36() {
-		return fixedFlag$sample36;
-	}
-
-	// Setter for fixedFlag$sample36.
-	@Override
-	public final void set$fixedFlag$sample36(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample36 including if probabilities
-		// need to be updated.
-		fixedFlag$sample36 = cv$value;
-		
-		// Should the probability of sample 36 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample36 = (fixedFlag$sample36 && fixedProbFlag$sample36);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample36 && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample5.
@@ -149,10 +120,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// Should the probability of sample 5 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample5 = (fixedFlag$sample5 && fixedProbFlag$sample5);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample5 && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample9.
@@ -171,10 +138,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// Should the probability of sample 9 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample9 = (fixedFlag$sample9 && fixedProbFlag$sample9);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample9 && fixedProbFlag$sample43);
 	}
 
 	// Getter for length$value.
@@ -258,9 +221,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		
 		// Unset the fixed probability flag for sample 5 as it depends on v1.
 		fixedProbFlag$sample5 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v1.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v2.
@@ -282,9 +242,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		
 		// Unset the fixed probability flag for sample 23 as it depends on v2.
 		fixedProbFlag$sample23 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v2.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v3.
@@ -455,35 +412,159 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	// Calculate the probability of the samples represented by sample43 using probability
 	// distributions.
 	private final void logProbabilityDistribution$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			
+			// Look for paths between the variable and the sample task 43 including any distribution
+			// values.
+			{
+				// The sample value to calculate the probability of generating
+				boolean cv$sampleValue = v[j];
 				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				// Enumerating the possible arguments for Bernoulli 42.
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample9) {
+						if((0 == j)) {
+							{
+								double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					} else {
+						if(true) {
+							// Enumerating the possible outputs of Categorical 8.
+							for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
+								int distributionTempVariable$var9$10 = index$sample9$8;
+								
+								// Update the probability of sampling this value from the distribution value.
+								double cv$probabilitySample9Value9 = (1.0 * distribution$sample9[index$sample9$8]);
+								if((0 == j)) {
+									{
+										double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+										
+										// Store the value of the function call, so the function call is only made once.
+										double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+										
+										// Add the probability of this sample task to the distribution accumulator.
+										if((cv$weightedProbability < cv$distributionAccumulator))
+											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+										else {
+											// If the second value is -infinity.
+											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+												cv$distributionAccumulator = cv$weightedProbability;
+											else
+												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+										}
+										
+										// Add the probability of this distribution configuration to the accumulator.
+										cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
+									}
+								}
+							}
+						}
+					}
+				} else {
+					if(true) {
+						// Enumerating the possible outputs of Categorical 4.
+						for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
+							int distributionTempVariable$v1$5 = index$sample5$3;
+							
+							// Update the probability of sampling this value from the distribution value.
+							double cv$probabilitySample5Value4 = (1.0 * distribution$sample5[index$sample5$3]);
+							if(fixedFlag$sample9) {
+								if((0 == j)) {
+									{
+										double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+										
+										// Store the value of the function call, so the function call is only made once.
+										double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+										
+										// Add the probability of this sample task to the distribution accumulator.
+										if((cv$weightedProbability < cv$distributionAccumulator))
+											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+										else {
+											// If the second value is -infinity.
+											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+												cv$distributionAccumulator = cv$weightedProbability;
+											else
+												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+										}
+										
+										// Add the probability of this distribution configuration to the accumulator.
+										cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+									}
+								}
+							} else {
+								if(true) {
+									// Enumerating the possible outputs of Categorical 8.
+									for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
+										int distributionTempVariable$var9$15 = index$sample9$13;
+										
+										// Update the probability of sampling this value from the distribution value.
+										double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
+										if((0 == j)) {
+											{
+												double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+												
+												// Store the value of the function call, so the function call is only made once.
+												double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+												
+												// Add the probability of this sample task to the distribution accumulator.
+												if((cv$weightedProbability < cv$distributionAccumulator))
+													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+												else {
+													// If the second value is -infinity.
+													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+														cv$distributionAccumulator = cv$weightedProbability;
+													else
+														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+												}
+												
+												// Add the probability of this distribution configuration to the accumulator.
+												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
 				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
-				
-				// Look for paths between the variable and the sample task 43 including any distribution
-				// values.
-				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = v[j];
-					
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample9) {
-							if((0 == j)) {
+				// Enumerating the possible arguments for Bernoulli 42.
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample23) {
+						for(int i = 1; i < size; i += 1) {
+							if((i == j)) {
 								{
 									double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
 									
@@ -505,20 +586,22 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 									cv$probabilityReached = (cv$probabilityReached + 1.0);
 								}
 							}
-						} else {
+						}
+					} else {
+						for(int i = 1; i < size; i += 1) {
 							if(true) {
-								// Enumerating the possible outputs of Categorical 8.
-								for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
-									int distributionTempVariable$var9$10 = index$sample9$8;
+								// Enumerating the possible outputs of Categorical 22.
+								for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
+									int distributionTempVariable$var23$30 = index$sample23$28;
 									
 									// Update the probability of sampling this value from the distribution value.
-									double cv$probabilitySample9Value9 = (1.0 * distribution$sample9[index$sample9$8]);
-									if((0 == j)) {
+									double cv$probabilitySample23Value29 = (1.0 * distribution$sample23[((i - 1) / 1)][index$sample23$28]);
+									if((i == j)) {
 										{
 											double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
 											
 											// Store the value of the function call, so the function call is only made once.
-											double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+											double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 											
 											// Add the probability of this sample task to the distribution accumulator.
 											if((cv$weightedProbability < cv$distributionAccumulator))
@@ -532,27 +615,29 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 											}
 											
 											// Add the probability of this distribution configuration to the accumulator.
-											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
+											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
 										}
 									}
 								}
 							}
 						}
-					} else {
-						if(true) {
-							// Enumerating the possible outputs of Categorical 4.
-							for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
-								int distributionTempVariable$v1$5 = index$sample5$3;
-								
-								// Update the probability of sampling this value from the distribution value.
-								double cv$probabilitySample5Value4 = (1.0 * distribution$sample5[index$sample5$3]);
-								if(fixedFlag$sample9) {
-									if((0 == j)) {
+					}
+				} else {
+					if(true) {
+						// Enumerating the possible outputs of Categorical 4.
+						for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
+							int distributionTempVariable$v1$24 = index$sample5$22;
+							
+							// Update the probability of sampling this value from the distribution value.
+							double cv$probabilitySample5Value23 = (1.0 * distribution$sample5[index$sample5$22]);
+							if(fixedFlag$sample23) {
+								for(int i = 1; i < size; i += 1) {
+									if((i == j)) {
 										{
-											double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+											double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
 											
 											// Store the value of the function call, so the function call is only made once.
-											double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+											double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 											
 											// Add the probability of this sample task to the distribution accumulator.
 											if((cv$weightedProbability < cv$distributionAccumulator))
@@ -566,23 +651,25 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 											}
 											
 											// Add the probability of this distribution configuration to the accumulator.
-											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
 										}
 									}
-								} else {
+								}
+							} else {
+								for(int i = 1; i < size; i += 1) {
 									if(true) {
-										// Enumerating the possible outputs of Categorical 8.
-										for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
-											int distributionTempVariable$var9$15 = index$sample9$13;
+										// Enumerating the possible outputs of Categorical 22.
+										for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
+											int distributionTempVariable$var23$36 = index$sample23$34;
 											
 											// Update the probability of sampling this value from the distribution value.
-											double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
-											if((0 == j)) {
+											double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[((i - 1) / 1)][index$sample23$34]);
+											if((i == j)) {
 												{
-													double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+													double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
 													
 													// Store the value of the function call, so the function call is only made once.
-													double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+													double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 													
 													// Add the probability of this sample task to the distribution accumulator.
 													if((cv$weightedProbability < cv$distributionAccumulator))
@@ -596,141 +683,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 													}
 													
 													// Add the probability of this distribution configuration to the accumulator.
-													cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample23) {
-							for(int i = 1; i < size; i += 1) {
-								if((i == j)) {
-									{
-										double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-										
-										// Store the value of the function call, so the function call is only made once.
-										double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-										
-										// Add the probability of this sample task to the distribution accumulator.
-										if((cv$weightedProbability < cv$distributionAccumulator))
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-										else {
-											// If the second value is -infinity.
-											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-												cv$distributionAccumulator = cv$weightedProbability;
-											else
-												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-										}
-										
-										// Add the probability of this distribution configuration to the accumulator.
-										cv$probabilityReached = (cv$probabilityReached + 1.0);
-									}
-								}
-							}
-						} else {
-							for(int i = 1; i < size; i += 1) {
-								if(true) {
-									// Enumerating the possible outputs of Categorical 22.
-									for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
-										int distributionTempVariable$var23$30 = index$sample23$28;
-										
-										// Update the probability of sampling this value from the distribution value.
-										double cv$probabilitySample23Value29 = (1.0 * distribution$sample23[((i - 1) / 1)][index$sample23$28]);
-										if((i == j)) {
-											{
-												double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-												
-												// Store the value of the function call, so the function call is only made once.
-												double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-												
-												// Add the probability of this sample task to the distribution accumulator.
-												if((cv$weightedProbability < cv$distributionAccumulator))
-													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-												else {
-													// If the second value is -infinity.
-													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-														cv$distributionAccumulator = cv$weightedProbability;
-													else
-														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-												}
-												
-												// Add the probability of this distribution configuration to the accumulator.
-												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
-											}
-										}
-									}
-								}
-							}
-						}
-					} else {
-						if(true) {
-							// Enumerating the possible outputs of Categorical 4.
-							for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
-								int distributionTempVariable$v1$24 = index$sample5$22;
-								
-								// Update the probability of sampling this value from the distribution value.
-								double cv$probabilitySample5Value23 = (1.0 * distribution$sample5[index$sample5$22]);
-								if(fixedFlag$sample23) {
-									for(int i = 1; i < size; i += 1) {
-										if((i == j)) {
-											{
-												double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
-												
-												// Store the value of the function call, so the function call is only made once.
-												double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-												
-												// Add the probability of this sample task to the distribution accumulator.
-												if((cv$weightedProbability < cv$distributionAccumulator))
-													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-												else {
-													// If the second value is -infinity.
-													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-														cv$distributionAccumulator = cv$weightedProbability;
-													else
-														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-												}
-												
-												// Add the probability of this distribution configuration to the accumulator.
-												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
-											}
-										}
-									}
-								} else {
-									for(int i = 1; i < size; i += 1) {
-										if(true) {
-											// Enumerating the possible outputs of Categorical 22.
-											for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
-												int distributionTempVariable$var23$36 = index$sample23$34;
-												
-												// Update the probability of sampling this value from the distribution value.
-												double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[((i - 1) / 1)][index$sample23$34]);
-												if((i == j)) {
-													{
-														double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
-														
-														// Store the value of the function call, so the function call is only made once.
-														double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-														
-														// Add the probability of this sample task to the distribution accumulator.
-														if((cv$weightedProbability < cv$distributionAccumulator))
-															cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-														else {
-															// If the second value is -infinity.
-															if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-																cv$distributionAccumulator = cv$weightedProbability;
-															else
-																cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-														}
-														
-														// Add the probability of this distribution configuration to the accumulator.
-														cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
-													}
+													cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
 												}
 											}
 										}
@@ -740,66 +693,36 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 						}
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample43[((j - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$v = (logProbability$v + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using probability
@@ -1129,217 +1052,145 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	// Calculate the probability of the samples represented by sample36 using sampled
 	// values.
 	private final void logProbabilityValue$sample36() {
-		// Determine if we need to calculate the values for sample task 36 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample36) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = v3[((j - 0) / 1)];
 				{
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = v3[((j - 0) / 1)];
 					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$c = (logProbability$c + cv$sampleAccumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Store the random variable instance probability
-			logProbability$v3 = cv$sampleAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample36 = fixedFlag$sample36;
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$v3;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$c = (logProbability$c + cv$rvAccumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		
+		// Store the random variable instance probability
+		logProbability$v3 = cv$sampleAccumulator;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample43 using sampled
 	// values.
 	private final void logProbabilityValue$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				boolean cv$sampleValue = v[j];
 				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = v[j];
 					{
-						{
-							double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample43[((j - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$v = (logProbability$v + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using sampled values.
@@ -2774,12 +2625,9 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			v = new boolean[length$value];
 		}
 		
-		// If v3 has not been set already allocate space.
-		if(!fixedFlag$sample36) {
-			// Constructor for v3
-			{
-				v3 = new int[((((length$value - 1) - 0) / 1) + 1)];
-			}
+		// Constructor for v3
+		{
+			v3 = new int[((((length$value - 1) - 0) / 1) + 1)];
 		}
 		
 		// Constructor for distribution$sample5
@@ -2844,8 +2692,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			}
 		);
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)])));
 		}
 	}
@@ -2860,9 +2707,9 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		for(int index$c = 0; index$c < weightings.length; index$c += 1) {
 			// Probability for this value
 			double cv$value = (((0.0 <= index$c) && (index$c < weightings.length))?weightings[index$c]:0.0);
-			if(!(fixedFlag$sample5 && fixedFlag$sample36))
-				// Save the probability of each value
-				cv$distribution$sample5[index$c] = cv$value;
+			
+			// Save the probability of each value
+			cv$distribution$sample5[index$c] = cv$value;
 		}
 		
 		// Create local copy of variable probabilities.
@@ -2894,10 +2741,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 					}
 			}
 		);
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -2922,8 +2767,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			}
 		);
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)])));
 		}
 	}
@@ -2949,10 +2793,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 					}
 			}
 		);
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -2977,10 +2819,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 					}
 			}
 		);
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -3005,17 +2845,13 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 						}
 				}
 			);
-			for(int j = 0; j < size; j += 1) {
-				if(!fixedFlag$sample36)
-					sample36(j);
-			}
+			for(int j = 0; j < size; j += 1)
+				sample36(j);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			for(int j = (size - ((((size - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1) {
-				if(!fixedFlag$sample36)
-					sample36(j);
-			}
+			for(int j = (size - ((((size - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1)
+				sample36(j);
 			
 			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 			parallelFor(RNG$, 1, size, 1,
@@ -3069,15 +2905,12 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			for(int i = 1; i < size; i += 1)
 				logProbability$sample23[((i - 1) / 1)] = Double.NaN;
 		}
-		if(!fixedProbFlag$sample36)
-			logProbability$v3 = Double.NaN;
+		logProbability$v3 = Double.NaN;
 		for(int j = 0; j < size; j += 1)
 			logProbability$var42[((j - 0) / 1)] = Double.NaN;
 		logProbability$v = 0.0;
-		if(!fixedProbFlag$sample43) {
-			for(int j = 0; j < size; j += 1)
-				logProbability$sample43[((j - 0) / 1)] = Double.NaN;
-		}
+		for(int j = 0; j < size; j += 1)
+			logProbability$sample43[((j - 0) / 1)] = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -3087,8 +2920,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample36)
-			logProbabilityValue$sample36();
 		logProbabilityValue$sample43();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$MultiThreadCPU_modelNoComments.java
@@ -13,12 +13,9 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	private double[] distribution$sample5;
 	private double[] distribution$sample9;
 	private boolean fixedFlag$sample23 = false;
-	private boolean fixedFlag$sample36 = false;
 	private boolean fixedFlag$sample5 = false;
 	private boolean fixedFlag$sample9 = false;
 	private boolean fixedProbFlag$sample23 = false;
-	private boolean fixedProbFlag$sample36 = false;
-	private boolean fixedProbFlag$sample43 = false;
 	private boolean fixedProbFlag$sample5 = false;
 	private boolean fixedProbFlag$sample9 = false;
 	private int length$value;
@@ -87,19 +84,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	public final void set$fixedFlag$sample23(boolean cv$value) {
 		fixedFlag$sample23 = cv$value;
 		fixedProbFlag$sample23 = (fixedFlag$sample23 && fixedProbFlag$sample23);
-		fixedProbFlag$sample43 = (fixedFlag$sample23 && fixedProbFlag$sample43);
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample36() {
-		return fixedFlag$sample36;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample36(boolean cv$value) {
-		fixedFlag$sample36 = cv$value;
-		fixedProbFlag$sample36 = (fixedFlag$sample36 && fixedProbFlag$sample36);
-		fixedProbFlag$sample43 = (fixedFlag$sample36 && fixedProbFlag$sample43);
 	}
 
 	@Override
@@ -111,7 +95,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	public final void set$fixedFlag$sample5(boolean cv$value) {
 		fixedFlag$sample5 = cv$value;
 		fixedProbFlag$sample5 = (fixedFlag$sample5 && fixedProbFlag$sample5);
-		fixedProbFlag$sample43 = (fixedFlag$sample5 && fixedProbFlag$sample43);
 	}
 
 	@Override
@@ -123,7 +106,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	public final void set$fixedFlag$sample9(boolean cv$value) {
 		fixedFlag$sample9 = cv$value;
 		fixedProbFlag$sample9 = (fixedFlag$sample9 && fixedProbFlag$sample9);
-		fixedProbFlag$sample43 = (fixedFlag$sample9 && fixedProbFlag$sample43);
 	}
 
 	@Override
@@ -190,7 +172,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	public final void set$v1(int cv$value) {
 		v1 = cv$value;
 		fixedProbFlag$sample5 = false;
-		fixedProbFlag$sample43 = false;
 	}
 
 	@Override
@@ -203,7 +184,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		v2 = cv$value;
 		fixedProbFlag$sample9 = false;
 		fixedProbFlag$sample23 = false;
-		fixedProbFlag$sample43 = false;
 	}
 
 	@Override
@@ -301,18 +281,105 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	}
 
 	private final void logProbabilityDistribution$sample43() {
-		if(!fixedProbFlag$sample43) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
-				{
-					boolean cv$sampleValue = v[j];
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample9) {
-							if((0 == j)) {
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				boolean cv$sampleValue = v[j];
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample9) {
+						if((0 == j)) {
+							{
+								double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+								double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					} else {
+						if(true) {
+							for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
+								int distributionTempVariable$var9$10 = index$sample9$8;
+								double cv$probabilitySample9Value9 = (1.0 * distribution$sample9[index$sample9$8]);
+								if((0 == j)) {
+									{
+										double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+										double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+										if((cv$weightedProbability < cv$distributionAccumulator))
+											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+										else {
+											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+												cv$distributionAccumulator = cv$weightedProbability;
+											else
+												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+										}
+										cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
+									}
+								}
+							}
+						}
+					}
+				} else {
+					if(true) {
+						for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
+							int distributionTempVariable$v1$5 = index$sample5$3;
+							double cv$probabilitySample5Value4 = (1.0 * distribution$sample5[index$sample5$3]);
+							if(fixedFlag$sample9) {
+								if((0 == j)) {
+									{
+										double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+										double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+										if((cv$weightedProbability < cv$distributionAccumulator))
+											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+										else {
+											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+												cv$distributionAccumulator = cv$weightedProbability;
+											else
+												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+										}
+										cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+									}
+								}
+							} else {
+								if(true) {
+									for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
+										int distributionTempVariable$var9$15 = index$sample9$13;
+										double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
+										if((0 == j)) {
+											{
+												double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+												double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+												if((cv$weightedProbability < cv$distributionAccumulator))
+													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+												else {
+													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+														cv$distributionAccumulator = cv$weightedProbability;
+													else
+														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+												}
+												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample23) {
+						for(int i = 1; i < size; i += 1) {
+							if((i == j)) {
 								{
 									double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
 									double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
@@ -327,15 +394,17 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 									cv$probabilityReached = (cv$probabilityReached + 1.0);
 								}
 							}
-						} else {
+						}
+					} else {
+						for(int i = 1; i < size; i += 1) {
 							if(true) {
-								for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
-									int distributionTempVariable$var9$10 = index$sample9$8;
-									double cv$probabilitySample9Value9 = (1.0 * distribution$sample9[index$sample9$8]);
-									if((0 == j)) {
+								for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
+									int distributionTempVariable$var23$30 = index$sample23$28;
+									double cv$probabilitySample23Value29 = (1.0 * distribution$sample23[((i - 1) / 1)][index$sample23$28]);
+									if((i == j)) {
 										{
 											double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-											double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+											double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 											if((cv$weightedProbability < cv$distributionAccumulator))
 												cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
 											else {
@@ -344,22 +413,24 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 												else
 													cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 											}
-											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
+											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
 										}
 									}
 								}
 							}
 						}
-					} else {
-						if(true) {
-							for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
-								int distributionTempVariable$v1$5 = index$sample5$3;
-								double cv$probabilitySample5Value4 = (1.0 * distribution$sample5[index$sample5$3]);
-								if(fixedFlag$sample9) {
-									if((0 == j)) {
+					}
+				} else {
+					if(true) {
+						for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
+							int distributionTempVariable$v1$24 = index$sample5$22;
+							double cv$probabilitySample5Value23 = (1.0 * distribution$sample5[index$sample5$22]);
+							if(fixedFlag$sample23) {
+								for(int i = 1; i < size; i += 1) {
+									if((i == j)) {
 										{
-											double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
-											double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+											double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
+											double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 											if((cv$weightedProbability < cv$distributionAccumulator))
 												cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
 											else {
@@ -368,18 +439,20 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 												else
 													cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 											}
-											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
 										}
 									}
-								} else {
+								}
+							} else {
+								for(int i = 1; i < size; i += 1) {
 									if(true) {
-										for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
-											int distributionTempVariable$var9$15 = index$sample9$13;
-											double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
-											if((0 == j)) {
+										for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
+											int distributionTempVariable$var23$36 = index$sample23$34;
+											double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[((i - 1) / 1)][index$sample23$34]);
+											if((i == j)) {
 												{
-													double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
-													double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+													double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
+													double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 													if((cv$weightedProbability < cv$distributionAccumulator))
 														cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
 													else {
@@ -388,102 +461,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 														else
 															cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 													}
-													cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample23) {
-							for(int i = 1; i < size; i += 1) {
-								if((i == j)) {
-									{
-										double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-										double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-										if((cv$weightedProbability < cv$distributionAccumulator))
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-										else {
-											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-												cv$distributionAccumulator = cv$weightedProbability;
-											else
-												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-										}
-										cv$probabilityReached = (cv$probabilityReached + 1.0);
-									}
-								}
-							}
-						} else {
-							for(int i = 1; i < size; i += 1) {
-								if(true) {
-									for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
-										int distributionTempVariable$var23$30 = index$sample23$28;
-										double cv$probabilitySample23Value29 = (1.0 * distribution$sample23[((i - 1) / 1)][index$sample23$28]);
-										if((i == j)) {
-											{
-												double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-												double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-												if((cv$weightedProbability < cv$distributionAccumulator))
-													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-												else {
-													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-														cv$distributionAccumulator = cv$weightedProbability;
-													else
-														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-												}
-												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
-											}
-										}
-									}
-								}
-							}
-						}
-					} else {
-						if(true) {
-							for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
-								int distributionTempVariable$v1$24 = index$sample5$22;
-								double cv$probabilitySample5Value23 = (1.0 * distribution$sample5[index$sample5$22]);
-								if(fixedFlag$sample23) {
-									for(int i = 1; i < size; i += 1) {
-										if((i == j)) {
-											{
-												double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
-												double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-												if((cv$weightedProbability < cv$distributionAccumulator))
-													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-												else {
-													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-														cv$distributionAccumulator = cv$weightedProbability;
-													else
-														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-												}
-												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
-											}
-										}
-									}
-								} else {
-									for(int i = 1; i < size; i += 1) {
-										if(true) {
-											for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
-												int distributionTempVariable$var23$36 = index$sample23$34;
-												double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[((i - 1) / 1)][index$sample23$34]);
-												if((i == j)) {
-													{
-														double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
-														double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-														if((cv$weightedProbability < cv$distributionAccumulator))
-															cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-														else {
-															if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-																cv$distributionAccumulator = cv$weightedProbability;
-															else
-																cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-														}
-														cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
-													}
+													cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
 												}
 											}
 										}
@@ -493,36 +471,21 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 						}
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
-				logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample43[((j - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$rvAccumulator;
-			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
+			logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 		}
+		logProbability$v = (logProbability$v + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityDistribution$sample5() {
@@ -692,117 +655,82 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	}
 
 	private final void logProbabilityValue$sample36() {
-		if(!fixedProbFlag$sample36) {
-			double cv$accumulator = 0.0;
-			double cv$sampleAccumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		double cv$sampleAccumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				int cv$sampleValue = v3[((j - 0) / 1)];
 				{
-					int cv$sampleValue = v3[((j - 0) / 1)];
 					{
-						{
-							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$c = (logProbability$c + cv$sampleAccumulator);
-			logProbability$v3 = cv$sampleAccumulator;
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample36 = fixedFlag$sample36;
-		} else {
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1)
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$v3;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$c = (logProbability$c + cv$rvAccumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		logProbability$v3 = cv$sampleAccumulator;
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample43() {
-		if(!fixedProbFlag$sample43) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				boolean cv$sampleValue = v[j];
 				{
-					boolean cv$sampleValue = v[j];
 					{
-						{
-							double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
-				logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample43[((j - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$rvAccumulator;
-			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
+			logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 		}
+		logProbability$v = (logProbability$v + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample5() {
@@ -1702,10 +1630,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		{
 			v = new boolean[length$value];
 		}
-		if(!fixedFlag$sample36) {
-			{
-				v3 = new int[((((length$value - 1) - 0) / 1) + 1)];
-			}
+		{
+			v3 = new int[((((length$value - 1) - 0) / 1) + 1)];
 		}
 		{
 			distribution$sample5 = new double[weightings.length];
@@ -1748,8 +1674,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			}
 		);
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)])));
 		}
 	}
@@ -1759,8 +1684,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		double[] cv$distribution$sample5 = distribution$sample5;
 		for(int index$c = 0; index$c < weightings.length; index$c += 1) {
 			double cv$value = (((0.0 <= index$c) && (index$c < weightings.length))?weightings[index$c]:0.0);
-			if(!(fixedFlag$sample5 && fixedFlag$sample36))
-				cv$distribution$sample5[index$c] = cv$value;
+			cv$distribution$sample5[index$c] = cv$value;
 		}
 		double[] cv$distribution$sample9 = distribution$sample9;
 		for(int index$var8 = 0; index$var8 < weightings.length; index$var8 += 1) {
@@ -1780,10 +1704,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 					}
 			}
 		);
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	@Override
@@ -1801,8 +1723,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			}
 		);
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)])));
 		}
 	}
@@ -1821,10 +1742,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 					}
 			}
 		);
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	@Override
@@ -1841,10 +1760,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 					}
 			}
 		);
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	@Override
@@ -1862,15 +1779,11 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 						}
 				}
 			);
-			for(int j = 0; j < size; j += 1) {
-				if(!fixedFlag$sample36)
-					sample36(j);
-			}
+			for(int j = 0; j < size; j += 1)
+				sample36(j);
 		} else {
-			for(int j = (size - ((((size - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1) {
-				if(!fixedFlag$sample36)
-					sample36(j);
-			}
+			for(int j = (size - ((((size - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1)
+				sample36(j);
 			parallelFor(RNG$, 1, size, 1,
 				(int forStart$i, int forEnd$i, int threadID$i, org.sandwood.random.internal.Rng RNG$1) -> { 
 					for(int i = forStart$i; i < forEnd$i; i += 1) {
@@ -1908,22 +1821,17 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			for(int i = 1; i < size; i += 1)
 				logProbability$sample23[((i - 1) / 1)] = Double.NaN;
 		}
-		if(!fixedProbFlag$sample36)
-			logProbability$v3 = Double.NaN;
+		logProbability$v3 = Double.NaN;
 		for(int j = 0; j < size; j += 1)
 			logProbability$var42[((j - 0) / 1)] = Double.NaN;
 		logProbability$v = 0.0;
-		if(!fixedProbFlag$sample43) {
-			for(int j = 0; j < size; j += 1)
-				logProbability$sample43[((j - 0) / 1)] = Double.NaN;
-		}
+		for(int j = 0; j < size; j += 1)
+			logProbability$sample43[((j - 0) / 1)] = Double.NaN;
 	}
 
 	@Override
 	public final void logEvidenceProbabilities() {
 		initializeLogProbabilityFields();
-		if(fixedFlag$sample36)
-			logProbabilityValue$sample36();
 		logProbabilityValue$sample43();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$MultiThreadCPU_modelSingle.java
@@ -15,12 +15,9 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	private double[] distribution$sample5;
 	private double[] distribution$sample9;
 	private boolean fixedFlag$sample23 = false;
-	private boolean fixedFlag$sample36 = false;
 	private boolean fixedFlag$sample5 = false;
 	private boolean fixedFlag$sample9 = false;
 	private boolean fixedProbFlag$sample23 = false;
-	private boolean fixedProbFlag$sample36 = false;
-	private boolean fixedProbFlag$sample43 = false;
 	private boolean fixedProbFlag$sample5 = false;
 	private boolean fixedProbFlag$sample9 = false;
 	private int length$value;
@@ -105,32 +102,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// Should the probability of sample 23 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample23 = (fixedFlag$sample23 && fixedProbFlag$sample23);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample23 && fixedProbFlag$sample43);
-	}
-
-	// Getter for fixedFlag$sample36.
-	@Override
-	public final boolean get$fixedFlag$sample36() {
-		return fixedFlag$sample36;
-	}
-
-	// Setter for fixedFlag$sample36.
-	@Override
-	public final void set$fixedFlag$sample36(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample36 including if probabilities
-		// need to be updated.
-		fixedFlag$sample36 = cv$value;
-		
-		// Should the probability of sample 36 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample36 = (fixedFlag$sample36 && fixedProbFlag$sample36);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample36 && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample5.
@@ -149,10 +120,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// Should the probability of sample 5 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample5 = (fixedFlag$sample5 && fixedProbFlag$sample5);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample5 && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample9.
@@ -171,10 +138,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// Should the probability of sample 9 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample9 = (fixedFlag$sample9 && fixedProbFlag$sample9);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample9 && fixedProbFlag$sample43);
 	}
 
 	// Getter for length$value.
@@ -258,9 +221,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		
 		// Unset the fixed probability flag for sample 5 as it depends on v1.
 		fixedProbFlag$sample5 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v1.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v2.
@@ -282,9 +242,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		
 		// Unset the fixed probability flag for sample 23 as it depends on v2.
 		fixedProbFlag$sample23 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v2.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v3.
@@ -458,35 +415,159 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	// Calculate the probability of the samples represented by sample43 using probability
 	// distributions.
 	private final void logProbabilityDistribution$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			// Look for paths between the variable and the sample task 43 including any distribution
+			// values.
+			{
+				// The sample value to calculate the probability of generating
+				boolean cv$sampleValue = v[j];
 				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+				// Enumerating the possible arguments for Bernoulli 42.
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample9) {
+						if((0 == j)) {
+							{
+								double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					} else {
+						if(true) {
+							// Enumerating the possible outputs of Categorical 8.
+							for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
+								int distributionTempVariable$var9$10 = index$sample9$8;
+								
+								// Update the probability of sampling this value from the distribution value.
+								double cv$probabilitySample9Value9 = (1.0 * distribution$sample9[index$sample9$8]);
+								if((0 == j)) {
+									{
+										double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+										
+										// Store the value of the function call, so the function call is only made once.
+										double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+										
+										// Add the probability of this sample task to the distribution accumulator.
+										if((cv$weightedProbability < cv$distributionAccumulator))
+											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+										else {
+											// If the second value is -infinity.
+											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+												cv$distributionAccumulator = cv$weightedProbability;
+											else
+												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+										}
+										
+										// Add the probability of this distribution configuration to the accumulator.
+										cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
+									}
+								}
+							}
+						}
+					}
+				} else {
+					if(true) {
+						// Enumerating the possible outputs of Categorical 4.
+						for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
+							int distributionTempVariable$v1$5 = index$sample5$3;
+							
+							// Update the probability of sampling this value from the distribution value.
+							double cv$probabilitySample5Value4 = (1.0 * distribution$sample5[index$sample5$3]);
+							if(fixedFlag$sample9) {
+								if((0 == j)) {
+									{
+										double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+										
+										// Store the value of the function call, so the function call is only made once.
+										double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+										
+										// Add the probability of this sample task to the distribution accumulator.
+										if((cv$weightedProbability < cv$distributionAccumulator))
+											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+										else {
+											// If the second value is -infinity.
+											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+												cv$distributionAccumulator = cv$weightedProbability;
+											else
+												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+										}
+										
+										// Add the probability of this distribution configuration to the accumulator.
+										cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+									}
+								}
+							} else {
+								if(true) {
+									// Enumerating the possible outputs of Categorical 8.
+									for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
+										int distributionTempVariable$var9$15 = index$sample9$13;
+										
+										// Update the probability of sampling this value from the distribution value.
+										double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
+										if((0 == j)) {
+											{
+												double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+												
+												// Store the value of the function call, so the function call is only made once.
+												double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+												
+												// Add the probability of this sample task to the distribution accumulator.
+												if((cv$weightedProbability < cv$distributionAccumulator))
+													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+												else {
+													// If the second value is -infinity.
+													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+														cv$distributionAccumulator = cv$weightedProbability;
+													else
+														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+												}
+												
+												// Add the probability of this distribution configuration to the accumulator.
+												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
 				
-				// Look for paths between the variable and the sample task 43 including any distribution
-				// values.
-				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = v[j];
-					
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample9) {
-							if((0 == j)) {
+				// Enumerating the possible arguments for Bernoulli 42.
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample23) {
+						for(int i = 1; i < size; i += 1) {
+							if((i == j)) {
 								{
 									double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
 									
@@ -508,20 +589,22 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 									cv$probabilityReached = (cv$probabilityReached + 1.0);
 								}
 							}
-						} else {
+						}
+					} else {
+						for(int i = 1; i < size; i += 1) {
 							if(true) {
-								// Enumerating the possible outputs of Categorical 8.
-								for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
-									int distributionTempVariable$var9$10 = index$sample9$8;
+								// Enumerating the possible outputs of Categorical 22.
+								for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
+									int distributionTempVariable$var23$30 = index$sample23$28;
 									
 									// Update the probability of sampling this value from the distribution value.
-									double cv$probabilitySample9Value9 = (1.0 * distribution$sample9[index$sample9$8]);
-									if((0 == j)) {
+									double cv$probabilitySample23Value29 = (1.0 * distribution$sample23[((i - 1) / 1)][index$sample23$28]);
+									if((i == j)) {
 										{
 											double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
 											
 											// Store the value of the function call, so the function call is only made once.
-											double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+											double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 											
 											// Add the probability of this sample task to the distribution accumulator.
 											if((cv$weightedProbability < cv$distributionAccumulator))
@@ -535,27 +618,29 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 											}
 											
 											// Add the probability of this distribution configuration to the accumulator.
-											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
+											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
 										}
 									}
 								}
 							}
 						}
-					} else {
-						if(true) {
-							// Enumerating the possible outputs of Categorical 4.
-							for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
-								int distributionTempVariable$v1$5 = index$sample5$3;
-								
-								// Update the probability of sampling this value from the distribution value.
-								double cv$probabilitySample5Value4 = (1.0 * distribution$sample5[index$sample5$3]);
-								if(fixedFlag$sample9) {
-									if((0 == j)) {
+					}
+				} else {
+					if(true) {
+						// Enumerating the possible outputs of Categorical 4.
+						for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
+							int distributionTempVariable$v1$24 = index$sample5$22;
+							
+							// Update the probability of sampling this value from the distribution value.
+							double cv$probabilitySample5Value23 = (1.0 * distribution$sample5[index$sample5$22]);
+							if(fixedFlag$sample23) {
+								for(int i = 1; i < size; i += 1) {
+									if((i == j)) {
 										{
-											double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+											double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
 											
 											// Store the value of the function call, so the function call is only made once.
-											double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+											double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 											
 											// Add the probability of this sample task to the distribution accumulator.
 											if((cv$weightedProbability < cv$distributionAccumulator))
@@ -569,23 +654,25 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 											}
 											
 											// Add the probability of this distribution configuration to the accumulator.
-											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
 										}
 									}
-								} else {
+								}
+							} else {
+								for(int i = 1; i < size; i += 1) {
 									if(true) {
-										// Enumerating the possible outputs of Categorical 8.
-										for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
-											int distributionTempVariable$var9$15 = index$sample9$13;
+										// Enumerating the possible outputs of Categorical 22.
+										for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
+											int distributionTempVariable$var23$36 = index$sample23$34;
 											
 											// Update the probability of sampling this value from the distribution value.
-											double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
-											if((0 == j)) {
+											double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[((i - 1) / 1)][index$sample23$34]);
+											if((i == j)) {
 												{
-													double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+													double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
 													
 													// Store the value of the function call, so the function call is only made once.
-													double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+													double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 													
 													// Add the probability of this sample task to the distribution accumulator.
 													if((cv$weightedProbability < cv$distributionAccumulator))
@@ -599,141 +686,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 													}
 													
 													// Add the probability of this distribution configuration to the accumulator.
-													cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample23) {
-							for(int i = 1; i < size; i += 1) {
-								if((i == j)) {
-									{
-										double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-										
-										// Store the value of the function call, so the function call is only made once.
-										double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-										
-										// Add the probability of this sample task to the distribution accumulator.
-										if((cv$weightedProbability < cv$distributionAccumulator))
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-										else {
-											// If the second value is -infinity.
-											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-												cv$distributionAccumulator = cv$weightedProbability;
-											else
-												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-										}
-										
-										// Add the probability of this distribution configuration to the accumulator.
-										cv$probabilityReached = (cv$probabilityReached + 1.0);
-									}
-								}
-							}
-						} else {
-							for(int i = 1; i < size; i += 1) {
-								if(true) {
-									// Enumerating the possible outputs of Categorical 22.
-									for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
-										int distributionTempVariable$var23$30 = index$sample23$28;
-										
-										// Update the probability of sampling this value from the distribution value.
-										double cv$probabilitySample23Value29 = (1.0 * distribution$sample23[((i - 1) / 1)][index$sample23$28]);
-										if((i == j)) {
-											{
-												double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-												
-												// Store the value of the function call, so the function call is only made once.
-												double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-												
-												// Add the probability of this sample task to the distribution accumulator.
-												if((cv$weightedProbability < cv$distributionAccumulator))
-													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-												else {
-													// If the second value is -infinity.
-													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-														cv$distributionAccumulator = cv$weightedProbability;
-													else
-														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-												}
-												
-												// Add the probability of this distribution configuration to the accumulator.
-												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
-											}
-										}
-									}
-								}
-							}
-						}
-					} else {
-						if(true) {
-							// Enumerating the possible outputs of Categorical 4.
-							for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
-								int distributionTempVariable$v1$24 = index$sample5$22;
-								
-								// Update the probability of sampling this value from the distribution value.
-								double cv$probabilitySample5Value23 = (1.0 * distribution$sample5[index$sample5$22]);
-								if(fixedFlag$sample23) {
-									for(int i = 1; i < size; i += 1) {
-										if((i == j)) {
-											{
-												double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
-												
-												// Store the value of the function call, so the function call is only made once.
-												double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-												
-												// Add the probability of this sample task to the distribution accumulator.
-												if((cv$weightedProbability < cv$distributionAccumulator))
-													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-												else {
-													// If the second value is -infinity.
-													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-														cv$distributionAccumulator = cv$weightedProbability;
-													else
-														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-												}
-												
-												// Add the probability of this distribution configuration to the accumulator.
-												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
-											}
-										}
-									}
-								} else {
-									for(int i = 1; i < size; i += 1) {
-										if(true) {
-											// Enumerating the possible outputs of Categorical 22.
-											for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
-												int distributionTempVariable$var23$36 = index$sample23$34;
-												
-												// Update the probability of sampling this value from the distribution value.
-												double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[((i - 1) / 1)][index$sample23$34]);
-												if((i == j)) {
-													{
-														double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
-														
-														// Store the value of the function call, so the function call is only made once.
-														double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-														
-														// Add the probability of this sample task to the distribution accumulator.
-														if((cv$weightedProbability < cv$distributionAccumulator))
-															cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-														else {
-															// If the second value is -infinity.
-															if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-																cv$distributionAccumulator = cv$weightedProbability;
-															else
-																cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-														}
-														
-														// Add the probability of this distribution configuration to the accumulator.
-														cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
-													}
+													cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
 												}
 											}
 										}
@@ -743,69 +696,40 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 						}
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var42 = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$var43 = cv$accumulator;
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var43;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var42 = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var42 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$var43 = cv$accumulator;
+		
+		// Update the variable probability
+		logProbability$v = (logProbability$v + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using probability
@@ -1138,223 +1062,152 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	// Calculate the probability of the samples represented by sample36 using sampled
 	// values.
 	private final void logProbabilityValue$sample36() {
-		// Determine if we need to calculate the values for sample task 36 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample36) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = v3[((j - 0) / 1)];
 				{
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = v3[((j - 0) / 1)];
 					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$c = (logProbability$c + cv$sampleAccumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$v3 = cv$sampleAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample36 = fixedFlag$sample36;
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$v3;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$c = (logProbability$c + cv$rvAccumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$v3 = cv$sampleAccumulator;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample43 using sampled
 	// values.
 	private final void logProbabilityValue$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				boolean cv$sampleValue = v[j];
 				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = v[j];
 					{
-						{
-							double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var42 = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$var43 = cv$accumulator;
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var43;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var42 = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var42 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$var43 = cv$accumulator;
+		
+		// Update the variable probability
+		logProbability$v = (logProbability$v + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using sampled values.
@@ -2789,12 +2642,9 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			v = new boolean[length$value];
 		}
 		
-		// If v3 has not been set already allocate space.
-		if(!fixedFlag$sample36) {
-			// Constructor for v3
-			{
-				v3 = new int[((((length$value - 1) - 0) / 1) + 1)];
-			}
+		// Constructor for v3
+		{
+			v3 = new int[((((length$value - 1) - 0) / 1) + 1)];
 		}
 		
 		// Constructor for distribution$sample5
@@ -2839,8 +2689,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			}
 		);
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)])));
 		}
 	}
@@ -2855,9 +2704,9 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		for(int index$c = 0; index$c < weightings.length; index$c += 1) {
 			// Probability for this value
 			double cv$value = (((0.0 <= index$c) && (index$c < weightings.length))?weightings[index$c]:0.0);
-			if(!(fixedFlag$sample5 && fixedFlag$sample36))
-				// Save the probability of each value
-				cv$distribution$sample5[index$c] = cv$value;
+			
+			// Save the probability of each value
+			cv$distribution$sample5[index$c] = cv$value;
 		}
 		
 		// Create local copy of variable probabilities.
@@ -2889,10 +2738,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 					}
 			}
 		);
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -2917,8 +2764,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			}
 		);
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)])));
 		}
 	}
@@ -2944,10 +2790,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 					}
 			}
 		);
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -2972,10 +2816,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 					}
 			}
 		);
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -3000,17 +2842,13 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 						}
 				}
 			);
-			for(int j = 0; j < size; j += 1) {
-				if(!fixedFlag$sample36)
-					sample36(j);
-			}
+			for(int j = 0; j < size; j += 1)
+				sample36(j);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			for(int j = (size - ((((size - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1) {
-				if(!fixedFlag$sample36)
-					sample36(j);
-			}
+			for(int j = (size - ((((size - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1)
+				sample36(j);
 			
 			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 			parallelFor(RNG$, 1, size, 1,
@@ -3061,12 +2899,10 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		logProbability$var22 = Double.NaN;
 		if(!fixedProbFlag$sample23)
 			logProbability$var23 = Double.NaN;
-		if(!fixedProbFlag$sample36)
-			logProbability$v3 = Double.NaN;
+		logProbability$v3 = Double.NaN;
 		logProbability$var42 = Double.NaN;
 		logProbability$v = 0.0;
-		if(!fixedProbFlag$sample43)
-			logProbability$var43 = Double.NaN;
+		logProbability$var43 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -3076,8 +2912,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample36)
-			logProbabilityValue$sample36();
 		logProbabilityValue$sample43();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$MultiThreadCPU_optimisedModel.java
@@ -15,12 +15,9 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	private double[] distribution$sample5;
 	private double[] distribution$sample9;
 	private boolean fixedFlag$sample23 = false;
-	private boolean fixedFlag$sample36 = false;
 	private boolean fixedFlag$sample5 = false;
 	private boolean fixedFlag$sample9 = false;
 	private boolean fixedProbFlag$sample23 = false;
-	private boolean fixedProbFlag$sample36 = false;
-	private boolean fixedProbFlag$sample43 = false;
 	private boolean fixedProbFlag$sample5 = false;
 	private boolean fixedProbFlag$sample9 = false;
 	private int length$value;
@@ -107,38 +104,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// 
 		// Substituted "fixedFlag$sample23" with its value "cv$value".
 		fixedProbFlag$sample23 = (cv$value && fixedProbFlag$sample23);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample23" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
-	}
-
-	// Getter for fixedFlag$sample36.
-	@Override
-	public final boolean get$fixedFlag$sample36() {
-		return fixedFlag$sample36;
-	}
-
-	// Setter for fixedFlag$sample36.
-	@Override
-	public final void set$fixedFlag$sample36(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample36 including if probabilities
-		// need to be updated.
-		fixedFlag$sample36 = cv$value;
-		
-		// Should the probability of sample 36 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample36" with its value "cv$value".
-		fixedProbFlag$sample36 = (cv$value && fixedProbFlag$sample36);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample36" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample5.
@@ -159,12 +124,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// 
 		// Substituted "fixedFlag$sample5" with its value "cv$value".
 		fixedProbFlag$sample5 = (cv$value && fixedProbFlag$sample5);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample5" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample9.
@@ -185,12 +144,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// 
 		// Substituted "fixedFlag$sample9" with its value "cv$value".
 		fixedProbFlag$sample9 = (cv$value && fixedProbFlag$sample9);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample9" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	// Getter for length$value.
@@ -274,9 +227,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		
 		// Unset the fixed probability flag for sample 5 as it depends on v1.
 		fixedProbFlag$sample5 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v1.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v2.
@@ -298,9 +248,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		
 		// Unset the fixed probability flag for sample 23 as it depends on v2.
 		fixedProbFlag$sample23 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v2.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v3.
@@ -440,132 +387,48 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	// Calculate the probability of the samples represented by sample43 using probability
 	// distributions.
 	private final void logProbabilityDistribution$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
-				
-				// Look for paths between the variable and the sample task 43 including any distribution
-				// values.
-				// 
-				// The sample value to calculate the probability of generating
-				boolean cv$sampleValue = v[j];
-				
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		for(int j = 0; j < size; j += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			
+			// Look for paths between the variable and the sample task 43 including any distribution
+			// values.
+			// 
+			// The sample value to calculate the probability of generating
+			boolean cv$sampleValue = v[j];
+			
+			// Enumerating the possible arguments for Bernoulli 42.
+			if((0 == j)) {
 				// Enumerating the possible arguments for Bernoulli 42.
-				if((0 == j)) {
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample9) {
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample9) {
+						// Substituted "j" with its value "0".
+						double var41 = ((double)v1 / (v2[0] + v3[0]));
+						
+						// Store the value of the function call, so the function call is only made once.
+						cv$distributionAccumulator = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						// 
+						// An accumulator for the distributed probability space covered.
+						cv$probabilityReached = 1.0;
+					} else {
+						// Enumerating the possible outputs of Categorical 8.
+						for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
+							// Update the probability of sampling this value from the distribution value.
+							double cv$probabilitySample9Value9 = distribution$sample9[index$sample9$8];
+							
 							// Substituted "j" with its value "0".
 							double var41 = ((double)v1 / (v2[0] + v3[0]));
 							
 							// Store the value of the function call, so the function call is only made once.
-							cv$distributionAccumulator = Math.log((cv$sampleValue?var41:(1.0 - var41)));
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							// 
-							// An accumulator for the distributed probability space covered.
-							cv$probabilityReached = 1.0;
-						} else {
-							// Enumerating the possible outputs of Categorical 8.
-							for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
-								// Update the probability of sampling this value from the distribution value.
-								double cv$probabilitySample9Value9 = distribution$sample9[index$sample9$8];
-								
-								// Substituted "j" with its value "0".
-								double var41 = ((double)v1 / (v2[0] + v3[0]));
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
-							}
-						}
-					} else {
-						// Enumerating the possible outputs of Categorical 4.
-						for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
-							// Update the probability of sampling this value from the distribution value.
-							double cv$probabilitySample5Value4 = distribution$sample5[index$sample5$3];
-							if(fixedFlag$sample9) {
-								// Substituted "j" with its value "0".
-								double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
-							} else {
-								// Enumerating the possible outputs of Categorical 8.
-								for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
-									// Update the probability of sampling this value from the distribution value.
-									double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
-									
-									// Substituted "j" with its value "0".
-									double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
-									
-									// Store the value of the function call, so the function call is only made once.
-									double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-									
-									// Add the probability of this sample task to the distribution accumulator.
-									if((cv$weightedProbability < cv$distributionAccumulator))
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-									else {
-										// If the second value is -infinity.
-										if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-											cv$distributionAccumulator = cv$weightedProbability;
-										else
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-									}
-									
-									// Add the probability of this distribution configuration to the accumulator.
-									cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
-								}
-							}
-						}
-					}
-				}
-				
-				// Enumerating the possible arguments for Bernoulli 42.
-				if((1 <= j)) {
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample23) {
-							double var41 = ((double)v1 / (v2[j] + v3[j]));
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+							double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 							
 							// Add the probability of this sample task to the distribution accumulator.
 							if((cv$weightedProbability < cv$distributionAccumulator))
@@ -579,44 +442,45 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 							}
 							
 							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
-						} else {
-							// Enumerating the possible outputs of Categorical 22.
-							for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
-								// Update the probability of sampling this value from the distribution value.
-								// 
-								// Substituted "i" with its value "j".
-								double cv$probabilitySample23Value29 = distribution$sample23[(j - 1)][index$sample23$28];
-								double var41 = ((double)v1 / (v2[j] + v3[j]));
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
-							}
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
 						}
-					} else {
-						// Enumerating the possible outputs of Categorical 4.
-						for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
-							// Update the probability of sampling this value from the distribution value.
-							double cv$probabilitySample5Value23 = distribution$sample5[index$sample5$22];
-							if(fixedFlag$sample23) {
-								double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+					}
+				} else {
+					// Enumerating the possible outputs of Categorical 4.
+					for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
+						// Update the probability of sampling this value from the distribution value.
+						double cv$probabilitySample5Value4 = distribution$sample5[index$sample5$3];
+						if(fixedFlag$sample9) {
+							// Substituted "j" with its value "0".
+							double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+						} else {
+							// Enumerating the possible outputs of Categorical 8.
+							for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
+								// Update the probability of sampling this value from the distribution value.
+								double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
+								
+								// Substituted "j" with its value "0".
+								double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
 								
 								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 								
 								// Add the probability of this sample task to the distribution accumulator.
 								if((cv$weightedProbability < cv$distributionAccumulator))
@@ -630,91 +494,147 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 								}
 								
 								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
-							} else {
-								// Enumerating the possible outputs of Categorical 22.
-								for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
-									// Update the probability of sampling this value from the distribution value.
-									// 
-									// Substituted "i" with its value "j".
-									double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[(j - 1)][index$sample23$34]);
-									double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
-									
-									// Store the value of the function call, so the function call is only made once.
-									double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-									
-									// Add the probability of this sample task to the distribution accumulator.
-									if((cv$weightedProbability < cv$distributionAccumulator))
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-									else {
-										// If the second value is -infinity.
-										if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-											cv$distributionAccumulator = cv$weightedProbability;
-										else
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-									}
-									
-									// Add the probability of this distribution configuration to the accumulator.
-									cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
-								}
+								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
 							}
 						}
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var42[j] = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample43[j] = cv$distributionAccumulator;
 			}
 			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				// Variable declaration of cv$rvAccumulator moved.
-				double cv$rvAccumulator = logProbability$sample43[j];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[j] = cv$rvAccumulator;
+			// Enumerating the possible arguments for Bernoulli 42.
+			if((1 <= j)) {
+				// Enumerating the possible arguments for Bernoulli 42.
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample23) {
+						double var41 = ((double)v1 / (v2[j] + v3[j]));
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
+					} else {
+						// Enumerating the possible outputs of Categorical 22.
+						for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
+							// Update the probability of sampling this value from the distribution value.
+							// 
+							// Substituted "i" with its value "j".
+							double cv$probabilitySample23Value29 = distribution$sample23[(j - 1)][index$sample23$28];
+							double var41 = ((double)v1 / (v2[j] + v3[j]));
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
+						}
+					}
+				} else {
+					// Enumerating the possible outputs of Categorical 4.
+					for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
+						// Update the probability of sampling this value from the distribution value.
+						double cv$probabilitySample5Value23 = distribution$sample5[index$sample5$22];
+						if(fixedFlag$sample23) {
+							double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
+						} else {
+							// Enumerating the possible outputs of Categorical 22.
+							for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
+								// Update the probability of sampling this value from the distribution value.
+								// 
+								// Substituted "i" with its value "j".
+								double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[(j - 1)][index$sample23$34]);
+								double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
+							}
+						}
+					}
+				}
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
 			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var42[j] = cv$distributionAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample43[j] = cv$distributionAccumulator;
 		}
+		
+		// Update the variable probability
+		logProbability$v = (logProbability$v + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using probability
@@ -1031,160 +951,99 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	// Calculate the probability of the samples represented by sample36 using sampled
 	// values.
 	private final void logProbabilityValue$sample36() {
-		// Determine if we need to calculate the values for sample task 36 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample36) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				// The sample value to calculate the probability of generating
-				int cv$sampleValue = v3[j];
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-			}
-			logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		for(int j = 0; j < size; j += 1) {
+			// The sample value to calculate the probability of generating
+			int cv$sampleValue = v3[j];
 			
-			// Store the random variable instance probability
-			logProbability$v3 = cv$sampleAccumulator;
-			
-			// Add probability to model
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Scale the probability relative to the observed distribution space.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample36 = fixedFlag$sample36;
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			logProbability$c = (logProbability$c + logProbability$v3);
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$v3);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$v3);
-		}
+		logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		
+		// Store the random variable instance probability
+		logProbability$v3 = cv$sampleAccumulator;
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample43 using sampled
 	// values.
 	private final void logProbabilityValue$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				double var41 = ((double)v1 / (v2[j] + v3[j]));
-				
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = Math.log((v[j]?var41:(1.0 - var41)));
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var42[j] = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample43[j] = cv$distributionAccumulator;
-			}
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		for(int j = 0; j < size; j += 1) {
+			double var41 = ((double)v1 / (v2[j] + v3[j]));
 			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = Math.log((v[j]?var41:(1.0 - var41)));
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var42[j] = cv$distributionAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample43[j] = cv$distributionAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				// Variable declaration of cv$rvAccumulator moved.
-				double cv$rvAccumulator = logProbability$sample43[j];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[j] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$v = (logProbability$v + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using sampled values.
@@ -2435,10 +2294,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// Constructor for v
 		v = new boolean[length$value];
 		
-		// If v3 has not been set already allocate space.
-		if(!fixedFlag$sample36)
-			// Constructor for v3
-			v3 = new int[length$value];
+		// Constructor for v3
+		v3 = new int[length$value];
 		
 		// Constructor for distribution$sample5
 		distribution$sample5 = new double[weightings.length];
@@ -2489,8 +2346,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			);
 
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((double)v1 / (v2[j] + v3[j])));
 		}
 	}
@@ -2500,15 +2356,12 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if((!fixedFlag$sample5 || !fixedFlag$sample36)) {
-			for(int index$c = 0; index$c < weightings.length; index$c += 1)
-				// Save the probability of each value
-				// 
-				// cv$distribution$sample5's comment
-				// Create local copy of variable probabilities.
-				distribution$sample5[index$c] = weightings[index$c];
-		}
+		for(int index$c = 0; index$c < weightings.length; index$c += 1)
+			// Save the probability of each value
+			// 
+			// cv$distribution$sample5's comment
+			// Create local copy of variable probabilities.
+			distribution$sample5[index$c] = weightings[index$c];
 		
 		// Constraints moved from conditionals in inner loops/scopes/etc.
 		if(!fixedFlag$sample9) {
@@ -2540,12 +2393,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 				}
 			);
 
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -2571,8 +2420,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			);
 
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((double)v1 / (v2[j] + v3[j])));
 		}
 	}
@@ -2599,12 +2447,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 				}
 			);
 
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -2630,12 +2474,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 				}
 			);
 
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -2661,20 +2501,13 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 					}
 				);
 
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample36) {
-				for(int j = 0; j < size; j += 1)
-					sample36(j);
-			}
+			for(int j = 0; j < size; j += 1)
+				sample36(j);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample36) {
-				for(int j = (size - 1); j >= 0; j -= 1)
-					sample36(j);
-			}
+			for(int j = (size - 1); j >= 0; j -= 1)
+				sample36(j);
 			
 			// Constraints moved from conditionals in inner loops/scopes/etc.
 			if(!fixedFlag$sample23)
@@ -2729,15 +2562,12 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			for(int i = 1; i < size; i += 1)
 				logProbability$sample23[(i - 1)] = Double.NaN;
 		}
-		if(!fixedProbFlag$sample36)
-			logProbability$v3 = Double.NaN;
+		logProbability$v3 = Double.NaN;
 		for(int j = 0; j < size; j += 1)
 			logProbability$var42[j] = Double.NaN;
 		logProbability$v = 0.0;
-		if(!fixedProbFlag$sample43) {
-			for(int j = 0; j < size; j += 1)
-				logProbability$sample43[j] = Double.NaN;
-		}
+		for(int j = 0; j < size; j += 1)
+			logProbability$sample43[j] = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -2747,8 +2577,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample36)
-			logProbabilityValue$sample36();
 		logProbabilityValue$sample43();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$MultiThreadCPU_optimisedModelNoComments.java
@@ -13,12 +13,9 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	private double[] distribution$sample5;
 	private double[] distribution$sample9;
 	private boolean fixedFlag$sample23 = false;
-	private boolean fixedFlag$sample36 = false;
 	private boolean fixedFlag$sample5 = false;
 	private boolean fixedFlag$sample9 = false;
 	private boolean fixedProbFlag$sample23 = false;
-	private boolean fixedProbFlag$sample36 = false;
-	private boolean fixedProbFlag$sample43 = false;
 	private boolean fixedProbFlag$sample5 = false;
 	private boolean fixedProbFlag$sample9 = false;
 	private int length$value;
@@ -87,19 +84,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	public final void set$fixedFlag$sample23(boolean cv$value) {
 		fixedFlag$sample23 = cv$value;
 		fixedProbFlag$sample23 = (cv$value && fixedProbFlag$sample23);
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample36() {
-		return fixedFlag$sample36;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample36(boolean cv$value) {
-		fixedFlag$sample36 = cv$value;
-		fixedProbFlag$sample36 = (cv$value && fixedProbFlag$sample36);
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	@Override
@@ -111,7 +95,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	public final void set$fixedFlag$sample5(boolean cv$value) {
 		fixedFlag$sample5 = cv$value;
 		fixedProbFlag$sample5 = (cv$value && fixedProbFlag$sample5);
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	@Override
@@ -123,7 +106,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	public final void set$fixedFlag$sample9(boolean cv$value) {
 		fixedFlag$sample9 = cv$value;
 		fixedProbFlag$sample9 = (cv$value && fixedProbFlag$sample9);
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	@Override
@@ -190,7 +172,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	public final void set$v1(int cv$value) {
 		v1 = cv$value;
 		fixedProbFlag$sample5 = false;
-		fixedProbFlag$sample43 = false;
 	}
 
 	@Override
@@ -203,7 +184,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		v2 = cv$value;
 		fixedProbFlag$sample9 = false;
 		fixedProbFlag$sample23 = false;
-		fixedProbFlag$sample43 = false;
 	}
 
 	@Override
@@ -268,73 +248,22 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	}
 
 	private final void logProbabilityDistribution$sample43() {
-		if(!fixedProbFlag$sample43) {
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
-				boolean cv$sampleValue = v[j];
-				if((0 == j)) {
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample9) {
-							double var41 = ((double)v1 / (v2[0] + v3[0]));
-							cv$distributionAccumulator = Math.log((cv$sampleValue?var41:(1.0 - var41)));
-							cv$probabilityReached = 1.0;
-						} else {
-							for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
-								double cv$probabilitySample9Value9 = distribution$sample9[index$sample9$8];
-								double var41 = ((double)v1 / (v2[0] + v3[0]));
-								double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
-							}
-						}
+		double cv$accumulator = 0.0;
+		for(int j = 0; j < size; j += 1) {
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			boolean cv$sampleValue = v[j];
+			if((0 == j)) {
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample9) {
+						double var41 = ((double)v1 / (v2[0] + v3[0]));
+						cv$distributionAccumulator = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						cv$probabilityReached = 1.0;
 					} else {
-						for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
-							double cv$probabilitySample5Value4 = distribution$sample5[index$sample5$3];
-							if(fixedFlag$sample9) {
-								double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
-								double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
-							} else {
-								for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
-									double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
-									double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
-									double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-									if((cv$weightedProbability < cv$distributionAccumulator))
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-									else {
-										if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-											cv$distributionAccumulator = cv$weightedProbability;
-										else
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-									}
-									cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
-								}
-							}
-						}
-					}
-				}
-				if((1 <= j)) {
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample23) {
-							double var41 = ((double)v1 / (v2[j] + v3[j]));
-							double cv$weightedProbability = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
+							double cv$probabilitySample9Value9 = distribution$sample9[index$sample9$8];
+							double var41 = ((double)v1 / (v2[0] + v3[0]));
+							double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 							if((cv$weightedProbability < cv$distributionAccumulator))
 								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
 							else {
@@ -343,29 +272,29 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 								else
 									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
-						} else {
-							for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
-								double cv$probabilitySample23Value29 = distribution$sample23[(j - 1)][index$sample23$28];
-								double var41 = ((double)v1 / (v2[j] + v3[j]));
-								double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
-							}
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
 						}
-					} else {
-						for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
-							double cv$probabilitySample5Value23 = distribution$sample5[index$sample5$22];
-							if(fixedFlag$sample23) {
-								double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
-								double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+					}
+				} else {
+					for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
+						double cv$probabilitySample5Value4 = distribution$sample5[index$sample5$3];
+						if(fixedFlag$sample9) {
+							double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
+							double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+						} else {
+							for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
+								double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
+								double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
+								double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 								if((cv$weightedProbability < cv$distributionAccumulator))
 									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
 								else {
@@ -374,49 +303,87 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 									else
 										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 								}
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
-							} else {
-								for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
-									double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[(j - 1)][index$sample23$34]);
-									double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
-									double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-									if((cv$weightedProbability < cv$distributionAccumulator))
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-									else {
-										if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-											cv$distributionAccumulator = cv$weightedProbability;
-										else
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-									}
-									cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
-								}
+								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
 							}
 						}
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				logProbability$var42[j] = cv$distributionAccumulator;
-				logProbability$sample43[j] = cv$distributionAccumulator;
 			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
-		} else {
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				double cv$rvAccumulator = logProbability$sample43[j];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[j] = cv$rvAccumulator;
+			if((1 <= j)) {
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample23) {
+						double var41 = ((double)v1 / (v2[j] + v3[j]));
+						double cv$weightedProbability = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
+					} else {
+						for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
+							double cv$probabilitySample23Value29 = distribution$sample23[(j - 1)][index$sample23$28];
+							double var41 = ((double)v1 / (v2[j] + v3[j]));
+							double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
+						}
+					}
+				} else {
+					for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
+						double cv$probabilitySample5Value23 = distribution$sample5[index$sample5$22];
+						if(fixedFlag$sample23) {
+							double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+							double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
+						} else {
+							for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
+								double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[(j - 1)][index$sample23$34]);
+								double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+								double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
+							}
+						}
+					}
+				}
 			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+			logProbability$var42[j] = cv$distributionAccumulator;
+			logProbability$sample43[j] = cv$distributionAccumulator;
 		}
+		logProbability$v = (logProbability$v + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityDistribution$sample5() {
@@ -489,51 +456,28 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	}
 
 	private final void logProbabilityValue$sample36() {
-		if(!fixedProbFlag$sample36) {
-			double cv$sampleAccumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				int cv$sampleValue = v3[j];
-				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-			}
-			logProbability$c = (logProbability$c + cv$sampleAccumulator);
-			logProbability$v3 = cv$sampleAccumulator;
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			fixedProbFlag$sample36 = fixedFlag$sample36;
-		} else {
-			logProbability$c = (logProbability$c + logProbability$v3);
-			logProbability$$model = (logProbability$$model + logProbability$v3);
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + logProbability$v3);
+		double cv$sampleAccumulator = 0.0;
+		for(int j = 0; j < size; j += 1) {
+			int cv$sampleValue = v3[j];
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
 		}
+		logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		logProbability$v3 = cv$sampleAccumulator;
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
 	}
 
 	private final void logProbabilityValue$sample43() {
-		if(!fixedProbFlag$sample43) {
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				double var41 = ((double)v1 / (v2[j] + v3[j]));
-				double cv$distributionAccumulator = Math.log((v[j]?var41:(1.0 - var41)));
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				logProbability$var42[j] = cv$distributionAccumulator;
-				logProbability$sample43[j] = cv$distributionAccumulator;
-			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
-		} else {
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				double cv$rvAccumulator = logProbability$sample43[j];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[j] = cv$rvAccumulator;
-			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		for(int j = 0; j < size; j += 1) {
+			double var41 = ((double)v1 / (v2[j] + v3[j]));
+			double cv$distributionAccumulator = Math.log((v[j]?var41:(1.0 - var41)));
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+			logProbability$var42[j] = cv$distributionAccumulator;
+			logProbability$sample43[j] = cv$distributionAccumulator;
 		}
+		logProbability$v = (logProbability$v + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample5() {
@@ -969,8 +913,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		if((!fixedFlag$sample9 || !fixedFlag$sample23))
 			v2 = new int[length$value];
 		v = new boolean[length$value];
-		if(!fixedFlag$sample36)
-			v3 = new int[length$value];
+		v3 = new int[length$value];
 		distribution$sample5 = new double[weightings.length];
 		distribution$sample23 = new double[(length$value - 1)][];
 		for(int i = 1; i < length$value; i += 1)
@@ -998,18 +941,15 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			);
 
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((double)v1 / (v2[j] + v3[j])));
 		}
 	}
 
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if((!fixedFlag$sample5 || !fixedFlag$sample36)) {
-			for(int index$c = 0; index$c < weightings.length; index$c += 1)
-				distribution$sample5[index$c] = weightings[index$c];
-		}
+		for(int index$c = 0; index$c < weightings.length; index$c += 1)
+			distribution$sample5[index$c] = weightings[index$c];
 		if(!fixedFlag$sample9) {
 			for(int index$var8 = 0; index$var8 < weightings.length; index$var8 += 1)
 				distribution$sample9[index$var8] = weightings[index$var8];
@@ -1025,10 +965,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 				}
 			);
 
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	@Override
@@ -1046,8 +984,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			);
 
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((double)v1 / (v2[j] + v3[j])));
 		}
 	}
@@ -1066,10 +1003,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 				}
 			);
 
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	@Override
@@ -1086,10 +1021,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 				}
 			);
 
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	@Override
@@ -1107,15 +1040,11 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 					}
 				);
 
-			if(!fixedFlag$sample36) {
-				for(int j = 0; j < size; j += 1)
-					sample36(j);
-			}
+			for(int j = 0; j < size; j += 1)
+				sample36(j);
 		} else {
-			if(!fixedFlag$sample36) {
-				for(int j = (size - 1); j >= 0; j -= 1)
-					sample36(j);
-			}
+			for(int j = (size - 1); j >= 0; j -= 1)
+				sample36(j);
 			if(!fixedFlag$sample23)
 				parallelFor(RNG$, 1, size, 1,
 					(int forStart$i, int forEnd$i, int threadID$i, org.sandwood.random.internal.Rng RNG$1) -> { 
@@ -1153,22 +1082,17 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			for(int i = 1; i < size; i += 1)
 				logProbability$sample23[(i - 1)] = Double.NaN;
 		}
-		if(!fixedProbFlag$sample36)
-			logProbability$v3 = Double.NaN;
+		logProbability$v3 = Double.NaN;
 		for(int j = 0; j < size; j += 1)
 			logProbability$var42[j] = Double.NaN;
 		logProbability$v = 0.0;
-		if(!fixedProbFlag$sample43) {
-			for(int j = 0; j < size; j += 1)
-				logProbability$sample43[j] = Double.NaN;
-		}
+		for(int j = 0; j < size; j += 1)
+			logProbability$sample43[j] = Double.NaN;
 	}
 
 	@Override
 	public final void logEvidenceProbabilities() {
 		initializeLogProbabilityFields();
-		if(fixedFlag$sample36)
-			logProbabilityValue$sample36();
 		logProbabilityValue$sample43();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$MultiThreadCPU_optimisedModelSingle.java
@@ -15,12 +15,9 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	private double[] distribution$sample5;
 	private double[] distribution$sample9;
 	private boolean fixedFlag$sample23 = false;
-	private boolean fixedFlag$sample36 = false;
 	private boolean fixedFlag$sample5 = false;
 	private boolean fixedFlag$sample9 = false;
 	private boolean fixedProbFlag$sample23 = false;
-	private boolean fixedProbFlag$sample36 = false;
-	private boolean fixedProbFlag$sample43 = false;
 	private boolean fixedProbFlag$sample5 = false;
 	private boolean fixedProbFlag$sample9 = false;
 	private int length$value;
@@ -107,38 +104,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// 
 		// Substituted "fixedFlag$sample23" with its value "cv$value".
 		fixedProbFlag$sample23 = (cv$value && fixedProbFlag$sample23);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample23" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
-	}
-
-	// Getter for fixedFlag$sample36.
-	@Override
-	public final boolean get$fixedFlag$sample36() {
-		return fixedFlag$sample36;
-	}
-
-	// Setter for fixedFlag$sample36.
-	@Override
-	public final void set$fixedFlag$sample36(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample36 including if probabilities
-		// need to be updated.
-		fixedFlag$sample36 = cv$value;
-		
-		// Should the probability of sample 36 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample36" with its value "cv$value".
-		fixedProbFlag$sample36 = (cv$value && fixedProbFlag$sample36);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample36" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample5.
@@ -159,12 +124,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// 
 		// Substituted "fixedFlag$sample5" with its value "cv$value".
 		fixedProbFlag$sample5 = (cv$value && fixedProbFlag$sample5);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample5" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample9.
@@ -185,12 +144,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// 
 		// Substituted "fixedFlag$sample9" with its value "cv$value".
 		fixedProbFlag$sample9 = (cv$value && fixedProbFlag$sample9);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample9" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	// Getter for length$value.
@@ -274,9 +227,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		
 		// Unset the fixed probability flag for sample 5 as it depends on v1.
 		fixedProbFlag$sample5 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v1.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v2.
@@ -298,9 +248,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		
 		// Unset the fixed probability flag for sample 23 as it depends on v2.
 		fixedProbFlag$sample23 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v2.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v3.
@@ -457,135 +404,51 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	// Calculate the probability of the samples represented by sample43 using probability
 	// distributions.
 	private final void logProbabilityDistribution$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
-				
-				// Look for paths between the variable and the sample task 43 including any distribution
-				// values.
-				// 
-				// The sample value to calculate the probability of generating
-				boolean cv$sampleValue = v[j];
-				
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			
+			// Look for paths between the variable and the sample task 43 including any distribution
+			// values.
+			// 
+			// The sample value to calculate the probability of generating
+			boolean cv$sampleValue = v[j];
+			
+			// Enumerating the possible arguments for Bernoulli 42.
+			if((0 == j)) {
 				// Enumerating the possible arguments for Bernoulli 42.
-				if((0 == j)) {
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample9) {
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample9) {
+						// Substituted "j" with its value "0".
+						double var41 = ((double)v1 / (v2[0] + v3[0]));
+						
+						// Store the value of the function call, so the function call is only made once.
+						cv$distributionAccumulator = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						// 
+						// An accumulator for the distributed probability space covered.
+						cv$probabilityReached = 1.0;
+					} else {
+						// Enumerating the possible outputs of Categorical 8.
+						for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
+							// Update the probability of sampling this value from the distribution value.
+							double cv$probabilitySample9Value9 = distribution$sample9[index$sample9$8];
+							
 							// Substituted "j" with its value "0".
 							double var41 = ((double)v1 / (v2[0] + v3[0]));
 							
 							// Store the value of the function call, so the function call is only made once.
-							cv$distributionAccumulator = Math.log((cv$sampleValue?var41:(1.0 - var41)));
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							// 
-							// An accumulator for the distributed probability space covered.
-							cv$probabilityReached = 1.0;
-						} else {
-							// Enumerating the possible outputs of Categorical 8.
-							for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
-								// Update the probability of sampling this value from the distribution value.
-								double cv$probabilitySample9Value9 = distribution$sample9[index$sample9$8];
-								
-								// Substituted "j" with its value "0".
-								double var41 = ((double)v1 / (v2[0] + v3[0]));
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
-							}
-						}
-					} else {
-						// Enumerating the possible outputs of Categorical 4.
-						for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
-							// Update the probability of sampling this value from the distribution value.
-							double cv$probabilitySample5Value4 = distribution$sample5[index$sample5$3];
-							if(fixedFlag$sample9) {
-								// Substituted "j" with its value "0".
-								double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
-							} else {
-								// Enumerating the possible outputs of Categorical 8.
-								for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
-									// Update the probability of sampling this value from the distribution value.
-									double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
-									
-									// Substituted "j" with its value "0".
-									double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
-									
-									// Store the value of the function call, so the function call is only made once.
-									double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-									
-									// Add the probability of this sample task to the distribution accumulator.
-									if((cv$weightedProbability < cv$distributionAccumulator))
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-									else {
-										// If the second value is -infinity.
-										if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-											cv$distributionAccumulator = cv$weightedProbability;
-										else
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-									}
-									
-									// Add the probability of this distribution configuration to the accumulator.
-									cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
-								}
-							}
-						}
-					}
-				}
-				
-				// Enumerating the possible arguments for Bernoulli 42.
-				if((1 <= j)) {
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample23) {
-							double var41 = ((double)v1 / (v2[j] + v3[j]));
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+							double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 							
 							// Add the probability of this sample task to the distribution accumulator.
 							if((cv$weightedProbability < cv$distributionAccumulator))
@@ -599,44 +462,45 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 							}
 							
 							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
-						} else {
-							// Enumerating the possible outputs of Categorical 22.
-							for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
-								// Update the probability of sampling this value from the distribution value.
-								// 
-								// Substituted "i" with its value "j".
-								double cv$probabilitySample23Value29 = distribution$sample23[(j - 1)][index$sample23$28];
-								double var41 = ((double)v1 / (v2[j] + v3[j]));
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
-							}
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
 						}
-					} else {
-						// Enumerating the possible outputs of Categorical 4.
-						for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
-							// Update the probability of sampling this value from the distribution value.
-							double cv$probabilitySample5Value23 = distribution$sample5[index$sample5$22];
-							if(fixedFlag$sample23) {
-								double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+					}
+				} else {
+					// Enumerating the possible outputs of Categorical 4.
+					for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
+						// Update the probability of sampling this value from the distribution value.
+						double cv$probabilitySample5Value4 = distribution$sample5[index$sample5$3];
+						if(fixedFlag$sample9) {
+							// Substituted "j" with its value "0".
+							double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+						} else {
+							// Enumerating the possible outputs of Categorical 8.
+							for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
+								// Update the probability of sampling this value from the distribution value.
+								double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
+								
+								// Substituted "j" with its value "0".
+								double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
 								
 								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 								
 								// Add the probability of this sample task to the distribution accumulator.
 								if((cv$weightedProbability < cv$distributionAccumulator))
@@ -650,115 +514,165 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 								}
 								
 								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
-							} else {
-								// Enumerating the possible outputs of Categorical 22.
-								for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
-									// Update the probability of sampling this value from the distribution value.
-									// 
-									// Substituted "i" with its value "j".
-									double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[(j - 1)][index$sample23$34]);
-									double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
-									
-									// Store the value of the function call, so the function call is only made once.
-									double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-									
-									// Add the probability of this sample task to the distribution accumulator.
-									if((cv$weightedProbability < cv$distributionAccumulator))
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-									else {
-										// If the second value is -infinity.
-										if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-											cv$distributionAccumulator = cv$weightedProbability;
-										else
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-									}
-									
-									// Add the probability of this distribution configuration to the accumulator.
-									cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
-								}
+								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
 							}
 						}
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$distributionAccumulator);
 			}
 			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var42 = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$var43 = cv$sampleAccumulator;
+			// Enumerating the possible arguments for Bernoulli 42.
+			if((1 <= j)) {
+				// Enumerating the possible arguments for Bernoulli 42.
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample23) {
+						double var41 = ((double)v1 / (v2[j] + v3[j]));
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
+					} else {
+						// Enumerating the possible outputs of Categorical 22.
+						for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
+							// Update the probability of sampling this value from the distribution value.
+							// 
+							// Substituted "i" with its value "j".
+							double cv$probabilitySample23Value29 = distribution$sample23[(j - 1)][index$sample23$28];
+							double var41 = ((double)v1 / (v2[j] + v3[j]));
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
+						}
+					}
+				} else {
+					// Enumerating the possible outputs of Categorical 4.
+					for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
+						// Update the probability of sampling this value from the distribution value.
+						double cv$probabilitySample5Value23 = distribution$sample5[index$sample5$22];
+						if(fixedFlag$sample23) {
+							double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
+						} else {
+							// Enumerating the possible outputs of Categorical 22.
+							for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
+								// Update the probability of sampling this value from the distribution value.
+								// 
+								// Substituted "i" with its value "j".
+								double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[(j - 1)][index$sample23$34]);
+								double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
+							}
+						}
+					}
+				}
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
 			
-			// Update the variable probability
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$v = (logProbability$v + cv$sampleAccumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$distributionAccumulator);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if((0 < size))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$var42 = logProbability$var43;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var42 = cv$sampleAccumulator;
 			
-			// Update the variable probability
+			// Store the random variable instance probability
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$v = (logProbability$v + logProbability$var43);
-			
-			// Add probability to model
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var43);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var43);
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$var43 = cv$sampleAccumulator;
 		}
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$v = (logProbability$v + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using probability
@@ -1091,185 +1005,118 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	// Calculate the probability of the samples represented by sample36 using sampled
 	// values.
 	private final void logProbabilityValue$sample36() {
-		// Determine if we need to calculate the values for sample task 36 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample36) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// The sample value to calculate the probability of generating
+			int cv$sampleValue = v3[j];
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// The sample value to calculate the probability of generating
-				int cv$sampleValue = v3[j];
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-			}
-			logProbability$c = (logProbability$c + cv$sampleAccumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$v3 = cv$sampleAccumulator;
-			
-			// Add probability to model
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Scale the probability relative to the observed distribution space.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample36 = fixedFlag$sample36;
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			logProbability$c = (logProbability$c + logProbability$v3);
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$v3);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$v3);
-		}
+		logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$v3 = cv$sampleAccumulator;
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample43 using sampled
 	// values.
 	private final void logProbabilityValue$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			double var41 = ((double)v1 / (v2[j] + v3[j]));
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double var41 = ((double)v1 / (v2[j] + v3[j]));
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((v[j]?var41:(1.0 - var41))));
-			}
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var42 = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$var43 = cv$sampleAccumulator;
-			}
-			
-			// Update the variable probability
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Scale the probability relative to the observed distribution space.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$v = (logProbability$v + cv$sampleAccumulator);
-			
-			// Add probability to model
+			// Add the probability of this distribution configuration to the accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// An accumulator for the distributed probability space covered.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((v[j]?var41:(1.0 - var41))));
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if((0 < size))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$var42 = logProbability$var43;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var42 = cv$sampleAccumulator;
 			
-			// Update the variable probability
+			// Store the random variable instance probability
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$v = (logProbability$v + logProbability$var43);
-			
-			// Add probability to model
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var43);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var43);
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$var43 = cv$sampleAccumulator;
 		}
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$v = (logProbability$v + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using sampled values.
@@ -2520,10 +2367,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		// Constructor for v
 		v = new boolean[length$value];
 		
-		// If v3 has not been set already allocate space.
-		if(!fixedFlag$sample36)
-			// Constructor for v3
-			v3 = new int[length$value];
+		// Constructor for v3
+		v3 = new int[length$value];
 		
 		// Constructor for distribution$sample5
 		distribution$sample5 = new double[weightings.length];
@@ -2562,8 +2407,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			);
 
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((double)v1 / (v2[j] + v3[j])));
 		}
 	}
@@ -2573,15 +2417,12 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if((!fixedFlag$sample5 || !fixedFlag$sample36)) {
-			for(int index$c = 0; index$c < weightings.length; index$c += 1)
-				// Save the probability of each value
-				// 
-				// cv$distribution$sample5's comment
-				// Create local copy of variable probabilities.
-				distribution$sample5[index$c] = weightings[index$c];
-		}
+		for(int index$c = 0; index$c < weightings.length; index$c += 1)
+			// Save the probability of each value
+			// 
+			// cv$distribution$sample5's comment
+			// Create local copy of variable probabilities.
+			distribution$sample5[index$c] = weightings[index$c];
 		
 		// Constraints moved from conditionals in inner loops/scopes/etc.
 		if(!fixedFlag$sample9) {
@@ -2613,12 +2454,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 				}
 			);
 
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -2644,8 +2481,7 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 			);
 
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((double)v1 / (v2[j] + v3[j])));
 		}
 	}
@@ -2672,12 +2508,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 				}
 			);
 
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -2703,12 +2535,8 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 				}
 			);
 
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -2734,20 +2562,13 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 					}
 				);
 
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample36) {
-				for(int j = 0; j < size; j += 1)
-					sample36(j);
-			}
+			for(int j = 0; j < size; j += 1)
+				sample36(j);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample36) {
-				for(int j = (size - 1); j >= 0; j -= 1)
-					sample36(j);
-			}
+			for(int j = (size - 1); j >= 0; j -= 1)
+				sample36(j);
 			
 			// Constraints moved from conditionals in inner loops/scopes/etc.
 			if(!fixedFlag$sample23)
@@ -2799,12 +2620,10 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		logProbability$var22 = Double.NaN;
 		if(!fixedProbFlag$sample23)
 			logProbability$var23 = Double.NaN;
-		if(!fixedProbFlag$sample36)
-			logProbability$v3 = Double.NaN;
+		logProbability$v3 = Double.NaN;
 		logProbability$var42 = Double.NaN;
 		logProbability$v = 0.0;
-		if(!fixedProbFlag$sample43)
-			logProbability$var43 = Double.NaN;
+		logProbability$var43 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -2814,8 +2633,6 @@ class DistributionTest2b$MultiThreadCPU extends org.sandwood.runtime.internal.mo
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample36)
-			logProbabilityValue$sample36();
 		logProbabilityValue$sample43();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$SingleThreadCPU_model.java
@@ -14,12 +14,9 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	private double[] distribution$sample5;
 	private double[] distribution$sample9;
 	private boolean fixedFlag$sample23 = false;
-	private boolean fixedFlag$sample36 = false;
 	private boolean fixedFlag$sample5 = false;
 	private boolean fixedFlag$sample9 = false;
 	private boolean fixedProbFlag$sample23 = false;
-	private boolean fixedProbFlag$sample36 = false;
-	private boolean fixedProbFlag$sample43 = false;
 	private boolean fixedProbFlag$sample5 = false;
 	private boolean fixedProbFlag$sample9 = false;
 	private int length$value;
@@ -104,32 +101,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// Should the probability of sample 23 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample23 = (fixedFlag$sample23 && fixedProbFlag$sample23);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample23 && fixedProbFlag$sample43);
-	}
-
-	// Getter for fixedFlag$sample36.
-	@Override
-	public final boolean get$fixedFlag$sample36() {
-		return fixedFlag$sample36;
-	}
-
-	// Setter for fixedFlag$sample36.
-	@Override
-	public final void set$fixedFlag$sample36(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample36 including if probabilities
-		// need to be updated.
-		fixedFlag$sample36 = cv$value;
-		
-		// Should the probability of sample 36 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample36 = (fixedFlag$sample36 && fixedProbFlag$sample36);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample36 && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample5.
@@ -148,10 +119,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// Should the probability of sample 5 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample5 = (fixedFlag$sample5 && fixedProbFlag$sample5);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample5 && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample9.
@@ -170,10 +137,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// Should the probability of sample 9 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample9 = (fixedFlag$sample9 && fixedProbFlag$sample9);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample9 && fixedProbFlag$sample43);
 	}
 
 	// Getter for length$value.
@@ -257,9 +220,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 5 as it depends on v1.
 		fixedProbFlag$sample5 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v1.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v2.
@@ -281,9 +241,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 23 as it depends on v2.
 		fixedProbFlag$sample23 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v2.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v3.
@@ -454,35 +411,159 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	// Calculate the probability of the samples represented by sample43 using probability
 	// distributions.
 	private final void logProbabilityDistribution$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			
+			// Look for paths between the variable and the sample task 43 including any distribution
+			// values.
+			{
+				// The sample value to calculate the probability of generating
+				boolean cv$sampleValue = v[j];
 				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				// Enumerating the possible arguments for Bernoulli 42.
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample9) {
+						if((0 == j)) {
+							{
+								double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					} else {
+						if(true) {
+							// Enumerating the possible outputs of Categorical 8.
+							for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
+								int distributionTempVariable$var9$10 = index$sample9$8;
+								
+								// Update the probability of sampling this value from the distribution value.
+								double cv$probabilitySample9Value9 = (1.0 * distribution$sample9[index$sample9$8]);
+								if((0 == j)) {
+									{
+										double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+										
+										// Store the value of the function call, so the function call is only made once.
+										double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+										
+										// Add the probability of this sample task to the distribution accumulator.
+										if((cv$weightedProbability < cv$distributionAccumulator))
+											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+										else {
+											// If the second value is -infinity.
+											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+												cv$distributionAccumulator = cv$weightedProbability;
+											else
+												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+										}
+										
+										// Add the probability of this distribution configuration to the accumulator.
+										cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
+									}
+								}
+							}
+						}
+					}
+				} else {
+					if(true) {
+						// Enumerating the possible outputs of Categorical 4.
+						for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
+							int distributionTempVariable$v1$5 = index$sample5$3;
+							
+							// Update the probability of sampling this value from the distribution value.
+							double cv$probabilitySample5Value4 = (1.0 * distribution$sample5[index$sample5$3]);
+							if(fixedFlag$sample9) {
+								if((0 == j)) {
+									{
+										double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+										
+										// Store the value of the function call, so the function call is only made once.
+										double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+										
+										// Add the probability of this sample task to the distribution accumulator.
+										if((cv$weightedProbability < cv$distributionAccumulator))
+											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+										else {
+											// If the second value is -infinity.
+											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+												cv$distributionAccumulator = cv$weightedProbability;
+											else
+												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+										}
+										
+										// Add the probability of this distribution configuration to the accumulator.
+										cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+									}
+								}
+							} else {
+								if(true) {
+									// Enumerating the possible outputs of Categorical 8.
+									for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
+										int distributionTempVariable$var9$15 = index$sample9$13;
+										
+										// Update the probability of sampling this value from the distribution value.
+										double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
+										if((0 == j)) {
+											{
+												double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+												
+												// Store the value of the function call, so the function call is only made once.
+												double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+												
+												// Add the probability of this sample task to the distribution accumulator.
+												if((cv$weightedProbability < cv$distributionAccumulator))
+													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+												else {
+													// If the second value is -infinity.
+													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+														cv$distributionAccumulator = cv$weightedProbability;
+													else
+														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+												}
+												
+												// Add the probability of this distribution configuration to the accumulator.
+												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
 				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
-				
-				// Look for paths between the variable and the sample task 43 including any distribution
-				// values.
-				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = v[j];
-					
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample9) {
-							if((0 == j)) {
+				// Enumerating the possible arguments for Bernoulli 42.
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample23) {
+						for(int i = 1; i < size; i += 1) {
+							if((i == j)) {
 								{
 									double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
 									
@@ -504,20 +585,22 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 									cv$probabilityReached = (cv$probabilityReached + 1.0);
 								}
 							}
-						} else {
+						}
+					} else {
+						for(int i = 1; i < size; i += 1) {
 							if(true) {
-								// Enumerating the possible outputs of Categorical 8.
-								for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
-									int distributionTempVariable$var9$10 = index$sample9$8;
+								// Enumerating the possible outputs of Categorical 22.
+								for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
+									int distributionTempVariable$var23$30 = index$sample23$28;
 									
 									// Update the probability of sampling this value from the distribution value.
-									double cv$probabilitySample9Value9 = (1.0 * distribution$sample9[index$sample9$8]);
-									if((0 == j)) {
+									double cv$probabilitySample23Value29 = (1.0 * distribution$sample23[((i - 1) / 1)][index$sample23$28]);
+									if((i == j)) {
 										{
 											double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
 											
 											// Store the value of the function call, so the function call is only made once.
-											double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+											double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 											
 											// Add the probability of this sample task to the distribution accumulator.
 											if((cv$weightedProbability < cv$distributionAccumulator))
@@ -531,27 +614,29 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 											}
 											
 											// Add the probability of this distribution configuration to the accumulator.
-											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
+											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
 										}
 									}
 								}
 							}
 						}
-					} else {
-						if(true) {
-							// Enumerating the possible outputs of Categorical 4.
-							for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
-								int distributionTempVariable$v1$5 = index$sample5$3;
-								
-								// Update the probability of sampling this value from the distribution value.
-								double cv$probabilitySample5Value4 = (1.0 * distribution$sample5[index$sample5$3]);
-								if(fixedFlag$sample9) {
-									if((0 == j)) {
+					}
+				} else {
+					if(true) {
+						// Enumerating the possible outputs of Categorical 4.
+						for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
+							int distributionTempVariable$v1$24 = index$sample5$22;
+							
+							// Update the probability of sampling this value from the distribution value.
+							double cv$probabilitySample5Value23 = (1.0 * distribution$sample5[index$sample5$22]);
+							if(fixedFlag$sample23) {
+								for(int i = 1; i < size; i += 1) {
+									if((i == j)) {
 										{
-											double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+											double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
 											
 											// Store the value of the function call, so the function call is only made once.
-											double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+											double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 											
 											// Add the probability of this sample task to the distribution accumulator.
 											if((cv$weightedProbability < cv$distributionAccumulator))
@@ -565,23 +650,25 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 											}
 											
 											// Add the probability of this distribution configuration to the accumulator.
-											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
 										}
 									}
-								} else {
+								}
+							} else {
+								for(int i = 1; i < size; i += 1) {
 									if(true) {
-										// Enumerating the possible outputs of Categorical 8.
-										for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
-											int distributionTempVariable$var9$15 = index$sample9$13;
+										// Enumerating the possible outputs of Categorical 22.
+										for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
+											int distributionTempVariable$var23$36 = index$sample23$34;
 											
 											// Update the probability of sampling this value from the distribution value.
-											double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
-											if((0 == j)) {
+											double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[((i - 1) / 1)][index$sample23$34]);
+											if((i == j)) {
 												{
-													double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+													double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
 													
 													// Store the value of the function call, so the function call is only made once.
-													double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+													double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 													
 													// Add the probability of this sample task to the distribution accumulator.
 													if((cv$weightedProbability < cv$distributionAccumulator))
@@ -595,141 +682,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 													}
 													
 													// Add the probability of this distribution configuration to the accumulator.
-													cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample23) {
-							for(int i = 1; i < size; i += 1) {
-								if((i == j)) {
-									{
-										double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-										
-										// Store the value of the function call, so the function call is only made once.
-										double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-										
-										// Add the probability of this sample task to the distribution accumulator.
-										if((cv$weightedProbability < cv$distributionAccumulator))
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-										else {
-											// If the second value is -infinity.
-											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-												cv$distributionAccumulator = cv$weightedProbability;
-											else
-												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-										}
-										
-										// Add the probability of this distribution configuration to the accumulator.
-										cv$probabilityReached = (cv$probabilityReached + 1.0);
-									}
-								}
-							}
-						} else {
-							for(int i = 1; i < size; i += 1) {
-								if(true) {
-									// Enumerating the possible outputs of Categorical 22.
-									for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
-										int distributionTempVariable$var23$30 = index$sample23$28;
-										
-										// Update the probability of sampling this value from the distribution value.
-										double cv$probabilitySample23Value29 = (1.0 * distribution$sample23[((i - 1) / 1)][index$sample23$28]);
-										if((i == j)) {
-											{
-												double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-												
-												// Store the value of the function call, so the function call is only made once.
-												double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-												
-												// Add the probability of this sample task to the distribution accumulator.
-												if((cv$weightedProbability < cv$distributionAccumulator))
-													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-												else {
-													// If the second value is -infinity.
-													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-														cv$distributionAccumulator = cv$weightedProbability;
-													else
-														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-												}
-												
-												// Add the probability of this distribution configuration to the accumulator.
-												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
-											}
-										}
-									}
-								}
-							}
-						}
-					} else {
-						if(true) {
-							// Enumerating the possible outputs of Categorical 4.
-							for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
-								int distributionTempVariable$v1$24 = index$sample5$22;
-								
-								// Update the probability of sampling this value from the distribution value.
-								double cv$probabilitySample5Value23 = (1.0 * distribution$sample5[index$sample5$22]);
-								if(fixedFlag$sample23) {
-									for(int i = 1; i < size; i += 1) {
-										if((i == j)) {
-											{
-												double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
-												
-												// Store the value of the function call, so the function call is only made once.
-												double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-												
-												// Add the probability of this sample task to the distribution accumulator.
-												if((cv$weightedProbability < cv$distributionAccumulator))
-													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-												else {
-													// If the second value is -infinity.
-													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-														cv$distributionAccumulator = cv$weightedProbability;
-													else
-														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-												}
-												
-												// Add the probability of this distribution configuration to the accumulator.
-												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
-											}
-										}
-									}
-								} else {
-									for(int i = 1; i < size; i += 1) {
-										if(true) {
-											// Enumerating the possible outputs of Categorical 22.
-											for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
-												int distributionTempVariable$var23$36 = index$sample23$34;
-												
-												// Update the probability of sampling this value from the distribution value.
-												double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[((i - 1) / 1)][index$sample23$34]);
-												if((i == j)) {
-													{
-														double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
-														
-														// Store the value of the function call, so the function call is only made once.
-														double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-														
-														// Add the probability of this sample task to the distribution accumulator.
-														if((cv$weightedProbability < cv$distributionAccumulator))
-															cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-														else {
-															// If the second value is -infinity.
-															if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-																cv$distributionAccumulator = cv$weightedProbability;
-															else
-																cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-														}
-														
-														// Add the probability of this distribution configuration to the accumulator.
-														cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
-													}
+													cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
 												}
 											}
 										}
@@ -739,66 +692,36 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 						}
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample43[((j - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$v = (logProbability$v + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using probability
@@ -1128,217 +1051,145 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	// Calculate the probability of the samples represented by sample36 using sampled
 	// values.
 	private final void logProbabilityValue$sample36() {
-		// Determine if we need to calculate the values for sample task 36 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample36) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = v3[((j - 0) / 1)];
 				{
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = v3[((j - 0) / 1)];
 					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$c = (logProbability$c + cv$sampleAccumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Store the random variable instance probability
-			logProbability$v3 = cv$sampleAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample36 = fixedFlag$sample36;
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$v3;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$c = (logProbability$c + cv$rvAccumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		
+		// Store the random variable instance probability
+		logProbability$v3 = cv$sampleAccumulator;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample43 using sampled
 	// values.
 	private final void logProbabilityValue$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				boolean cv$sampleValue = v[j];
 				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = v[j];
 					{
-						{
-							double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample43[((j - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$v = (logProbability$v + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using sampled values.
@@ -2763,12 +2614,9 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			v = new boolean[length$value];
 		}
 		
-		// If v3 has not been set already allocate space.
-		if(!fixedFlag$sample36) {
-			// Constructor for v3
-			{
-				v3 = new int[((((length$value - 1) - 0) / 1) + 1)];
-			}
+		// Constructor for v3
+		{
+			v3 = new int[((((length$value - 1) - 0) / 1) + 1)];
 		}
 		
 		// Constructor for distribution$sample5
@@ -2824,8 +2672,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)])));
 		}
 	}
@@ -2840,9 +2687,9 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		for(int index$c = 0; index$c < weightings.length; index$c += 1) {
 			// Probability for this value
 			double cv$value = (((0.0 <= index$c) && (index$c < weightings.length))?weightings[index$c]:0.0);
-			if(!(fixedFlag$sample5 && fixedFlag$sample36))
-				// Save the probability of each value
-				cv$distribution$sample5[index$c] = cv$value;
+			
+			// Save the probability of each value
+			cv$distribution$sample5[index$c] = cv$value;
 		}
 		
 		// Create local copy of variable probabilities.
@@ -2865,10 +2712,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 					cv$distribution$sample23[index$var22] = cv$value;
 			}
 		}
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -2884,8 +2729,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)])));
 		}
 	}
@@ -2902,10 +2746,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			if(!fixedFlag$sample23)
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -2921,10 +2763,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			if(!fixedFlag$sample23)
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -2940,17 +2780,13 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				if(!fixedFlag$sample23)
 					sample23(i);
 			}
-			for(int j = 0; j < size; j += 1) {
-				if(!fixedFlag$sample36)
-					sample36(j);
-			}
+			for(int j = 0; j < size; j += 1)
+				sample36(j);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			for(int j = (size - ((((size - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1) {
-				if(!fixedFlag$sample36)
-					sample36(j);
-			}
+			for(int j = (size - ((((size - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1)
+				sample36(j);
 			for(int i = (size - ((((size - 1) - 1) % 1) + 1)); i >= ((1 - 1) + 1); i -= 1) {
 				if(!fixedFlag$sample23)
 					sample23(i);
@@ -2995,15 +2831,12 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			for(int i = 1; i < size; i += 1)
 				logProbability$sample23[((i - 1) / 1)] = Double.NaN;
 		}
-		if(!fixedProbFlag$sample36)
-			logProbability$v3 = Double.NaN;
+		logProbability$v3 = Double.NaN;
 		for(int j = 0; j < size; j += 1)
 			logProbability$var42[((j - 0) / 1)] = Double.NaN;
 		logProbability$v = 0.0;
-		if(!fixedProbFlag$sample43) {
-			for(int j = 0; j < size; j += 1)
-				logProbability$sample43[((j - 0) / 1)] = Double.NaN;
-		}
+		for(int j = 0; j < size; j += 1)
+			logProbability$sample43[((j - 0) / 1)] = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -3013,8 +2846,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample36)
-			logProbabilityValue$sample36();
 		logProbabilityValue$sample43();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$SingleThreadCPU_modelNoComments.java
@@ -12,12 +12,9 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	private double[] distribution$sample5;
 	private double[] distribution$sample9;
 	private boolean fixedFlag$sample23 = false;
-	private boolean fixedFlag$sample36 = false;
 	private boolean fixedFlag$sample5 = false;
 	private boolean fixedFlag$sample9 = false;
 	private boolean fixedProbFlag$sample23 = false;
-	private boolean fixedProbFlag$sample36 = false;
-	private boolean fixedProbFlag$sample43 = false;
 	private boolean fixedProbFlag$sample5 = false;
 	private boolean fixedProbFlag$sample9 = false;
 	private int length$value;
@@ -86,19 +83,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$fixedFlag$sample23(boolean cv$value) {
 		fixedFlag$sample23 = cv$value;
 		fixedProbFlag$sample23 = (fixedFlag$sample23 && fixedProbFlag$sample23);
-		fixedProbFlag$sample43 = (fixedFlag$sample23 && fixedProbFlag$sample43);
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample36() {
-		return fixedFlag$sample36;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample36(boolean cv$value) {
-		fixedFlag$sample36 = cv$value;
-		fixedProbFlag$sample36 = (fixedFlag$sample36 && fixedProbFlag$sample36);
-		fixedProbFlag$sample43 = (fixedFlag$sample36 && fixedProbFlag$sample43);
 	}
 
 	@Override
@@ -110,7 +94,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$fixedFlag$sample5(boolean cv$value) {
 		fixedFlag$sample5 = cv$value;
 		fixedProbFlag$sample5 = (fixedFlag$sample5 && fixedProbFlag$sample5);
-		fixedProbFlag$sample43 = (fixedFlag$sample5 && fixedProbFlag$sample43);
 	}
 
 	@Override
@@ -122,7 +105,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$fixedFlag$sample9(boolean cv$value) {
 		fixedFlag$sample9 = cv$value;
 		fixedProbFlag$sample9 = (fixedFlag$sample9 && fixedProbFlag$sample9);
-		fixedProbFlag$sample43 = (fixedFlag$sample9 && fixedProbFlag$sample43);
 	}
 
 	@Override
@@ -189,7 +171,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$v1(int cv$value) {
 		v1 = cv$value;
 		fixedProbFlag$sample5 = false;
-		fixedProbFlag$sample43 = false;
 	}
 
 	@Override
@@ -202,7 +183,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		v2 = cv$value;
 		fixedProbFlag$sample9 = false;
 		fixedProbFlag$sample23 = false;
-		fixedProbFlag$sample43 = false;
 	}
 
 	@Override
@@ -300,18 +280,105 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	}
 
 	private final void logProbabilityDistribution$sample43() {
-		if(!fixedProbFlag$sample43) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
-				{
-					boolean cv$sampleValue = v[j];
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample9) {
-							if((0 == j)) {
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				boolean cv$sampleValue = v[j];
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample9) {
+						if((0 == j)) {
+							{
+								double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+								double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					} else {
+						if(true) {
+							for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
+								int distributionTempVariable$var9$10 = index$sample9$8;
+								double cv$probabilitySample9Value9 = (1.0 * distribution$sample9[index$sample9$8]);
+								if((0 == j)) {
+									{
+										double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+										double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+										if((cv$weightedProbability < cv$distributionAccumulator))
+											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+										else {
+											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+												cv$distributionAccumulator = cv$weightedProbability;
+											else
+												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+										}
+										cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
+									}
+								}
+							}
+						}
+					}
+				} else {
+					if(true) {
+						for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
+							int distributionTempVariable$v1$5 = index$sample5$3;
+							double cv$probabilitySample5Value4 = (1.0 * distribution$sample5[index$sample5$3]);
+							if(fixedFlag$sample9) {
+								if((0 == j)) {
+									{
+										double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+										double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+										if((cv$weightedProbability < cv$distributionAccumulator))
+											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+										else {
+											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+												cv$distributionAccumulator = cv$weightedProbability;
+											else
+												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+										}
+										cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+									}
+								}
+							} else {
+								if(true) {
+									for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
+										int distributionTempVariable$var9$15 = index$sample9$13;
+										double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
+										if((0 == j)) {
+											{
+												double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+												double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+												if((cv$weightedProbability < cv$distributionAccumulator))
+													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+												else {
+													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+														cv$distributionAccumulator = cv$weightedProbability;
+													else
+														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+												}
+												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample23) {
+						for(int i = 1; i < size; i += 1) {
+							if((i == j)) {
 								{
 									double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
 									double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
@@ -326,15 +393,17 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 									cv$probabilityReached = (cv$probabilityReached + 1.0);
 								}
 							}
-						} else {
+						}
+					} else {
+						for(int i = 1; i < size; i += 1) {
 							if(true) {
-								for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
-									int distributionTempVariable$var9$10 = index$sample9$8;
-									double cv$probabilitySample9Value9 = (1.0 * distribution$sample9[index$sample9$8]);
-									if((0 == j)) {
+								for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
+									int distributionTempVariable$var23$30 = index$sample23$28;
+									double cv$probabilitySample23Value29 = (1.0 * distribution$sample23[((i - 1) / 1)][index$sample23$28]);
+									if((i == j)) {
 										{
 											double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-											double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+											double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 											if((cv$weightedProbability < cv$distributionAccumulator))
 												cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
 											else {
@@ -343,22 +412,24 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 												else
 													cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 											}
-											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
+											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
 										}
 									}
 								}
 							}
 						}
-					} else {
-						if(true) {
-							for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
-								int distributionTempVariable$v1$5 = index$sample5$3;
-								double cv$probabilitySample5Value4 = (1.0 * distribution$sample5[index$sample5$3]);
-								if(fixedFlag$sample9) {
-									if((0 == j)) {
+					}
+				} else {
+					if(true) {
+						for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
+							int distributionTempVariable$v1$24 = index$sample5$22;
+							double cv$probabilitySample5Value23 = (1.0 * distribution$sample5[index$sample5$22]);
+							if(fixedFlag$sample23) {
+								for(int i = 1; i < size; i += 1) {
+									if((i == j)) {
 										{
-											double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
-											double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+											double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
+											double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 											if((cv$weightedProbability < cv$distributionAccumulator))
 												cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
 											else {
@@ -367,18 +438,20 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 												else
 													cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 											}
-											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
 										}
 									}
-								} else {
+								}
+							} else {
+								for(int i = 1; i < size; i += 1) {
 									if(true) {
-										for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
-											int distributionTempVariable$var9$15 = index$sample9$13;
-											double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
-											if((0 == j)) {
+										for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
+											int distributionTempVariable$var23$36 = index$sample23$34;
+											double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[((i - 1) / 1)][index$sample23$34]);
+											if((i == j)) {
 												{
-													double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
-													double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+													double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
+													double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 													if((cv$weightedProbability < cv$distributionAccumulator))
 														cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
 													else {
@@ -387,102 +460,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 														else
 															cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 													}
-													cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample23) {
-							for(int i = 1; i < size; i += 1) {
-								if((i == j)) {
-									{
-										double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-										double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-										if((cv$weightedProbability < cv$distributionAccumulator))
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-										else {
-											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-												cv$distributionAccumulator = cv$weightedProbability;
-											else
-												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-										}
-										cv$probabilityReached = (cv$probabilityReached + 1.0);
-									}
-								}
-							}
-						} else {
-							for(int i = 1; i < size; i += 1) {
-								if(true) {
-									for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
-										int distributionTempVariable$var23$30 = index$sample23$28;
-										double cv$probabilitySample23Value29 = (1.0 * distribution$sample23[((i - 1) / 1)][index$sample23$28]);
-										if((i == j)) {
-											{
-												double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-												double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-												if((cv$weightedProbability < cv$distributionAccumulator))
-													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-												else {
-													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-														cv$distributionAccumulator = cv$weightedProbability;
-													else
-														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-												}
-												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
-											}
-										}
-									}
-								}
-							}
-						}
-					} else {
-						if(true) {
-							for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
-								int distributionTempVariable$v1$24 = index$sample5$22;
-								double cv$probabilitySample5Value23 = (1.0 * distribution$sample5[index$sample5$22]);
-								if(fixedFlag$sample23) {
-									for(int i = 1; i < size; i += 1) {
-										if((i == j)) {
-											{
-												double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
-												double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-												if((cv$weightedProbability < cv$distributionAccumulator))
-													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-												else {
-													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-														cv$distributionAccumulator = cv$weightedProbability;
-													else
-														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-												}
-												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
-											}
-										}
-									}
-								} else {
-									for(int i = 1; i < size; i += 1) {
-										if(true) {
-											for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
-												int distributionTempVariable$var23$36 = index$sample23$34;
-												double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[((i - 1) / 1)][index$sample23$34]);
-												if((i == j)) {
-													{
-														double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
-														double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-														if((cv$weightedProbability < cv$distributionAccumulator))
-															cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-														else {
-															if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-																cv$distributionAccumulator = cv$weightedProbability;
-															else
-																cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-														}
-														cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
-													}
+													cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
 												}
 											}
 										}
@@ -492,36 +470,21 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 						}
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
-				logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample43[((j - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$rvAccumulator;
-			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
+			logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 		}
+		logProbability$v = (logProbability$v + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityDistribution$sample5() {
@@ -691,117 +654,82 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	}
 
 	private final void logProbabilityValue$sample36() {
-		if(!fixedProbFlag$sample36) {
-			double cv$accumulator = 0.0;
-			double cv$sampleAccumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		double cv$sampleAccumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				int cv$sampleValue = v3[((j - 0) / 1)];
 				{
-					int cv$sampleValue = v3[((j - 0) / 1)];
 					{
-						{
-							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$c = (logProbability$c + cv$sampleAccumulator);
-			logProbability$v3 = cv$sampleAccumulator;
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample36 = fixedFlag$sample36;
-		} else {
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1)
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$v3;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$c = (logProbability$c + cv$rvAccumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		logProbability$v3 = cv$sampleAccumulator;
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample43() {
-		if(!fixedProbFlag$sample43) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				boolean cv$sampleValue = v[j];
 				{
-					boolean cv$sampleValue = v[j];
 					{
-						{
-							double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
-				logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample43[((j - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[((j - 0) / 1)] = cv$rvAccumulator;
-			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var42[((j - 0) / 1)] = cv$sampleAccumulator;
+			logProbability$sample43[((j - 0) / 1)] = cv$sampleProbability;
 		}
+		logProbability$v = (logProbability$v + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample5() {
@@ -1696,10 +1624,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		{
 			v = new boolean[length$value];
 		}
-		if(!fixedFlag$sample36) {
-			{
-				v3 = new int[((((length$value - 1) - 0) / 1) + 1)];
-			}
+		{
+			v3 = new int[((((length$value - 1) - 0) / 1) + 1)];
 		}
 		{
 			distribution$sample5 = new double[weightings.length];
@@ -1738,8 +1664,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)])));
 		}
 	}
@@ -1749,8 +1674,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		double[] cv$distribution$sample5 = distribution$sample5;
 		for(int index$c = 0; index$c < weightings.length; index$c += 1) {
 			double cv$value = (((0.0 <= index$c) && (index$c < weightings.length))?weightings[index$c]:0.0);
-			if(!(fixedFlag$sample5 && fixedFlag$sample36))
-				cv$distribution$sample5[index$c] = cv$value;
+			cv$distribution$sample5[index$c] = cv$value;
 		}
 		double[] cv$distribution$sample9 = distribution$sample9;
 		for(int index$var8 = 0; index$var8 < weightings.length; index$var8 += 1) {
@@ -1766,10 +1690,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 					cv$distribution$sample23[index$var22] = cv$value;
 			}
 		}
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	@Override
@@ -1783,8 +1705,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)])));
 		}
 	}
@@ -1799,10 +1720,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			if(!fixedFlag$sample23)
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	@Override
@@ -1815,10 +1734,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			if(!fixedFlag$sample23)
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	@Override
@@ -1832,15 +1749,11 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				if(!fixedFlag$sample23)
 					sample23(i);
 			}
-			for(int j = 0; j < size; j += 1) {
-				if(!fixedFlag$sample36)
-					sample36(j);
-			}
+			for(int j = 0; j < size; j += 1)
+				sample36(j);
 		} else {
-			for(int j = (size - ((((size - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1) {
-				if(!fixedFlag$sample36)
-					sample36(j);
-			}
+			for(int j = (size - ((((size - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1)
+				sample36(j);
 			for(int i = (size - ((((size - 1) - 1) % 1) + 1)); i >= ((1 - 1) + 1); i -= 1) {
 				if(!fixedFlag$sample23)
 					sample23(i);
@@ -1874,22 +1787,17 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			for(int i = 1; i < size; i += 1)
 				logProbability$sample23[((i - 1) / 1)] = Double.NaN;
 		}
-		if(!fixedProbFlag$sample36)
-			logProbability$v3 = Double.NaN;
+		logProbability$v3 = Double.NaN;
 		for(int j = 0; j < size; j += 1)
 			logProbability$var42[((j - 0) / 1)] = Double.NaN;
 		logProbability$v = 0.0;
-		if(!fixedProbFlag$sample43) {
-			for(int j = 0; j < size; j += 1)
-				logProbability$sample43[((j - 0) / 1)] = Double.NaN;
-		}
+		for(int j = 0; j < size; j += 1)
+			logProbability$sample43[((j - 0) / 1)] = Double.NaN;
 	}
 
 	@Override
 	public final void logEvidenceProbabilities() {
 		initializeLogProbabilityFields();
-		if(fixedFlag$sample36)
-			logProbabilityValue$sample36();
 		logProbabilityValue$sample43();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$SingleThreadCPU_modelSingle.java
@@ -14,12 +14,9 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	private double[] distribution$sample5;
 	private double[] distribution$sample9;
 	private boolean fixedFlag$sample23 = false;
-	private boolean fixedFlag$sample36 = false;
 	private boolean fixedFlag$sample5 = false;
 	private boolean fixedFlag$sample9 = false;
 	private boolean fixedProbFlag$sample23 = false;
-	private boolean fixedProbFlag$sample36 = false;
-	private boolean fixedProbFlag$sample43 = false;
 	private boolean fixedProbFlag$sample5 = false;
 	private boolean fixedProbFlag$sample9 = false;
 	private int length$value;
@@ -104,32 +101,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// Should the probability of sample 23 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample23 = (fixedFlag$sample23 && fixedProbFlag$sample23);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample23 && fixedProbFlag$sample43);
-	}
-
-	// Getter for fixedFlag$sample36.
-	@Override
-	public final boolean get$fixedFlag$sample36() {
-		return fixedFlag$sample36;
-	}
-
-	// Setter for fixedFlag$sample36.
-	@Override
-	public final void set$fixedFlag$sample36(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample36 including if probabilities
-		// need to be updated.
-		fixedFlag$sample36 = cv$value;
-		
-		// Should the probability of sample 36 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample36 = (fixedFlag$sample36 && fixedProbFlag$sample36);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample36 && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample5.
@@ -148,10 +119,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// Should the probability of sample 5 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample5 = (fixedFlag$sample5 && fixedProbFlag$sample5);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample5 && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample9.
@@ -170,10 +137,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// Should the probability of sample 9 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample9 = (fixedFlag$sample9 && fixedProbFlag$sample9);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample43 = (fixedFlag$sample9 && fixedProbFlag$sample43);
 	}
 
 	// Getter for length$value.
@@ -257,9 +220,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 5 as it depends on v1.
 		fixedProbFlag$sample5 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v1.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v2.
@@ -281,9 +241,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 23 as it depends on v2.
 		fixedProbFlag$sample23 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v2.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v3.
@@ -457,35 +414,159 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	// Calculate the probability of the samples represented by sample43 using probability
 	// distributions.
 	private final void logProbabilityDistribution$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			// Look for paths between the variable and the sample task 43 including any distribution
+			// values.
+			{
+				// The sample value to calculate the probability of generating
+				boolean cv$sampleValue = v[j];
 				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+				// Enumerating the possible arguments for Bernoulli 42.
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample9) {
+						if((0 == j)) {
+							{
+								double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					} else {
+						if(true) {
+							// Enumerating the possible outputs of Categorical 8.
+							for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
+								int distributionTempVariable$var9$10 = index$sample9$8;
+								
+								// Update the probability of sampling this value from the distribution value.
+								double cv$probabilitySample9Value9 = (1.0 * distribution$sample9[index$sample9$8]);
+								if((0 == j)) {
+									{
+										double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+										
+										// Store the value of the function call, so the function call is only made once.
+										double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+										
+										// Add the probability of this sample task to the distribution accumulator.
+										if((cv$weightedProbability < cv$distributionAccumulator))
+											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+										else {
+											// If the second value is -infinity.
+											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+												cv$distributionAccumulator = cv$weightedProbability;
+											else
+												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+										}
+										
+										// Add the probability of this distribution configuration to the accumulator.
+										cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
+									}
+								}
+							}
+						}
+					}
+				} else {
+					if(true) {
+						// Enumerating the possible outputs of Categorical 4.
+						for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
+							int distributionTempVariable$v1$5 = index$sample5$3;
+							
+							// Update the probability of sampling this value from the distribution value.
+							double cv$probabilitySample5Value4 = (1.0 * distribution$sample5[index$sample5$3]);
+							if(fixedFlag$sample9) {
+								if((0 == j)) {
+									{
+										double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+										
+										// Store the value of the function call, so the function call is only made once.
+										double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+										
+										// Add the probability of this sample task to the distribution accumulator.
+										if((cv$weightedProbability < cv$distributionAccumulator))
+											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+										else {
+											// If the second value is -infinity.
+											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+												cv$distributionAccumulator = cv$weightedProbability;
+											else
+												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+										}
+										
+										// Add the probability of this distribution configuration to the accumulator.
+										cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+									}
+								}
+							} else {
+								if(true) {
+									// Enumerating the possible outputs of Categorical 8.
+									for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
+										int distributionTempVariable$var9$15 = index$sample9$13;
+										
+										// Update the probability of sampling this value from the distribution value.
+										double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
+										if((0 == j)) {
+											{
+												double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+												
+												// Store the value of the function call, so the function call is only made once.
+												double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+												
+												// Add the probability of this sample task to the distribution accumulator.
+												if((cv$weightedProbability < cv$distributionAccumulator))
+													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+												else {
+													// If the second value is -infinity.
+													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+														cv$distributionAccumulator = cv$weightedProbability;
+													else
+														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+												}
+												
+												// Add the probability of this distribution configuration to the accumulator.
+												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
 				
-				// Look for paths between the variable and the sample task 43 including any distribution
-				// values.
-				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = v[j];
-					
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample9) {
-							if((0 == j)) {
+				// Enumerating the possible arguments for Bernoulli 42.
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample23) {
+						for(int i = 1; i < size; i += 1) {
+							if((i == j)) {
 								{
 									double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
 									
@@ -507,20 +588,22 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 									cv$probabilityReached = (cv$probabilityReached + 1.0);
 								}
 							}
-						} else {
+						}
+					} else {
+						for(int i = 1; i < size; i += 1) {
 							if(true) {
-								// Enumerating the possible outputs of Categorical 8.
-								for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
-									int distributionTempVariable$var9$10 = index$sample9$8;
+								// Enumerating the possible outputs of Categorical 22.
+								for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
+									int distributionTempVariable$var23$30 = index$sample23$28;
 									
 									// Update the probability of sampling this value from the distribution value.
-									double cv$probabilitySample9Value9 = (1.0 * distribution$sample9[index$sample9$8]);
-									if((0 == j)) {
+									double cv$probabilitySample23Value29 = (1.0 * distribution$sample23[((i - 1) / 1)][index$sample23$28]);
+									if((i == j)) {
 										{
 											double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
 											
 											// Store the value of the function call, so the function call is only made once.
-											double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+											double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 											
 											// Add the probability of this sample task to the distribution accumulator.
 											if((cv$weightedProbability < cv$distributionAccumulator))
@@ -534,27 +617,29 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 											}
 											
 											// Add the probability of this distribution configuration to the accumulator.
-											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
+											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
 										}
 									}
 								}
 							}
 						}
-					} else {
-						if(true) {
-							// Enumerating the possible outputs of Categorical 4.
-							for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
-								int distributionTempVariable$v1$5 = index$sample5$3;
-								
-								// Update the probability of sampling this value from the distribution value.
-								double cv$probabilitySample5Value4 = (1.0 * distribution$sample5[index$sample5$3]);
-								if(fixedFlag$sample9) {
-									if((0 == j)) {
+					}
+				} else {
+					if(true) {
+						// Enumerating the possible outputs of Categorical 4.
+						for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
+							int distributionTempVariable$v1$24 = index$sample5$22;
+							
+							// Update the probability of sampling this value from the distribution value.
+							double cv$probabilitySample5Value23 = (1.0 * distribution$sample5[index$sample5$22]);
+							if(fixedFlag$sample23) {
+								for(int i = 1; i < size; i += 1) {
+									if((i == j)) {
 										{
-											double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+											double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
 											
 											// Store the value of the function call, so the function call is only made once.
-											double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+											double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 											
 											// Add the probability of this sample task to the distribution accumulator.
 											if((cv$weightedProbability < cv$distributionAccumulator))
@@ -568,23 +653,25 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 											}
 											
 											// Add the probability of this distribution configuration to the accumulator.
-											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+											cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
 										}
 									}
-								} else {
+								}
+							} else {
+								for(int i = 1; i < size; i += 1) {
 									if(true) {
-										// Enumerating the possible outputs of Categorical 8.
-										for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
-											int distributionTempVariable$var9$15 = index$sample9$13;
+										// Enumerating the possible outputs of Categorical 22.
+										for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
+											int distributionTempVariable$var23$36 = index$sample23$34;
 											
 											// Update the probability of sampling this value from the distribution value.
-											double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
-											if((0 == j)) {
+											double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[((i - 1) / 1)][index$sample23$34]);
+											if((i == j)) {
 												{
-													double var41 = ((1.0 * distributionTempVariable$v1$5) / (v2[j] + v3[((j - 0) / 1)]));
+													double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
 													
 													// Store the value of the function call, so the function call is only made once.
-													double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+													double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 													
 													// Add the probability of this sample task to the distribution accumulator.
 													if((cv$weightedProbability < cv$distributionAccumulator))
@@ -598,141 +685,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 													}
 													
 													// Add the probability of this distribution configuration to the accumulator.
-													cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample23) {
-							for(int i = 1; i < size; i += 1) {
-								if((i == j)) {
-									{
-										double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-										
-										// Store the value of the function call, so the function call is only made once.
-										double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-										
-										// Add the probability of this sample task to the distribution accumulator.
-										if((cv$weightedProbability < cv$distributionAccumulator))
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-										else {
-											// If the second value is -infinity.
-											if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-												cv$distributionAccumulator = cv$weightedProbability;
-											else
-												cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-										}
-										
-										// Add the probability of this distribution configuration to the accumulator.
-										cv$probabilityReached = (cv$probabilityReached + 1.0);
-									}
-								}
-							}
-						} else {
-							for(int i = 1; i < size; i += 1) {
-								if(true) {
-									// Enumerating the possible outputs of Categorical 22.
-									for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
-										int distributionTempVariable$var23$30 = index$sample23$28;
-										
-										// Update the probability of sampling this value from the distribution value.
-										double cv$probabilitySample23Value29 = (1.0 * distribution$sample23[((i - 1) / 1)][index$sample23$28]);
-										if((i == j)) {
-											{
-												double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-												
-												// Store the value of the function call, so the function call is only made once.
-												double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-												
-												// Add the probability of this sample task to the distribution accumulator.
-												if((cv$weightedProbability < cv$distributionAccumulator))
-													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-												else {
-													// If the second value is -infinity.
-													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-														cv$distributionAccumulator = cv$weightedProbability;
-													else
-														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-												}
-												
-												// Add the probability of this distribution configuration to the accumulator.
-												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
-											}
-										}
-									}
-								}
-							}
-						}
-					} else {
-						if(true) {
-							// Enumerating the possible outputs of Categorical 4.
-							for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
-								int distributionTempVariable$v1$24 = index$sample5$22;
-								
-								// Update the probability of sampling this value from the distribution value.
-								double cv$probabilitySample5Value23 = (1.0 * distribution$sample5[index$sample5$22]);
-								if(fixedFlag$sample23) {
-									for(int i = 1; i < size; i += 1) {
-										if((i == j)) {
-											{
-												double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
-												
-												// Store the value of the function call, so the function call is only made once.
-												double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-												
-												// Add the probability of this sample task to the distribution accumulator.
-												if((cv$weightedProbability < cv$distributionAccumulator))
-													cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-												else {
-													// If the second value is -infinity.
-													if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-														cv$distributionAccumulator = cv$weightedProbability;
-													else
-														cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-												}
-												
-												// Add the probability of this distribution configuration to the accumulator.
-												cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
-											}
-										}
-									}
-								} else {
-									for(int i = 1; i < size; i += 1) {
-										if(true) {
-											// Enumerating the possible outputs of Categorical 22.
-											for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
-												int distributionTempVariable$var23$36 = index$sample23$34;
-												
-												// Update the probability of sampling this value from the distribution value.
-												double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[((i - 1) / 1)][index$sample23$34]);
-												if((i == j)) {
-													{
-														double var41 = ((1.0 * distributionTempVariable$v1$24) / (v2[j] + v3[((j - 0) / 1)]));
-														
-														// Store the value of the function call, so the function call is only made once.
-														double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-														
-														// Add the probability of this sample task to the distribution accumulator.
-														if((cv$weightedProbability < cv$distributionAccumulator))
-															cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-														else {
-															// If the second value is -infinity.
-															if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-																cv$distributionAccumulator = cv$weightedProbability;
-															else
-																cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-														}
-														
-														// Add the probability of this distribution configuration to the accumulator.
-														cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
-													}
+													cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
 												}
 											}
 										}
@@ -742,69 +695,40 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 						}
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var42 = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$var43 = cv$accumulator;
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var43;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var42 = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var42 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$var43 = cv$accumulator;
+		
+		// Update the variable probability
+		logProbability$v = (logProbability$v + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using probability
@@ -1137,223 +1061,152 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	// Calculate the probability of the samples represented by sample36 using sampled
 	// values.
 	private final void logProbabilityValue$sample36() {
-		// Determine if we need to calculate the values for sample task 36 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample36) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = v3[((j - 0) / 1)];
 				{
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = v3[((j - 0) / 1)];
 					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$c = (logProbability$c + cv$sampleAccumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$v3 = cv$sampleAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample36 = fixedFlag$sample36;
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$v3;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$c = (logProbability$c + cv$rvAccumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$v3 = cv$sampleAccumulator;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample43 using sampled
 	// values.
 	private final void logProbabilityValue$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				boolean cv$sampleValue = v[j];
 				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = v[j];
 					{
-						{
-							double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var41 = ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)]));
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var42 = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$var43 = cv$accumulator;
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var43;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var42 = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var42 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$var43 = cv$accumulator;
+		
+		// Update the variable probability
+		logProbability$v = (logProbability$v + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using sampled values.
@@ -2778,12 +2631,9 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			v = new boolean[length$value];
 		}
 		
-		// If v3 has not been set already allocate space.
-		if(!fixedFlag$sample36) {
-			// Constructor for v3
-			{
-				v3 = new int[((((length$value - 1) - 0) / 1) + 1)];
-			}
+		// Constructor for v3
+		{
+			v3 = new int[((((length$value - 1) - 0) / 1) + 1)];
 		}
 		
 		// Constructor for distribution$sample5
@@ -2819,8 +2669,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)])));
 		}
 	}
@@ -2835,9 +2684,9 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		for(int index$c = 0; index$c < weightings.length; index$c += 1) {
 			// Probability for this value
 			double cv$value = (((0.0 <= index$c) && (index$c < weightings.length))?weightings[index$c]:0.0);
-			if(!(fixedFlag$sample5 && fixedFlag$sample36))
-				// Save the probability of each value
-				cv$distribution$sample5[index$c] = cv$value;
+			
+			// Save the probability of each value
+			cv$distribution$sample5[index$c] = cv$value;
 		}
 		
 		// Create local copy of variable probabilities.
@@ -2860,10 +2709,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 					cv$distribution$sample23[index$var22] = cv$value;
 			}
 		}
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -2879,8 +2726,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((1.0 * v1) / (v2[j] + v3[((j - 0) / 1)])));
 		}
 	}
@@ -2897,10 +2743,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			if(!fixedFlag$sample23)
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -2916,10 +2760,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			if(!fixedFlag$sample23)
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
-		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -2935,17 +2777,13 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				if(!fixedFlag$sample23)
 					sample23(i);
 			}
-			for(int j = 0; j < size; j += 1) {
-				if(!fixedFlag$sample36)
-					sample36(j);
-			}
+			for(int j = 0; j < size; j += 1)
+				sample36(j);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			for(int j = (size - ((((size - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1) {
-				if(!fixedFlag$sample36)
-					sample36(j);
-			}
+			for(int j = (size - ((((size - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1)
+				sample36(j);
 			for(int i = (size - ((((size - 1) - 1) % 1) + 1)); i >= ((1 - 1) + 1); i -= 1) {
 				if(!fixedFlag$sample23)
 					sample23(i);
@@ -2987,12 +2825,10 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		logProbability$var22 = Double.NaN;
 		if(!fixedProbFlag$sample23)
 			logProbability$var23 = Double.NaN;
-		if(!fixedProbFlag$sample36)
-			logProbability$v3 = Double.NaN;
+		logProbability$v3 = Double.NaN;
 		logProbability$var42 = Double.NaN;
 		logProbability$v = 0.0;
-		if(!fixedProbFlag$sample43)
-			logProbability$var43 = Double.NaN;
+		logProbability$var43 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -3002,8 +2838,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample36)
-			logProbabilityValue$sample36();
 		logProbabilityValue$sample43();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$SingleThreadCPU_optimisedModel.java
@@ -14,12 +14,9 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	private double[] distribution$sample5;
 	private double[] distribution$sample9;
 	private boolean fixedFlag$sample23 = false;
-	private boolean fixedFlag$sample36 = false;
 	private boolean fixedFlag$sample5 = false;
 	private boolean fixedFlag$sample9 = false;
 	private boolean fixedProbFlag$sample23 = false;
-	private boolean fixedProbFlag$sample36 = false;
-	private boolean fixedProbFlag$sample43 = false;
 	private boolean fixedProbFlag$sample5 = false;
 	private boolean fixedProbFlag$sample9 = false;
 	private int length$value;
@@ -106,38 +103,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// 
 		// Substituted "fixedFlag$sample23" with its value "cv$value".
 		fixedProbFlag$sample23 = (cv$value && fixedProbFlag$sample23);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample23" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
-	}
-
-	// Getter for fixedFlag$sample36.
-	@Override
-	public final boolean get$fixedFlag$sample36() {
-		return fixedFlag$sample36;
-	}
-
-	// Setter for fixedFlag$sample36.
-	@Override
-	public final void set$fixedFlag$sample36(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample36 including if probabilities
-		// need to be updated.
-		fixedFlag$sample36 = cv$value;
-		
-		// Should the probability of sample 36 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample36" with its value "cv$value".
-		fixedProbFlag$sample36 = (cv$value && fixedProbFlag$sample36);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample36" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample5.
@@ -158,12 +123,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// 
 		// Substituted "fixedFlag$sample5" with its value "cv$value".
 		fixedProbFlag$sample5 = (cv$value && fixedProbFlag$sample5);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample5" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample9.
@@ -184,12 +143,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// 
 		// Substituted "fixedFlag$sample9" with its value "cv$value".
 		fixedProbFlag$sample9 = (cv$value && fixedProbFlag$sample9);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample9" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	// Getter for length$value.
@@ -273,9 +226,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 5 as it depends on v1.
 		fixedProbFlag$sample5 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v1.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v2.
@@ -297,9 +247,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 23 as it depends on v2.
 		fixedProbFlag$sample23 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v2.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v3.
@@ -439,132 +386,48 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	// Calculate the probability of the samples represented by sample43 using probability
 	// distributions.
 	private final void logProbabilityDistribution$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
-				
-				// Look for paths between the variable and the sample task 43 including any distribution
-				// values.
-				// 
-				// The sample value to calculate the probability of generating
-				boolean cv$sampleValue = v[j];
-				
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		for(int j = 0; j < size; j += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			
+			// Look for paths between the variable and the sample task 43 including any distribution
+			// values.
+			// 
+			// The sample value to calculate the probability of generating
+			boolean cv$sampleValue = v[j];
+			
+			// Enumerating the possible arguments for Bernoulli 42.
+			if((0 == j)) {
 				// Enumerating the possible arguments for Bernoulli 42.
-				if((0 == j)) {
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample9) {
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample9) {
+						// Substituted "j" with its value "0".
+						double var41 = ((double)v1 / (v2[0] + v3[0]));
+						
+						// Store the value of the function call, so the function call is only made once.
+						cv$distributionAccumulator = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						// 
+						// An accumulator for the distributed probability space covered.
+						cv$probabilityReached = 1.0;
+					} else {
+						// Enumerating the possible outputs of Categorical 8.
+						for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
+							// Update the probability of sampling this value from the distribution value.
+							double cv$probabilitySample9Value9 = distribution$sample9[index$sample9$8];
+							
 							// Substituted "j" with its value "0".
 							double var41 = ((double)v1 / (v2[0] + v3[0]));
 							
 							// Store the value of the function call, so the function call is only made once.
-							cv$distributionAccumulator = Math.log((cv$sampleValue?var41:(1.0 - var41)));
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							// 
-							// An accumulator for the distributed probability space covered.
-							cv$probabilityReached = 1.0;
-						} else {
-							// Enumerating the possible outputs of Categorical 8.
-							for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
-								// Update the probability of sampling this value from the distribution value.
-								double cv$probabilitySample9Value9 = distribution$sample9[index$sample9$8];
-								
-								// Substituted "j" with its value "0".
-								double var41 = ((double)v1 / (v2[0] + v3[0]));
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
-							}
-						}
-					} else {
-						// Enumerating the possible outputs of Categorical 4.
-						for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
-							// Update the probability of sampling this value from the distribution value.
-							double cv$probabilitySample5Value4 = distribution$sample5[index$sample5$3];
-							if(fixedFlag$sample9) {
-								// Substituted "j" with its value "0".
-								double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
-							} else {
-								// Enumerating the possible outputs of Categorical 8.
-								for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
-									// Update the probability of sampling this value from the distribution value.
-									double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
-									
-									// Substituted "j" with its value "0".
-									double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
-									
-									// Store the value of the function call, so the function call is only made once.
-									double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-									
-									// Add the probability of this sample task to the distribution accumulator.
-									if((cv$weightedProbability < cv$distributionAccumulator))
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-									else {
-										// If the second value is -infinity.
-										if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-											cv$distributionAccumulator = cv$weightedProbability;
-										else
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-									}
-									
-									// Add the probability of this distribution configuration to the accumulator.
-									cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
-								}
-							}
-						}
-					}
-				}
-				
-				// Enumerating the possible arguments for Bernoulli 42.
-				if((1 <= j)) {
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample23) {
-							double var41 = ((double)v1 / (v2[j] + v3[j]));
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+							double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 							
 							// Add the probability of this sample task to the distribution accumulator.
 							if((cv$weightedProbability < cv$distributionAccumulator))
@@ -578,44 +441,45 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 							}
 							
 							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
-						} else {
-							// Enumerating the possible outputs of Categorical 22.
-							for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
-								// Update the probability of sampling this value from the distribution value.
-								// 
-								// Substituted "i" with its value "j".
-								double cv$probabilitySample23Value29 = distribution$sample23[(j - 1)][index$sample23$28];
-								double var41 = ((double)v1 / (v2[j] + v3[j]));
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
-							}
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
 						}
-					} else {
-						// Enumerating the possible outputs of Categorical 4.
-						for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
-							// Update the probability of sampling this value from the distribution value.
-							double cv$probabilitySample5Value23 = distribution$sample5[index$sample5$22];
-							if(fixedFlag$sample23) {
-								double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+					}
+				} else {
+					// Enumerating the possible outputs of Categorical 4.
+					for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
+						// Update the probability of sampling this value from the distribution value.
+						double cv$probabilitySample5Value4 = distribution$sample5[index$sample5$3];
+						if(fixedFlag$sample9) {
+							// Substituted "j" with its value "0".
+							double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+						} else {
+							// Enumerating the possible outputs of Categorical 8.
+							for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
+								// Update the probability of sampling this value from the distribution value.
+								double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
+								
+								// Substituted "j" with its value "0".
+								double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
 								
 								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 								
 								// Add the probability of this sample task to the distribution accumulator.
 								if((cv$weightedProbability < cv$distributionAccumulator))
@@ -629,91 +493,147 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 								}
 								
 								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
-							} else {
-								// Enumerating the possible outputs of Categorical 22.
-								for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
-									// Update the probability of sampling this value from the distribution value.
-									// 
-									// Substituted "i" with its value "j".
-									double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[(j - 1)][index$sample23$34]);
-									double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
-									
-									// Store the value of the function call, so the function call is only made once.
-									double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-									
-									// Add the probability of this sample task to the distribution accumulator.
-									if((cv$weightedProbability < cv$distributionAccumulator))
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-									else {
-										// If the second value is -infinity.
-										if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-											cv$distributionAccumulator = cv$weightedProbability;
-										else
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-									}
-									
-									// Add the probability of this distribution configuration to the accumulator.
-									cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
-								}
+								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
 							}
 						}
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var42[j] = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample43[j] = cv$distributionAccumulator;
 			}
 			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				// Variable declaration of cv$rvAccumulator moved.
-				double cv$rvAccumulator = logProbability$sample43[j];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[j] = cv$rvAccumulator;
+			// Enumerating the possible arguments for Bernoulli 42.
+			if((1 <= j)) {
+				// Enumerating the possible arguments for Bernoulli 42.
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample23) {
+						double var41 = ((double)v1 / (v2[j] + v3[j]));
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
+					} else {
+						// Enumerating the possible outputs of Categorical 22.
+						for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
+							// Update the probability of sampling this value from the distribution value.
+							// 
+							// Substituted "i" with its value "j".
+							double cv$probabilitySample23Value29 = distribution$sample23[(j - 1)][index$sample23$28];
+							double var41 = ((double)v1 / (v2[j] + v3[j]));
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
+						}
+					}
+				} else {
+					// Enumerating the possible outputs of Categorical 4.
+					for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
+						// Update the probability of sampling this value from the distribution value.
+						double cv$probabilitySample5Value23 = distribution$sample5[index$sample5$22];
+						if(fixedFlag$sample23) {
+							double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
+						} else {
+							// Enumerating the possible outputs of Categorical 22.
+							for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
+								// Update the probability of sampling this value from the distribution value.
+								// 
+								// Substituted "i" with its value "j".
+								double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[(j - 1)][index$sample23$34]);
+								double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
+							}
+						}
+					}
+				}
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
 			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var42[j] = cv$distributionAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample43[j] = cv$distributionAccumulator;
 		}
+		
+		// Update the variable probability
+		logProbability$v = (logProbability$v + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using probability
@@ -1030,160 +950,99 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	// Calculate the probability of the samples represented by sample36 using sampled
 	// values.
 	private final void logProbabilityValue$sample36() {
-		// Determine if we need to calculate the values for sample task 36 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample36) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				// The sample value to calculate the probability of generating
-				int cv$sampleValue = v3[j];
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-			}
-			logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		for(int j = 0; j < size; j += 1) {
+			// The sample value to calculate the probability of generating
+			int cv$sampleValue = v3[j];
 			
-			// Store the random variable instance probability
-			logProbability$v3 = cv$sampleAccumulator;
-			
-			// Add probability to model
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Scale the probability relative to the observed distribution space.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample36 = fixedFlag$sample36;
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			logProbability$c = (logProbability$c + logProbability$v3);
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$v3);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$v3);
-		}
+		logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		
+		// Store the random variable instance probability
+		logProbability$v3 = cv$sampleAccumulator;
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample43 using sampled
 	// values.
 	private final void logProbabilityValue$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				double var41 = ((double)v1 / (v2[j] + v3[j]));
-				
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = Math.log((v[j]?var41:(1.0 - var41)));
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var42[j] = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample43[j] = cv$distributionAccumulator;
-			}
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		for(int j = 0; j < size; j += 1) {
+			double var41 = ((double)v1 / (v2[j] + v3[j]));
 			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = Math.log((v[j]?var41:(1.0 - var41)));
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var42[j] = cv$distributionAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample43[j] = cv$distributionAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				// Variable declaration of cv$rvAccumulator moved.
-				double cv$rvAccumulator = logProbability$sample43[j];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[j] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$v = (logProbability$v + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$v = (logProbability$v + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using sampled values.
@@ -2428,10 +2287,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// Constructor for v
 		v = new boolean[length$value];
 		
-		// If v3 has not been set already allocate space.
-		if(!fixedFlag$sample36)
-			// Constructor for v3
-			v3 = new int[length$value];
+		// Constructor for v3
+		v3 = new int[length$value];
 		
 		// Constructor for distribution$sample5
 		distribution$sample5 = new double[weightings.length];
@@ -2474,8 +2331,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((double)v1 / (v2[j] + v3[j])));
 		}
 	}
@@ -2485,15 +2341,12 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if((!fixedFlag$sample5 || !fixedFlag$sample36)) {
-			for(int index$c = 0; index$c < weightings.length; index$c += 1)
-				// Save the probability of each value
-				// 
-				// cv$distribution$sample5's comment
-				// Create local copy of variable probabilities.
-				distribution$sample5[index$c] = weightings[index$c];
-		}
+		for(int index$c = 0; index$c < weightings.length; index$c += 1)
+			// Save the probability of each value
+			// 
+			// cv$distribution$sample5's comment
+			// Create local copy of variable probabilities.
+			distribution$sample5[index$c] = weightings[index$c];
 		
 		// Constraints moved from conditionals in inner loops/scopes/etc.
 		if(!fixedFlag$sample9) {
@@ -2517,12 +2370,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 					cv$distribution$sample23[index$var22] = weightings[index$var22];
 			}
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -2540,8 +2389,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((double)v1 / (v2[j] + v3[j])));
 		}
 	}
@@ -2560,12 +2408,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			for(int i = 1; i < size; i += 1)
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -2583,12 +2427,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			for(int i = 1; i < size; i += 1)
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -2606,20 +2446,13 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				for(int i = 1; i < size; i += 1)
 					sample23(i);
 			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample36) {
-				for(int j = 0; j < size; j += 1)
-					sample36(j);
-			}
+			for(int j = 0; j < size; j += 1)
+				sample36(j);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample36) {
-				for(int j = (size - 1); j >= 0; j -= 1)
-					sample36(j);
-			}
+			for(int j = (size - 1); j >= 0; j -= 1)
+				sample36(j);
 			
 			// Constraints moved from conditionals in inner loops/scopes/etc.
 			if(!fixedFlag$sample23) {
@@ -2666,15 +2499,12 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			for(int i = 1; i < size; i += 1)
 				logProbability$sample23[(i - 1)] = Double.NaN;
 		}
-		if(!fixedProbFlag$sample36)
-			logProbability$v3 = Double.NaN;
+		logProbability$v3 = Double.NaN;
 		for(int j = 0; j < size; j += 1)
 			logProbability$var42[j] = Double.NaN;
 		logProbability$v = 0.0;
-		if(!fixedProbFlag$sample43) {
-			for(int j = 0; j < size; j += 1)
-				logProbability$sample43[j] = Double.NaN;
-		}
+		for(int j = 0; j < size; j += 1)
+			logProbability$sample43[j] = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -2684,8 +2514,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample36)
-			logProbabilityValue$sample36();
 		logProbabilityValue$sample43();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$SingleThreadCPU_optimisedModelNoComments.java
@@ -12,12 +12,9 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	private double[] distribution$sample5;
 	private double[] distribution$sample9;
 	private boolean fixedFlag$sample23 = false;
-	private boolean fixedFlag$sample36 = false;
 	private boolean fixedFlag$sample5 = false;
 	private boolean fixedFlag$sample9 = false;
 	private boolean fixedProbFlag$sample23 = false;
-	private boolean fixedProbFlag$sample36 = false;
-	private boolean fixedProbFlag$sample43 = false;
 	private boolean fixedProbFlag$sample5 = false;
 	private boolean fixedProbFlag$sample9 = false;
 	private int length$value;
@@ -86,19 +83,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$fixedFlag$sample23(boolean cv$value) {
 		fixedFlag$sample23 = cv$value;
 		fixedProbFlag$sample23 = (cv$value && fixedProbFlag$sample23);
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample36() {
-		return fixedFlag$sample36;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample36(boolean cv$value) {
-		fixedFlag$sample36 = cv$value;
-		fixedProbFlag$sample36 = (cv$value && fixedProbFlag$sample36);
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	@Override
@@ -110,7 +94,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$fixedFlag$sample5(boolean cv$value) {
 		fixedFlag$sample5 = cv$value;
 		fixedProbFlag$sample5 = (cv$value && fixedProbFlag$sample5);
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	@Override
@@ -122,7 +105,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$fixedFlag$sample9(boolean cv$value) {
 		fixedFlag$sample9 = cv$value;
 		fixedProbFlag$sample9 = (cv$value && fixedProbFlag$sample9);
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	@Override
@@ -189,7 +171,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$v1(int cv$value) {
 		v1 = cv$value;
 		fixedProbFlag$sample5 = false;
-		fixedProbFlag$sample43 = false;
 	}
 
 	@Override
@@ -202,7 +183,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		v2 = cv$value;
 		fixedProbFlag$sample9 = false;
 		fixedProbFlag$sample23 = false;
-		fixedProbFlag$sample43 = false;
 	}
 
 	@Override
@@ -267,73 +247,22 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	}
 
 	private final void logProbabilityDistribution$sample43() {
-		if(!fixedProbFlag$sample43) {
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
-				boolean cv$sampleValue = v[j];
-				if((0 == j)) {
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample9) {
-							double var41 = ((double)v1 / (v2[0] + v3[0]));
-							cv$distributionAccumulator = Math.log((cv$sampleValue?var41:(1.0 - var41)));
-							cv$probabilityReached = 1.0;
-						} else {
-							for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
-								double cv$probabilitySample9Value9 = distribution$sample9[index$sample9$8];
-								double var41 = ((double)v1 / (v2[0] + v3[0]));
-								double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
-							}
-						}
+		double cv$accumulator = 0.0;
+		for(int j = 0; j < size; j += 1) {
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			boolean cv$sampleValue = v[j];
+			if((0 == j)) {
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample9) {
+						double var41 = ((double)v1 / (v2[0] + v3[0]));
+						cv$distributionAccumulator = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						cv$probabilityReached = 1.0;
 					} else {
-						for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
-							double cv$probabilitySample5Value4 = distribution$sample5[index$sample5$3];
-							if(fixedFlag$sample9) {
-								double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
-								double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
-							} else {
-								for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
-									double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
-									double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
-									double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-									if((cv$weightedProbability < cv$distributionAccumulator))
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-									else {
-										if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-											cv$distributionAccumulator = cv$weightedProbability;
-										else
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-									}
-									cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
-								}
-							}
-						}
-					}
-				}
-				if((1 <= j)) {
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample23) {
-							double var41 = ((double)v1 / (v2[j] + v3[j]));
-							double cv$weightedProbability = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
+							double cv$probabilitySample9Value9 = distribution$sample9[index$sample9$8];
+							double var41 = ((double)v1 / (v2[0] + v3[0]));
+							double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 							if((cv$weightedProbability < cv$distributionAccumulator))
 								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
 							else {
@@ -342,29 +271,29 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 								else
 									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
-						} else {
-							for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
-								double cv$probabilitySample23Value29 = distribution$sample23[(j - 1)][index$sample23$28];
-								double var41 = ((double)v1 / (v2[j] + v3[j]));
-								double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
-							}
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
 						}
-					} else {
-						for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
-							double cv$probabilitySample5Value23 = distribution$sample5[index$sample5$22];
-							if(fixedFlag$sample23) {
-								double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
-								double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+					}
+				} else {
+					for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
+						double cv$probabilitySample5Value4 = distribution$sample5[index$sample5$3];
+						if(fixedFlag$sample9) {
+							double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
+							double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+						} else {
+							for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
+								double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
+								double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
+								double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 								if((cv$weightedProbability < cv$distributionAccumulator))
 									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
 								else {
@@ -373,49 +302,87 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 									else
 										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 								}
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
-							} else {
-								for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
-									double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[(j - 1)][index$sample23$34]);
-									double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
-									double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-									if((cv$weightedProbability < cv$distributionAccumulator))
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-									else {
-										if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-											cv$distributionAccumulator = cv$weightedProbability;
-										else
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-									}
-									cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
-								}
+								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
 							}
 						}
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				logProbability$var42[j] = cv$distributionAccumulator;
-				logProbability$sample43[j] = cv$distributionAccumulator;
 			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
-		} else {
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				double cv$rvAccumulator = logProbability$sample43[j];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[j] = cv$rvAccumulator;
+			if((1 <= j)) {
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample23) {
+						double var41 = ((double)v1 / (v2[j] + v3[j]));
+						double cv$weightedProbability = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
+					} else {
+						for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
+							double cv$probabilitySample23Value29 = distribution$sample23[(j - 1)][index$sample23$28];
+							double var41 = ((double)v1 / (v2[j] + v3[j]));
+							double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
+						}
+					}
+				} else {
+					for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
+						double cv$probabilitySample5Value23 = distribution$sample5[index$sample5$22];
+						if(fixedFlag$sample23) {
+							double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+							double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
+						} else {
+							for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
+								double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[(j - 1)][index$sample23$34]);
+								double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+								double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
+							}
+						}
+					}
+				}
 			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+			logProbability$var42[j] = cv$distributionAccumulator;
+			logProbability$sample43[j] = cv$distributionAccumulator;
 		}
+		logProbability$v = (logProbability$v + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityDistribution$sample5() {
@@ -488,51 +455,28 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	}
 
 	private final void logProbabilityValue$sample36() {
-		if(!fixedProbFlag$sample36) {
-			double cv$sampleAccumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				int cv$sampleValue = v3[j];
-				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-			}
-			logProbability$c = (logProbability$c + cv$sampleAccumulator);
-			logProbability$v3 = cv$sampleAccumulator;
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			fixedProbFlag$sample36 = fixedFlag$sample36;
-		} else {
-			logProbability$c = (logProbability$c + logProbability$v3);
-			logProbability$$model = (logProbability$$model + logProbability$v3);
-			if(fixedFlag$sample36)
-				logProbability$$evidence = (logProbability$$evidence + logProbability$v3);
+		double cv$sampleAccumulator = 0.0;
+		for(int j = 0; j < size; j += 1) {
+			int cv$sampleValue = v3[j];
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
 		}
+		logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		logProbability$v3 = cv$sampleAccumulator;
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
 	}
 
 	private final void logProbabilityValue$sample43() {
-		if(!fixedProbFlag$sample43) {
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				double var41 = ((double)v1 / (v2[j] + v3[j]));
-				double cv$distributionAccumulator = Math.log((v[j]?var41:(1.0 - var41)));
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				logProbability$var42[j] = cv$distributionAccumulator;
-				logProbability$sample43[j] = cv$distributionAccumulator;
-			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
-		} else {
-			double cv$accumulator = 0.0;
-			for(int j = 0; j < size; j += 1) {
-				double cv$rvAccumulator = logProbability$sample43[j];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var42[j] = cv$rvAccumulator;
-			}
-			logProbability$v = (logProbability$v + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		for(int j = 0; j < size; j += 1) {
+			double var41 = ((double)v1 / (v2[j] + v3[j]));
+			double cv$distributionAccumulator = Math.log((v[j]?var41:(1.0 - var41)));
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+			logProbability$var42[j] = cv$distributionAccumulator;
+			logProbability$sample43[j] = cv$distributionAccumulator;
 		}
+		logProbability$v = (logProbability$v + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample5() {
@@ -964,8 +908,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		if((!fixedFlag$sample9 || !fixedFlag$sample23))
 			v2 = new int[length$value];
 		v = new boolean[length$value];
-		if(!fixedFlag$sample36)
-			v3 = new int[length$value];
+		v3 = new int[length$value];
 		distribution$sample5 = new double[weightings.length];
 		distribution$sample23 = new double[(length$value - 1)][];
 		for(int i = 1; i < length$value; i += 1)
@@ -989,18 +932,15 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((double)v1 / (v2[j] + v3[j])));
 		}
 	}
 
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if((!fixedFlag$sample5 || !fixedFlag$sample36)) {
-			for(int index$c = 0; index$c < weightings.length; index$c += 1)
-				distribution$sample5[index$c] = weightings[index$c];
-		}
+		for(int index$c = 0; index$c < weightings.length; index$c += 1)
+			distribution$sample5[index$c] = weightings[index$c];
 		if(!fixedFlag$sample9) {
 			for(int index$var8 = 0; index$var8 < weightings.length; index$var8 += 1)
 				distribution$sample9[index$var8] = weightings[index$var8];
@@ -1012,10 +952,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 					cv$distribution$sample23[index$var22] = weightings[index$var22];
 			}
 		}
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	@Override
@@ -1029,8 +967,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((double)v1 / (v2[j] + v3[j])));
 		}
 	}
@@ -1045,10 +982,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			for(int i = 1; i < size; i += 1)
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	@Override
@@ -1061,10 +996,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			for(int i = 1; i < size; i += 1)
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	@Override
@@ -1078,15 +1011,11 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				for(int i = 1; i < size; i += 1)
 					sample23(i);
 			}
-			if(!fixedFlag$sample36) {
-				for(int j = 0; j < size; j += 1)
-					sample36(j);
-			}
+			for(int j = 0; j < size; j += 1)
+				sample36(j);
 		} else {
-			if(!fixedFlag$sample36) {
-				for(int j = (size - 1); j >= 0; j -= 1)
-					sample36(j);
-			}
+			for(int j = (size - 1); j >= 0; j -= 1)
+				sample36(j);
 			if(!fixedFlag$sample23) {
 				for(int i = (size - 1); i >= 1; i -= 1)
 					sample23(i);
@@ -1120,22 +1049,17 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			for(int i = 1; i < size; i += 1)
 				logProbability$sample23[(i - 1)] = Double.NaN;
 		}
-		if(!fixedProbFlag$sample36)
-			logProbability$v3 = Double.NaN;
+		logProbability$v3 = Double.NaN;
 		for(int j = 0; j < size; j += 1)
 			logProbability$var42[j] = Double.NaN;
 		logProbability$v = 0.0;
-		if(!fixedProbFlag$sample43) {
-			for(int j = 0; j < size; j += 1)
-				logProbability$sample43[j] = Double.NaN;
-		}
+		for(int j = 0; j < size; j += 1)
+			logProbability$sample43[j] = Double.NaN;
 	}
 
 	@Override
 	public final void logEvidenceProbabilities() {
 		initializeLogProbabilityFields();
-		if(fixedFlag$sample36)
-			logProbabilityValue$sample36();
 		logProbabilityValue$sample43();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b$SingleThreadCPU_optimisedModelSingle.java
@@ -14,12 +14,9 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	private double[] distribution$sample5;
 	private double[] distribution$sample9;
 	private boolean fixedFlag$sample23 = false;
-	private boolean fixedFlag$sample36 = false;
 	private boolean fixedFlag$sample5 = false;
 	private boolean fixedFlag$sample9 = false;
 	private boolean fixedProbFlag$sample23 = false;
-	private boolean fixedProbFlag$sample36 = false;
-	private boolean fixedProbFlag$sample43 = false;
 	private boolean fixedProbFlag$sample5 = false;
 	private boolean fixedProbFlag$sample9 = false;
 	private int length$value;
@@ -106,38 +103,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// 
 		// Substituted "fixedFlag$sample23" with its value "cv$value".
 		fixedProbFlag$sample23 = (cv$value && fixedProbFlag$sample23);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample23" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
-	}
-
-	// Getter for fixedFlag$sample36.
-	@Override
-	public final boolean get$fixedFlag$sample36() {
-		return fixedFlag$sample36;
-	}
-
-	// Setter for fixedFlag$sample36.
-	@Override
-	public final void set$fixedFlag$sample36(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample36 including if probabilities
-		// need to be updated.
-		fixedFlag$sample36 = cv$value;
-		
-		// Should the probability of sample 36 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample36" with its value "cv$value".
-		fixedProbFlag$sample36 = (cv$value && fixedProbFlag$sample36);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample36" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample5.
@@ -158,12 +123,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// 
 		// Substituted "fixedFlag$sample5" with its value "cv$value".
 		fixedProbFlag$sample5 = (cv$value && fixedProbFlag$sample5);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample5" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	// Getter for fixedFlag$sample9.
@@ -184,12 +143,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// 
 		// Substituted "fixedFlag$sample9" with its value "cv$value".
 		fixedProbFlag$sample9 = (cv$value && fixedProbFlag$sample9);
-		
-		// Should the probability of sample 43 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample9" with its value "cv$value".
-		fixedProbFlag$sample43 = (cv$value && fixedProbFlag$sample43);
 	}
 
 	// Getter for length$value.
@@ -273,9 +226,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 5 as it depends on v1.
 		fixedProbFlag$sample5 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v1.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v2.
@@ -297,9 +247,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 23 as it depends on v2.
 		fixedProbFlag$sample23 = false;
-		
-		// Unset the fixed probability flag for sample 43 as it depends on v2.
-		fixedProbFlag$sample43 = false;
 	}
 
 	// Getter for v3.
@@ -456,135 +403,51 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	// Calculate the probability of the samples represented by sample43 using probability
 	// distributions.
 	private final void logProbabilityDistribution$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
-				
-				// Look for paths between the variable and the sample task 43 including any distribution
-				// values.
-				// 
-				// The sample value to calculate the probability of generating
-				boolean cv$sampleValue = v[j];
-				
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			
+			// Look for paths between the variable and the sample task 43 including any distribution
+			// values.
+			// 
+			// The sample value to calculate the probability of generating
+			boolean cv$sampleValue = v[j];
+			
+			// Enumerating the possible arguments for Bernoulli 42.
+			if((0 == j)) {
 				// Enumerating the possible arguments for Bernoulli 42.
-				if((0 == j)) {
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample9) {
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample9) {
+						// Substituted "j" with its value "0".
+						double var41 = ((double)v1 / (v2[0] + v3[0]));
+						
+						// Store the value of the function call, so the function call is only made once.
+						cv$distributionAccumulator = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						// 
+						// An accumulator for the distributed probability space covered.
+						cv$probabilityReached = 1.0;
+					} else {
+						// Enumerating the possible outputs of Categorical 8.
+						for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
+							// Update the probability of sampling this value from the distribution value.
+							double cv$probabilitySample9Value9 = distribution$sample9[index$sample9$8];
+							
 							// Substituted "j" with its value "0".
 							double var41 = ((double)v1 / (v2[0] + v3[0]));
 							
 							// Store the value of the function call, so the function call is only made once.
-							cv$distributionAccumulator = Math.log((cv$sampleValue?var41:(1.0 - var41)));
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							// 
-							// An accumulator for the distributed probability space covered.
-							cv$probabilityReached = 1.0;
-						} else {
-							// Enumerating the possible outputs of Categorical 8.
-							for(int index$sample9$8 = 0; index$sample9$8 < weightings.length; index$sample9$8 += 1) {
-								// Update the probability of sampling this value from the distribution value.
-								double cv$probabilitySample9Value9 = distribution$sample9[index$sample9$8];
-								
-								// Substituted "j" with its value "0".
-								double var41 = ((double)v1 / (v2[0] + v3[0]));
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
-							}
-						}
-					} else {
-						// Enumerating the possible outputs of Categorical 4.
-						for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
-							// Update the probability of sampling this value from the distribution value.
-							double cv$probabilitySample5Value4 = distribution$sample5[index$sample5$3];
-							if(fixedFlag$sample9) {
-								// Substituted "j" with its value "0".
-								double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
-							} else {
-								// Enumerating the possible outputs of Categorical 8.
-								for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
-									// Update the probability of sampling this value from the distribution value.
-									double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
-									
-									// Substituted "j" with its value "0".
-									double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
-									
-									// Store the value of the function call, so the function call is only made once.
-									double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-									
-									// Add the probability of this sample task to the distribution accumulator.
-									if((cv$weightedProbability < cv$distributionAccumulator))
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-									else {
-										// If the second value is -infinity.
-										if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-											cv$distributionAccumulator = cv$weightedProbability;
-										else
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-									}
-									
-									// Add the probability of this distribution configuration to the accumulator.
-									cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
-								}
-							}
-						}
-					}
-				}
-				
-				// Enumerating the possible arguments for Bernoulli 42.
-				if((1 <= j)) {
-					// Enumerating the possible arguments for Bernoulli 42.
-					if(fixedFlag$sample5) {
-						if(fixedFlag$sample23) {
-							double var41 = ((double)v1 / (v2[j] + v3[j]));
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+							double cv$weightedProbability = (Math.log(cv$probabilitySample9Value9) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 							
 							// Add the probability of this sample task to the distribution accumulator.
 							if((cv$weightedProbability < cv$distributionAccumulator))
@@ -598,44 +461,45 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 							}
 							
 							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
-						} else {
-							// Enumerating the possible outputs of Categorical 22.
-							for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
-								// Update the probability of sampling this value from the distribution value.
-								// 
-								// Substituted "i" with its value "j".
-								double cv$probabilitySample23Value29 = distribution$sample23[(j - 1)][index$sample23$28];
-								double var41 = ((double)v1 / (v2[j] + v3[j]));
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
-							}
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value9);
 						}
-					} else {
-						// Enumerating the possible outputs of Categorical 4.
-						for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
-							// Update the probability of sampling this value from the distribution value.
-							double cv$probabilitySample5Value23 = distribution$sample5[index$sample5$22];
-							if(fixedFlag$sample23) {
-								double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+					}
+				} else {
+					// Enumerating the possible outputs of Categorical 4.
+					for(int index$sample5$3 = 0; index$sample5$3 < weightings.length; index$sample5$3 += 1) {
+						// Update the probability of sampling this value from the distribution value.
+						double cv$probabilitySample5Value4 = distribution$sample5[index$sample5$3];
+						if(fixedFlag$sample9) {
+							// Substituted "j" with its value "0".
+							double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(cv$probabilitySample5Value4) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value4);
+						} else {
+							// Enumerating the possible outputs of Categorical 8.
+							for(int index$sample9$13 = 0; index$sample9$13 < weightings.length; index$sample9$13 += 1) {
+								// Update the probability of sampling this value from the distribution value.
+								double cv$probabilitySample9Value14 = (cv$probabilitySample5Value4 * distribution$sample9[index$sample9$13]);
+								
+								// Substituted "j" with its value "0".
+								double var41 = ((double)index$sample5$3 / (v2[0] + v3[0]));
 								
 								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								double cv$weightedProbability = (Math.log(cv$probabilitySample9Value14) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
 								
 								// Add the probability of this sample task to the distribution accumulator.
 								if((cv$weightedProbability < cv$distributionAccumulator))
@@ -649,115 +513,165 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 								}
 								
 								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
-							} else {
-								// Enumerating the possible outputs of Categorical 22.
-								for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
-									// Update the probability of sampling this value from the distribution value.
-									// 
-									// Substituted "i" with its value "j".
-									double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[(j - 1)][index$sample23$34]);
-									double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
-									
-									// Store the value of the function call, so the function call is only made once.
-									double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
-									
-									// Add the probability of this sample task to the distribution accumulator.
-									if((cv$weightedProbability < cv$distributionAccumulator))
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-									else {
-										// If the second value is -infinity.
-										if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-											cv$distributionAccumulator = cv$weightedProbability;
-										else
-											cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-									}
-									
-									// Add the probability of this distribution configuration to the accumulator.
-									cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
-								}
+								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample9Value14);
 							}
 						}
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$distributionAccumulator);
 			}
 			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var42 = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$var43 = cv$sampleAccumulator;
+			// Enumerating the possible arguments for Bernoulli 42.
+			if((1 <= j)) {
+				// Enumerating the possible arguments for Bernoulli 42.
+				if(fixedFlag$sample5) {
+					if(fixedFlag$sample23) {
+						double var41 = ((double)v1 / (v2[j] + v3[j]));
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = Math.log((cv$sampleValue?var41:(1.0 - var41)));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
+					} else {
+						// Enumerating the possible outputs of Categorical 22.
+						for(int index$sample23$28 = 0; index$sample23$28 < weightings.length; index$sample23$28 += 1) {
+							// Update the probability of sampling this value from the distribution value.
+							// 
+							// Substituted "i" with its value "j".
+							double cv$probabilitySample23Value29 = distribution$sample23[(j - 1)][index$sample23$28];
+							double var41 = ((double)v1 / (v2[j] + v3[j]));
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(cv$probabilitySample23Value29) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value29);
+						}
+					}
+				} else {
+					// Enumerating the possible outputs of Categorical 4.
+					for(int index$sample5$22 = 0; index$sample5$22 < weightings.length; index$sample5$22 += 1) {
+						// Update the probability of sampling this value from the distribution value.
+						double cv$probabilitySample5Value23 = distribution$sample5[index$sample5$22];
+						if(fixedFlag$sample23) {
+							double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(cv$probabilitySample5Value23) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample5Value23);
+						} else {
+							// Enumerating the possible outputs of Categorical 22.
+							for(int index$sample23$34 = 0; index$sample23$34 < weightings.length; index$sample23$34 += 1) {
+								// Update the probability of sampling this value from the distribution value.
+								// 
+								// Substituted "i" with its value "j".
+								double cv$probabilitySample23Value35 = (cv$probabilitySample5Value23 * distribution$sample23[(j - 1)][index$sample23$34]);
+								double var41 = ((double)index$sample5$22 / (v2[j] + v3[j]));
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(cv$probabilitySample23Value35) + Math.log((cv$sampleValue?var41:(1.0 - var41))));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + cv$probabilitySample23Value35);
+							}
+						}
+					}
+				}
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
 			
-			// Update the variable probability
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$v = (logProbability$v + cv$sampleAccumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$distributionAccumulator);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if((0 < size))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$var42 = logProbability$var43;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var42 = cv$sampleAccumulator;
 			
-			// Update the variable probability
+			// Store the random variable instance probability
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$v = (logProbability$v + logProbability$var43);
-			
-			// Add probability to model
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var43);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var43);
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$var43 = cv$sampleAccumulator;
 		}
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$v = (logProbability$v + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using probability
@@ -1090,185 +1004,118 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	// Calculate the probability of the samples represented by sample36 using sampled
 	// values.
 	private final void logProbabilityValue$sample36() {
-		// Determine if we need to calculate the values for sample task 36 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample36) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			// The sample value to calculate the probability of generating
+			int cv$sampleValue = v3[j];
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				// The sample value to calculate the probability of generating
-				int cv$sampleValue = v3[j];
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-			}
-			logProbability$c = (logProbability$c + cv$sampleAccumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$v3 = cv$sampleAccumulator;
-			
-			// Add probability to model
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Scale the probability relative to the observed distribution space.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample36 = fixedFlag$sample36;
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < weightings.length))?Math.log(weightings[cv$sampleValue]):Double.NEGATIVE_INFINITY));
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			logProbability$c = (logProbability$c + logProbability$v3);
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$v3);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample36)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$v3);
-		}
+		logProbability$c = (logProbability$c + cv$sampleAccumulator);
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$v3 = cv$sampleAccumulator;
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample43 using sampled
 	// values.
 	private final void logProbabilityValue$sample43() {
-		// Determine if we need to calculate the values for sample task 43 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample43) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int j = 0; j < size; j += 1) {
+			double var41 = ((double)v1 / (v2[j] + v3[j]));
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int j = 0; j < size; j += 1) {
-				double var41 = ((double)v1 / (v2[j] + v3[j]));
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((v[j]?var41:(1.0 - var41))));
-			}
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var42 = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$var43 = cv$sampleAccumulator;
-			}
-			
-			// Update the variable probability
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Scale the probability relative to the observed distribution space.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$v = (logProbability$v + cv$sampleAccumulator);
-			
-			// Add probability to model
+			// Add the probability of this distribution configuration to the accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// An accumulator for the distributed probability space covered.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample43 = (((fixedFlag$sample5 && fixedFlag$sample9) && fixedFlag$sample23) && fixedFlag$sample36);
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((v[j]?var41:(1.0 - var41))));
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if((0 < size))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$var42 = logProbability$var43;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var42 = cv$sampleAccumulator;
 			
-			// Update the variable probability
+			// Store the random variable instance probability
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$v = (logProbability$v + logProbability$var43);
-			
-			// Add probability to model
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var43);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var43);
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$var43 = cv$sampleAccumulator;
 		}
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$v = (logProbability$v + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample5 using sampled values.
@@ -2513,10 +2360,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		// Constructor for v
 		v = new boolean[length$value];
 		
-		// If v3 has not been set already allocate space.
-		if(!fixedFlag$sample36)
-			// Constructor for v3
-			v3 = new int[length$value];
+		// Constructor for v3
+		v3 = new int[length$value];
 		
 		// Constructor for distribution$sample5
 		distribution$sample5 = new double[weightings.length];
@@ -2547,8 +2392,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((double)v1 / (v2[j] + v3[j])));
 		}
 	}
@@ -2558,15 +2402,12 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if((!fixedFlag$sample5 || !fixedFlag$sample36)) {
-			for(int index$c = 0; index$c < weightings.length; index$c += 1)
-				// Save the probability of each value
-				// 
-				// cv$distribution$sample5's comment
-				// Create local copy of variable probabilities.
-				distribution$sample5[index$c] = weightings[index$c];
-		}
+		for(int index$c = 0; index$c < weightings.length; index$c += 1)
+			// Save the probability of each value
+			// 
+			// cv$distribution$sample5's comment
+			// Create local copy of variable probabilities.
+			distribution$sample5[index$c] = weightings[index$c];
 		
 		// Constraints moved from conditionals in inner loops/scopes/etc.
 		if(!fixedFlag$sample9) {
@@ -2590,12 +2431,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 					cv$distribution$sample23[index$var22] = weightings[index$var22];
 			}
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -2613,8 +2450,7 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
 		for(int j = 0; j < size; j += 1) {
-			if(!fixedFlag$sample36)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 			v[j] = DistributionSampling.sampleBernoulli(RNG$, ((double)v1 / (v2[j] + v3[j])));
 		}
 	}
@@ -2633,12 +2469,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			for(int i = 1; i < size; i += 1)
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -2656,12 +2488,8 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 			for(int i = 1; i < size; i += 1)
 				v2[i] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample36) {
-			for(int j = 0; j < size; j += 1)
-				v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
-		}
+		for(int j = 0; j < size; j += 1)
+			v3[j] = DistributionSampling.sampleCategorical(RNG$, weightings, weightings.length);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -2679,20 +2507,13 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 				for(int i = 1; i < size; i += 1)
 					sample23(i);
 			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample36) {
-				for(int j = 0; j < size; j += 1)
-					sample36(j);
-			}
+			for(int j = 0; j < size; j += 1)
+				sample36(j);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample36) {
-				for(int j = (size - 1); j >= 0; j -= 1)
-					sample36(j);
-			}
+			for(int j = (size - 1); j >= 0; j -= 1)
+				sample36(j);
 			
 			// Constraints moved from conditionals in inner loops/scopes/etc.
 			if(!fixedFlag$sample23) {
@@ -2736,12 +2557,10 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		logProbability$var22 = Double.NaN;
 		if(!fixedProbFlag$sample23)
 			logProbability$var23 = Double.NaN;
-		if(!fixedProbFlag$sample36)
-			logProbability$v3 = Double.NaN;
+		logProbability$v3 = Double.NaN;
 		logProbability$var42 = Double.NaN;
 		logProbability$v = 0.0;
-		if(!fixedProbFlag$sample43)
-			logProbability$var43 = Double.NaN;
+		logProbability$var43 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -2751,8 +2570,6 @@ class DistributionTest2b$SingleThreadCPU extends org.sandwood.runtime.internal.m
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample36)
-			logProbabilityValue$sample36();
 		logProbabilityValue$sample43();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -136,17 +137,12 @@ public class DistributionTest2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample36(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample36())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -308,7 +304,6 @@ public class DistributionTest2b extends Model {
 
         //Set fixed flags
         newCore.set$fixedFlag$sample23(oldCore.get$fixedFlag$sample23());
-        newCore.set$fixedFlag$sample36(oldCore.get$fixedFlag$sample36());
         newCore.set$fixedFlag$sample5(oldCore.get$fixedFlag$sample5());
         newCore.set$fixedFlag$sample9(oldCore.get$fixedFlag$sample9());
     }

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -136,17 +137,12 @@ public class DistributionTest2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample36(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample36())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -308,7 +304,6 @@ public class DistributionTest2b extends Model {
 
         //Set fixed flags
         newCore.set$fixedFlag$sample23(oldCore.get$fixedFlag$sample23());
-        newCore.set$fixedFlag$sample36(oldCore.get$fixedFlag$sample36());
         newCore.set$fixedFlag$sample5(oldCore.get$fixedFlag$sample5());
         newCore.set$fixedFlag$sample9(oldCore.get$fixedFlag$sample9());
     }

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -136,17 +137,12 @@ public class DistributionTest2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample36(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample36())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -308,7 +304,6 @@ public class DistributionTest2b extends Model {
 
         //Set fixed flags
         newCore.set$fixedFlag$sample23(oldCore.get$fixedFlag$sample23());
-        newCore.set$fixedFlag$sample36(oldCore.get$fixedFlag$sample36());
         newCore.set$fixedFlag$sample5(oldCore.get$fixedFlag$sample5());
         newCore.set$fixedFlag$sample9(oldCore.get$fixedFlag$sample9());
     }

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -136,17 +137,12 @@ public class DistributionTest2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample36(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample36())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -308,7 +304,6 @@ public class DistributionTest2b extends Model {
 
         //Set fixed flags
         newCore.set$fixedFlag$sample23(oldCore.get$fixedFlag$sample23());
-        newCore.set$fixedFlag$sample36(oldCore.get$fixedFlag$sample36());
         newCore.set$fixedFlag$sample5(oldCore.get$fixedFlag$sample5());
         newCore.set$fixedFlag$sample9(oldCore.get$fixedFlag$sample9());
     }

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -136,17 +137,12 @@ public class DistributionTest2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample36(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample36())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -308,7 +304,6 @@ public class DistributionTest2b extends Model {
 
         //Set fixed flags
         newCore.set$fixedFlag$sample23(oldCore.get$fixedFlag$sample23());
-        newCore.set$fixedFlag$sample36(oldCore.get$fixedFlag$sample36());
         newCore.set$fixedFlag$sample5(oldCore.get$fixedFlag$sample5());
         newCore.set$fixedFlag$sample9(oldCore.get$fixedFlag$sample9());
     }

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest2b/DistributionTest2b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -136,17 +137,12 @@ public class DistributionTest2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample36(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample36())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -308,7 +304,6 @@ public class DistributionTest2b extends Model {
 
         //Set fixed flags
         newCore.set$fixedFlag$sample23(oldCore.get$fixedFlag$sample23());
-        newCore.set$fixedFlag$sample36(oldCore.get$fixedFlag$sample36());
         newCore.set$fixedFlag$sample5(oldCore.get$fixedFlag$sample5());
         newCore.set$fixedFlag$sample9(oldCore.get$fixedFlag$sample9());
     }

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest3/DistributionTest3_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest3/DistributionTest3_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest3/DistributionTest3_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest3/DistributionTest3_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest3/DistributionTest3_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest3/DistributionTest3_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest3/DistributionTest3_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest3/DistributionTest3_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest3/DistributionTest3_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest3/DistributionTest3_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest3/DistributionTest3_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest3/DistributionTest3_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest4/DistributionTest4_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest4/DistributionTest4_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest4/DistributionTest4_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest4/DistributionTest4_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest4/DistributionTest4_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest4/DistributionTest4_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest4/DistributionTest4_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest4/DistributionTest4_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest4/DistributionTest4_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest4/DistributionTest4_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest4/DistributionTest4_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest4/DistributionTest4_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest5/DistributionTest5_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest5/DistributionTest5_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest5/DistributionTest5_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest5/DistributionTest5_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest5/DistributionTest5_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest5/DistributionTest5_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest5/DistributionTest5_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest5/DistributionTest5_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest5/DistributionTest5_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest5/DistributionTest5_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest5/DistributionTest5_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest5/DistributionTest5_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest6/DistributionTest6_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest6/DistributionTest6_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest6/DistributionTest6_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest6/DistributionTest6_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest6/DistributionTest6_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest6/DistributionTest6_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest6/DistributionTest6_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest6/DistributionTest6_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest6/DistributionTest6_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest6/DistributionTest6_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest6/DistributionTest6_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionTest6/DistributionTest6_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class DistributionTest6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionsTest/DistributionsTest_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionsTest/DistributionsTest_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class DistributionsTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionsTest/DistributionsTest_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionsTest/DistributionsTest_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class DistributionsTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionsTest/DistributionsTest_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionsTest/DistributionsTest_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class DistributionsTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionsTest/DistributionsTest_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionsTest/DistributionsTest_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class DistributionsTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionsTest/DistributionsTest_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionsTest/DistributionsTest_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class DistributionsTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionsTest/DistributionsTest_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/DistributionsTest/DistributionsTest_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class DistributionsTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ExponentialDecayMK1/ExponentialDecayMK1_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ExponentialDecayMK1/ExponentialDecayMK1_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ExponentialDecayMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ExponentialDecayMK1/ExponentialDecayMK1_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ExponentialDecayMK1/ExponentialDecayMK1_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ExponentialDecayMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ExponentialDecayMK1/ExponentialDecayMK1_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ExponentialDecayMK1/ExponentialDecayMK1_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ExponentialDecayMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ExponentialDecayMK1/ExponentialDecayMK1_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ExponentialDecayMK1/ExponentialDecayMK1_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ExponentialDecayMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ExponentialDecayMK1/ExponentialDecayMK1_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ExponentialDecayMK1/ExponentialDecayMK1_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ExponentialDecayMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ExponentialDecayMK1/ExponentialDecayMK1_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ExponentialDecayMK1/ExponentialDecayMK1_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ExponentialDecayMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPass/Flip1CoinArrayCopyPass_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPass/Flip1CoinArrayCopyPass_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinArrayCopyPass extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPass/Flip1CoinArrayCopyPass_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPass/Flip1CoinArrayCopyPass_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinArrayCopyPass extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPass/Flip1CoinArrayCopyPass_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPass/Flip1CoinArrayCopyPass_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinArrayCopyPass extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPass/Flip1CoinArrayCopyPass_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPass/Flip1CoinArrayCopyPass_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinArrayCopyPass extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPass/Flip1CoinArrayCopyPass_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPass/Flip1CoinArrayCopyPass_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinArrayCopyPass extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPass/Flip1CoinArrayCopyPass_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPass/Flip1CoinArrayCopyPass_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinArrayCopyPass extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPassMK2/Flip1CoinArrayCopyPassMK2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPassMK2/Flip1CoinArrayCopyPassMK2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinArrayCopyPassMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPassMK2/Flip1CoinArrayCopyPassMK2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPassMK2/Flip1CoinArrayCopyPassMK2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinArrayCopyPassMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPassMK2/Flip1CoinArrayCopyPassMK2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPassMK2/Flip1CoinArrayCopyPassMK2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinArrayCopyPassMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPassMK2/Flip1CoinArrayCopyPassMK2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPassMK2/Flip1CoinArrayCopyPassMK2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinArrayCopyPassMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPassMK2/Flip1CoinArrayCopyPassMK2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPassMK2/Flip1CoinArrayCopyPassMK2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinArrayCopyPassMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPassMK2/Flip1CoinArrayCopyPassMK2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinArrayCopyPassMK2/Flip1CoinArrayCopyPassMK2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinArrayCopyPassMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK0/Flip1CoinMK0_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK0/Flip1CoinMK0_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK0 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK0/Flip1CoinMK0_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK0/Flip1CoinMK0_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK0 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK0/Flip1CoinMK0_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK0/Flip1CoinMK0_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK0 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK0/Flip1CoinMK0_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK0/Flip1CoinMK0_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK0 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK0/Flip1CoinMK0_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK0/Flip1CoinMK0_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK0 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK0/Flip1CoinMK0_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK0/Flip1CoinMK0_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK0 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1/Flip1CoinMK1_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1/Flip1CoinMK1_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1/Flip1CoinMK1_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1/Flip1CoinMK1_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1/Flip1CoinMK1_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1/Flip1CoinMK1_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1/Flip1CoinMK1_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1/Flip1CoinMK1_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1/Flip1CoinMK1_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1/Flip1CoinMK1_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1/Flip1CoinMK1_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1/Flip1CoinMK1_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK10/Flip1CoinMK10_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK10/Flip1CoinMK10_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK10 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK10/Flip1CoinMK10_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK10/Flip1CoinMK10_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK10 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK10/Flip1CoinMK10_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK10/Flip1CoinMK10_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK10 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK10/Flip1CoinMK10_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK10/Flip1CoinMK10_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK10 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK10/Flip1CoinMK10_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK10/Flip1CoinMK10_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK10 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK10/Flip1CoinMK10_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK10/Flip1CoinMK10_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK10 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12/Flip1CoinMK12_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12/Flip1CoinMK12_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -106,17 +107,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -135,17 +131,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample28(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample28())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -164,17 +155,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample35(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample35())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -353,11 +339,6 @@ public class Flip1CoinMK12 extends Model {
             newCore.set$var26(oldCore.get$var26());
         if($var33.isSet())
             newCore.set$var33(oldCore.get$var33());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
-        newCore.set$fixedFlag$sample28(oldCore.get$fixedFlag$sample28());
-        newCore.set$fixedFlag$sample35(oldCore.get$fixedFlag$sample35());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12/Flip1CoinMK12_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12/Flip1CoinMK12_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -106,17 +107,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -135,17 +131,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample28(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample28())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -164,17 +155,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample35(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample35())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -353,11 +339,6 @@ public class Flip1CoinMK12 extends Model {
             newCore.set$var26(oldCore.get$var26());
         if($var33.isSet())
             newCore.set$var33(oldCore.get$var33());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
-        newCore.set$fixedFlag$sample28(oldCore.get$fixedFlag$sample28());
-        newCore.set$fixedFlag$sample35(oldCore.get$fixedFlag$sample35());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12/Flip1CoinMK12_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12/Flip1CoinMK12_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -106,17 +107,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -135,17 +131,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample28(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample28())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -164,17 +155,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample35(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample35())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -353,11 +339,6 @@ public class Flip1CoinMK12 extends Model {
             newCore.set$var26(oldCore.get$var26());
         if($var33.isSet())
             newCore.set$var33(oldCore.get$var33());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
-        newCore.set$fixedFlag$sample28(oldCore.get$fixedFlag$sample28());
-        newCore.set$fixedFlag$sample35(oldCore.get$fixedFlag$sample35());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12/Flip1CoinMK12_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12/Flip1CoinMK12_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -106,17 +107,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -135,17 +131,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample28(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample28())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -164,17 +155,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample35(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample35())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -353,11 +339,6 @@ public class Flip1CoinMK12 extends Model {
             newCore.set$var26(oldCore.get$var26());
         if($var33.isSet())
             newCore.set$var33(oldCore.get$var33());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
-        newCore.set$fixedFlag$sample28(oldCore.get$fixedFlag$sample28());
-        newCore.set$fixedFlag$sample35(oldCore.get$fixedFlag$sample35());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12/Flip1CoinMK12_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12/Flip1CoinMK12_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -106,17 +107,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -135,17 +131,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample28(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample28())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -164,17 +155,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample35(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample35())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -353,11 +339,6 @@ public class Flip1CoinMK12 extends Model {
             newCore.set$var26(oldCore.get$var26());
         if($var33.isSet())
             newCore.set$var33(oldCore.get$var33());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
-        newCore.set$fixedFlag$sample28(oldCore.get$fixedFlag$sample28());
-        newCore.set$fixedFlag$sample35(oldCore.get$fixedFlag$sample35());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12/Flip1CoinMK12_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12/Flip1CoinMK12_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -106,17 +107,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -135,17 +131,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample28(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample28())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -164,17 +155,12 @@ public class Flip1CoinMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample35(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample35())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -353,11 +339,6 @@ public class Flip1CoinMK12 extends Model {
             newCore.set$var26(oldCore.get$var26());
         if($var33.isSet())
             newCore.set$var33(oldCore.get$var33());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
-        newCore.set$fixedFlag$sample28(oldCore.get$fixedFlag$sample28());
-        newCore.set$fixedFlag$sample35(oldCore.get$fixedFlag$sample35());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12b/Flip1CoinMK12b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12b/Flip1CoinMK12b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -106,17 +107,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -135,17 +131,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample28(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample28())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -164,17 +155,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample35(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample35())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -353,11 +339,6 @@ public class Flip1CoinMK12b extends Model {
             newCore.set$var26(oldCore.get$var26());
         if($var33.isSet())
             newCore.set$var33(oldCore.get$var33());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
-        newCore.set$fixedFlag$sample28(oldCore.get$fixedFlag$sample28());
-        newCore.set$fixedFlag$sample35(oldCore.get$fixedFlag$sample35());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12b/Flip1CoinMK12b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12b/Flip1CoinMK12b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -106,17 +107,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -135,17 +131,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample28(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample28())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -164,17 +155,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample35(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample35())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -353,11 +339,6 @@ public class Flip1CoinMK12b extends Model {
             newCore.set$var26(oldCore.get$var26());
         if($var33.isSet())
             newCore.set$var33(oldCore.get$var33());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
-        newCore.set$fixedFlag$sample28(oldCore.get$fixedFlag$sample28());
-        newCore.set$fixedFlag$sample35(oldCore.get$fixedFlag$sample35());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12b/Flip1CoinMK12b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12b/Flip1CoinMK12b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -106,17 +107,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -135,17 +131,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample28(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample28())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -164,17 +155,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample35(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample35())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -353,11 +339,6 @@ public class Flip1CoinMK12b extends Model {
             newCore.set$var26(oldCore.get$var26());
         if($var33.isSet())
             newCore.set$var33(oldCore.get$var33());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
-        newCore.set$fixedFlag$sample28(oldCore.get$fixedFlag$sample28());
-        newCore.set$fixedFlag$sample35(oldCore.get$fixedFlag$sample35());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12b/Flip1CoinMK12b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12b/Flip1CoinMK12b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -106,17 +107,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -135,17 +131,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample28(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample28())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -164,17 +155,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample35(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample35())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -353,11 +339,6 @@ public class Flip1CoinMK12b extends Model {
             newCore.set$var26(oldCore.get$var26());
         if($var33.isSet())
             newCore.set$var33(oldCore.get$var33());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
-        newCore.set$fixedFlag$sample28(oldCore.get$fixedFlag$sample28());
-        newCore.set$fixedFlag$sample35(oldCore.get$fixedFlag$sample35());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12b/Flip1CoinMK12b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12b/Flip1CoinMK12b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -106,17 +107,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -135,17 +131,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample28(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample28())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -164,17 +155,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample35(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample35())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -353,11 +339,6 @@ public class Flip1CoinMK12b extends Model {
             newCore.set$var26(oldCore.get$var26());
         if($var33.isSet())
             newCore.set$var33(oldCore.get$var33());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
-        newCore.set$fixedFlag$sample28(oldCore.get$fixedFlag$sample28());
-        newCore.set$fixedFlag$sample35(oldCore.get$fixedFlag$sample35());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12b/Flip1CoinMK12b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK12b/Flip1CoinMK12b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -106,17 +107,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -135,17 +131,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample28(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample28())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -164,17 +155,12 @@ public class Flip1CoinMK12b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample35(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample35())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -353,11 +339,6 @@ public class Flip1CoinMK12b extends Model {
             newCore.set$var26(oldCore.get$var26());
         if($var33.isSet())
             newCore.set$var33(oldCore.get$var33());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
-        newCore.set$fixedFlag$sample28(oldCore.get$fixedFlag$sample28());
-        newCore.set$fixedFlag$sample35(oldCore.get$fixedFlag$sample35());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK13/Flip1CoinMK13_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK13/Flip1CoinMK13_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK13 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK13/Flip1CoinMK13_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK13/Flip1CoinMK13_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK13 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK13/Flip1CoinMK13_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK13/Flip1CoinMK13_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK13 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK13/Flip1CoinMK13_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK13/Flip1CoinMK13_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK13 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK13/Flip1CoinMK13_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK13/Flip1CoinMK13_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK13 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK13/Flip1CoinMK13_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK13/Flip1CoinMK13_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK13 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK14/Flip1CoinMK14_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK14/Flip1CoinMK14_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK14 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK14/Flip1CoinMK14_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK14/Flip1CoinMK14_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK14 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK14/Flip1CoinMK14_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK14/Flip1CoinMK14_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK14 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK14/Flip1CoinMK14_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK14/Flip1CoinMK14_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK14 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK14/Flip1CoinMK14_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK14/Flip1CoinMK14_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK14 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK14/Flip1CoinMK14_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK14/Flip1CoinMK14_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK14 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK15/Flip1CoinMK15_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK15/Flip1CoinMK15_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK15 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK15/Flip1CoinMK15_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK15/Flip1CoinMK15_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK15 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK15/Flip1CoinMK15_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK15/Flip1CoinMK15_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK15 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK15/Flip1CoinMK15_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK15/Flip1CoinMK15_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK15 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK15/Flip1CoinMK15_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK15/Flip1CoinMK15_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK15 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK15/Flip1CoinMK15_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK15/Flip1CoinMK15_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class Flip1CoinMK15 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$CoreInterface_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$CoreInterface_model.java
@@ -8,12 +8,6 @@ interface Flip1CoinMK16$CoreInterface extends org.sandwood.runtime.internal.mode
 	// Setter for bias.
 	public void set$bias(double cv$value);
 
-	// Getter for fixedFlag$sample14.
-	public boolean get$fixedFlag$sample14();
-
-	// Setter for fixedFlag$sample14.
-	public void set$fixedFlag$sample14(boolean cv$value);
-
 	// Getter for flip.
 	public boolean get$flip();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$CoreInterface_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$CoreInterface_modelNoComments.java
@@ -3,8 +3,6 @@ package org.sandwood.compiler.tests.parser;
 interface Flip1CoinMK16$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
 	public double get$bias();
 	public void set$bias(double cv$value);
-	public boolean get$fixedFlag$sample14();
-	public void set$fixedFlag$sample14(boolean cv$value);
 	public boolean get$flip();
 	public boolean get$flipMeasured();
 	public void set$flipMeasured(boolean cv$value);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$CoreInterface_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$CoreInterface_modelSingle.java
@@ -8,12 +8,6 @@ interface Flip1CoinMK16$CoreInterface extends org.sandwood.runtime.internal.mode
 	// Setter for bias.
 	public void set$bias(double cv$value);
 
-	// Getter for fixedFlag$sample14.
-	public boolean get$fixedFlag$sample14();
-
-	// Setter for fixedFlag$sample14.
-	public void set$fixedFlag$sample14(boolean cv$value);
-
 	// Getter for flip.
 	public boolean get$flip();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$CoreInterface_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$CoreInterface_optimisedModel.java
@@ -8,12 +8,6 @@ interface Flip1CoinMK16$CoreInterface extends org.sandwood.runtime.internal.mode
 	// Setter for bias.
 	public void set$bias(double cv$value);
 
-	// Getter for fixedFlag$sample14.
-	public boolean get$fixedFlag$sample14();
-
-	// Setter for fixedFlag$sample14.
-	public void set$fixedFlag$sample14(boolean cv$value);
-
 	// Getter for flip.
 	public boolean get$flip();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$CoreInterface_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$CoreInterface_optimisedModelNoComments.java
@@ -3,8 +3,6 @@ package org.sandwood.compiler.tests.parser;
 interface Flip1CoinMK16$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
 	public double get$bias();
 	public void set$bias(double cv$value);
-	public boolean get$fixedFlag$sample14();
-	public void set$fixedFlag$sample14(boolean cv$value);
 	public boolean get$flip();
 	public boolean get$flipMeasured();
 	public void set$flipMeasured(boolean cv$value);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$CoreInterface_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$CoreInterface_optimisedModelSingle.java
@@ -8,12 +8,6 @@ interface Flip1CoinMK16$CoreInterface extends org.sandwood.runtime.internal.mode
 	// Setter for bias.
 	public void set$bias(double cv$value);
 
-	// Getter for fixedFlag$sample14.
-	public boolean get$fixedFlag$sample14();
-
-	// Setter for fixedFlag$sample14.
-	public void set$fixedFlag$sample14(boolean cv$value);
-
 	// Getter for flip.
 	public boolean get$flip();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$MultiThreadCPU_model.java
@@ -8,9 +8,6 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	
 	// Declare the variables for the model.
 	private double bias;
-	private boolean fixedFlag$sample14 = false;
-	private boolean fixedProbFlag$sample14 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean flip;
 	private boolean flipMeasured;
 	private double guard;
@@ -37,37 +34,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for bias.
 	@Override
 	public final void set$bias(double cv$value) {
-		// Set flags for all the side effects of bias including if probabilities need to be
-		// updated.
 		bias = cv$value;
-		
-		// Unset the fixed probability flag for sample 14 as it depends on bias.
-		fixedProbFlag$sample14 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on bias.
-		fixedProbFlag$sample16 = false;
-	}
-
-	// Getter for fixedFlag$sample14.
-	@Override
-	public final boolean get$fixedFlag$sample14() {
-		return fixedFlag$sample14;
-	}
-
-	// Setter for fixedFlag$sample14.
-	@Override
-	public final void set$fixedFlag$sample14(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample14 including if probabilities
-		// need to be updated.
-		fixedFlag$sample14 = cv$value;
-		
-		// Should the probability of sample 14 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample14 = (fixedFlag$sample14 && fixedProbFlag$sample14);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample16 = (fixedFlag$sample14 && fixedProbFlag$sample16);
 	}
 
 	// Getter for flip.
@@ -133,226 +100,149 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Calculate the probability of the samples represented by sample14 using sampled
 	// values.
 	private final void logProbabilityValue$sample14() {
-		// Determine if we need to calculate the values for sample task 14 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample14) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = bias;
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = bias;
 					{
-						{
-							double var9 = 1.0;
-							double var10 = 1.0;
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var9, var10));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var9 = 1.0;
+						double var10 = 1.0;
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var9, var10));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var11 = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample14 = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$bias = (logProbability$bias + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var11 = cv$sampleAccumulator;
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample14 = fixedFlag$sample14;
+			// Store the sample task probability
+			logProbability$sample14 = cv$sampleProbability;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample14;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var11 = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$bias = (logProbability$bias + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$bias = (logProbability$bias + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				boolean cv$sampleValue = flip;
 				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = flip;
 					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?bias:(1.0 - bias))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?bias:(1.0 - bias))));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$bernoulli = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample16 = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$flip = (logProbability$flip + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = fixedFlag$sample14;
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$bernoulli = cv$sampleAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample16 = cv$sampleProbability;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample16;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$bernoulli = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$flip = (logProbability$flip + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$flip = (logProbability$flip + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -410,8 +300,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void forwardGeneration() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -421,10 +310,8 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -432,8 +319,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void forwardGenerationPrime() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -442,10 +328,8 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -453,10 +337,8 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -464,17 +346,13 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void gibbsRound() {
 		// Infer the samples in chronological order.
 		if(system$gibbsForward) {
-			if(Double.isNaN(guard)) {
-				if(!fixedFlag$sample14)
-					sample14();
-			}
+			if(Double.isNaN(guard))
+				sample14();
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			if(Double.isNaN(guard)) {
-				if(!fixedFlag$sample14)
-					sample14();
-			}
+			if(Double.isNaN(guard))
+				sample14();
 		}
 		
 		// Reverse the direction of execution for the next iteration
@@ -498,12 +376,10 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$$evidence = 0.0;
 		logProbability$var11 = Double.NaN;
 		logProbability$bias = 0.0;
-		if(!fixedProbFlag$sample14)
-			logProbability$sample14 = Double.NaN;
+		logProbability$sample14 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flip = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -513,8 +389,6 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample14)
-			logProbabilityValue$sample14();
 		logProbabilityValue$sample16();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$MultiThreadCPU_modelNoComments.java
@@ -6,9 +6,6 @@ import org.sandwood.runtime.model.ExecutionTarget;
 
 class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements Flip1CoinMK16$CoreInterface {
 	private double bias;
-	private boolean fixedFlag$sample14 = false;
-	private boolean fixedProbFlag$sample14 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean flip;
 	private boolean flipMeasured;
 	private double guard;
@@ -34,20 +31,6 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$bias(double cv$value) {
 		bias = cv$value;
-		fixedProbFlag$sample14 = false;
-		fixedProbFlag$sample16 = false;
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample14() {
-		return fixedFlag$sample14;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample14(boolean cv$value) {
-		fixedFlag$sample14 = cv$value;
-		fixedProbFlag$sample14 = (fixedFlag$sample14 && fixedProbFlag$sample14);
-		fixedProbFlag$sample16 = (fixedFlag$sample14 && fixedProbFlag$sample16);
 	}
 
 	@Override
@@ -101,121 +84,84 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	}
 
 	private final void logProbabilityValue$sample14() {
-		if(!fixedProbFlag$sample14) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				double cv$sampleValue = bias;
 				{
-					double cv$sampleValue = bias;
 					{
-						{
-							double var9 = 1.0;
-							double var10 = 1.0;
-							double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var9, var10));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var9 = 1.0;
+						double var10 = 1.0;
+						double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var9, var10));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var11 = cv$sampleAccumulator;
-				logProbability$sample14 = cv$sampleProbability;
 			}
-			logProbability$bias = (logProbability$bias + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample14 = fixedFlag$sample14;
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample14;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var11 = cv$rvAccumulator;
-			}
-			logProbability$bias = (logProbability$bias + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var11 = cv$sampleAccumulator;
+			logProbability$sample14 = cv$sampleProbability;
 		}
+		logProbability$bias = (logProbability$bias + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample16() {
-		if(!fixedProbFlag$sample16) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				boolean cv$sampleValue = flip;
 				{
-					boolean cv$sampleValue = flip;
 					{
-						{
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?bias:(1.0 - bias))));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?bias:(1.0 - bias))));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$bernoulli = cv$sampleAccumulator;
-				logProbability$sample16 = cv$sampleProbability;
 			}
-			logProbability$flip = (logProbability$flip + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample16 = fixedFlag$sample14;
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample16;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$bernoulli = cv$rvAccumulator;
-			}
-			logProbability$flip = (logProbability$flip + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$bernoulli = cv$sampleAccumulator;
+			logProbability$sample16 = cv$sampleProbability;
 		}
+		logProbability$flip = (logProbability$flip + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void sample14() {
@@ -254,57 +200,45 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void forwardGeneration() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
 
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	@Override
 	public final void forwardGenerationPrime() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	@Override
 	public final void gibbsRound() {
 		if(system$gibbsForward) {
-			if(Double.isNaN(guard)) {
-				if(!fixedFlag$sample14)
-					sample14();
-			}
+			if(Double.isNaN(guard))
+				sample14();
 		} else {
-			if(Double.isNaN(guard)) {
-				if(!fixedFlag$sample14)
-					sample14();
-			}
+			if(Double.isNaN(guard))
+				sample14();
 		}
 		system$gibbsForward = !system$gibbsForward;
 	}
@@ -317,19 +251,15 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$$evidence = 0.0;
 		logProbability$var11 = Double.NaN;
 		logProbability$bias = 0.0;
-		if(!fixedProbFlag$sample14)
-			logProbability$sample14 = Double.NaN;
+		logProbability$sample14 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flip = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	@Override
 	public final void logEvidenceProbabilities() {
 		initializeLogProbabilityFields();
-		if(fixedFlag$sample14)
-			logProbabilityValue$sample14();
 		logProbabilityValue$sample16();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$MultiThreadCPU_modelSingle.java
@@ -8,9 +8,6 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	
 	// Declare the variables for the model.
 	private double bias;
-	private boolean fixedFlag$sample14 = false;
-	private boolean fixedProbFlag$sample14 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean flip;
 	private boolean flipMeasured;
 	private double guard;
@@ -35,37 +32,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for bias.
 	@Override
 	public final void set$bias(double cv$value) {
-		// Set flags for all the side effects of bias including if probabilities need to be
-		// updated.
 		bias = cv$value;
-		
-		// Unset the fixed probability flag for sample 14 as it depends on bias.
-		fixedProbFlag$sample14 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on bias.
-		fixedProbFlag$sample16 = false;
-	}
-
-	// Getter for fixedFlag$sample14.
-	@Override
-	public final boolean get$fixedFlag$sample14() {
-		return fixedFlag$sample14;
-	}
-
-	// Setter for fixedFlag$sample14.
-	@Override
-	public final void set$fixedFlag$sample14(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample14 including if probabilities
-		// need to be updated.
-		fixedFlag$sample14 = cv$value;
-		
-		// Should the probability of sample 14 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample14 = (fixedFlag$sample14 && fixedProbFlag$sample14);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample16 = (fixedFlag$sample14 && fixedProbFlag$sample16);
 	}
 
 	// Getter for flip.
@@ -131,220 +98,151 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Calculate the probability of the samples represented by sample14 using sampled
 	// values.
 	private final void logProbabilityValue$sample14() {
-		// Determine if we need to calculate the values for sample task 14 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample14) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = bias;
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = bias;
 					{
-						{
-							double var9 = 1.0;
-							double var10 = 1.0;
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var9, var10));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var9 = 1.0;
+						double var10 = 1.0;
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var9, var10));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var11 = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$bias = cv$accumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample14 = fixedFlag$sample14;
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$bias;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var11 = cv$rvAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var11 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$bias = cv$accumulator;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				boolean cv$sampleValue = flip;
 				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = flip;
 					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?bias:(1.0 - bias))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?bias:(1.0 - bias))));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$bernoulli = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$flip = cv$accumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = fixedFlag$sample14;
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$flip;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$bernoulli = cv$rvAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$bernoulli = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$flip = cv$accumulator;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -402,8 +300,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void forwardGeneration() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -413,10 +310,8 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -424,8 +319,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void forwardGenerationPrime() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -434,10 +328,8 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -445,10 +337,8 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -456,17 +346,13 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void gibbsRound() {
 		// Infer the samples in chronological order.
 		if(system$gibbsForward) {
-			if(Double.isNaN(guard)) {
-				if(!fixedFlag$sample14)
-					sample14();
-			}
+			if(Double.isNaN(guard))
+				sample14();
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			if(Double.isNaN(guard)) {
-				if(!fixedFlag$sample14)
-					sample14();
-			}
+			if(Double.isNaN(guard))
+				sample14();
 		}
 		
 		// Reverse the direction of execution for the next iteration
@@ -489,11 +375,9 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var11 = Double.NaN;
-		if(!fixedProbFlag$sample14)
-			logProbability$bias = Double.NaN;
+		logProbability$bias = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
-		if(!fixedProbFlag$sample16)
-			logProbability$flip = Double.NaN;
+		logProbability$flip = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -503,8 +387,6 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample14)
-			logProbabilityValue$sample14();
 		logProbabilityValue$sample16();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$MultiThreadCPU_optimisedModel.java
@@ -8,9 +8,6 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	
 	// Declare the variables for the model.
 	private double bias;
-	private boolean fixedFlag$sample14 = false;
-	private boolean fixedProbFlag$sample14 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean flip;
 	private boolean flipMeasured;
 	private double guard;
@@ -37,41 +34,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for bias.
 	@Override
 	public final void set$bias(double cv$value) {
-		// Set flags for all the side effects of bias including if probabilities need to be
-		// updated.
 		bias = cv$value;
-		
-		// Unset the fixed probability flag for sample 14 as it depends on bias.
-		fixedProbFlag$sample14 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on bias.
-		fixedProbFlag$sample16 = false;
-	}
-
-	// Getter for fixedFlag$sample14.
-	@Override
-	public final boolean get$fixedFlag$sample14() {
-		return fixedFlag$sample14;
-	}
-
-	// Setter for fixedFlag$sample14.
-	@Override
-	public final void set$fixedFlag$sample14(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample14 including if probabilities
-		// need to be updated.
-		fixedFlag$sample14 = cv$value;
-		
-		// Should the probability of sample 14 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample14" with its value "cv$value".
-		fixedProbFlag$sample14 = (cv$value && fixedProbFlag$sample14);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample14" with its value "cv$value".
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	// Getter for flip.
@@ -137,177 +100,118 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Calculate the probability of the samples represented by sample14 using sampled
 	// values.
 	private final void logProbabilityValue$sample14() {
-		// Determine if we need to calculate the values for sample task 14 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample14) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		if(Double.isNaN(guard)) {
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(bias, 1.0, 1.0);
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
 			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(bias, 1.0, 1.0);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = cv$distributionAccumulator;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var11 = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample14 = cv$distributionAccumulator;
-			}
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$bias = (logProbability$bias + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var11 = cv$distributionAccumulator;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample14 = fixedFlag$sample14;
+			// Store the sample task probability
+			logProbability$sample14 = cv$distributionAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				cv$accumulator = logProbability$sample14;
-				logProbability$var11 = logProbability$sample14;
-			}
-			
-			// Update the variable probability
-			logProbability$bias = (logProbability$bias + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$bias = (logProbability$bias + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		if(Double.isNaN(guard)) {
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = Math.log((flip?bias:(1.0 - bias)));
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
 			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = Math.log((flip?bias:(1.0 - bias)));
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = cv$distributionAccumulator;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$bernoulli = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample16 = cv$distributionAccumulator;
-			}
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$flip = (logProbability$flip + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$bernoulli = cv$distributionAccumulator;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = fixedFlag$sample14;
+			// Store the sample task probability
+			logProbability$sample16 = cv$distributionAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				cv$accumulator = logProbability$sample16;
-				logProbability$bernoulli = logProbability$sample16;
-			}
-			
-			// Update the variable probability
-			logProbability$flip = (logProbability$flip + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$flip = (logProbability$flip + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -350,8 +254,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void forwardGeneration() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -361,7 +264,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
@@ -370,8 +273,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void forwardGenerationPrime() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -380,7 +282,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
@@ -389,7 +291,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
@@ -397,7 +299,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void gibbsRound() {
 		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			sample14();
 		
 		// Reverse the direction of execution for the next iteration
@@ -421,12 +323,10 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$$evidence = 0.0;
 		logProbability$var11 = Double.NaN;
 		logProbability$bias = 0.0;
-		if(!fixedProbFlag$sample14)
-			logProbability$sample14 = Double.NaN;
+		logProbability$sample14 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flip = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -436,8 +336,6 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample14)
-			logProbabilityValue$sample14();
 		logProbabilityValue$sample16();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$MultiThreadCPU_optimisedModelNoComments.java
@@ -6,9 +6,6 @@ import org.sandwood.runtime.model.ExecutionTarget;
 
 class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements Flip1CoinMK16$CoreInterface {
 	private double bias;
-	private boolean fixedFlag$sample14 = false;
-	private boolean fixedProbFlag$sample14 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean flip;
 	private boolean flipMeasured;
 	private double guard;
@@ -34,20 +31,6 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$bias(double cv$value) {
 		bias = cv$value;
-		fixedProbFlag$sample14 = false;
-		fixedProbFlag$sample16 = false;
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample14() {
-		return fixedFlag$sample14;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample14(boolean cv$value) {
-		fixedFlag$sample14 = cv$value;
-		fixedProbFlag$sample14 = (cv$value && fixedProbFlag$sample14);
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	@Override
@@ -101,55 +84,28 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	}
 
 	private final void logProbabilityValue$sample14() {
-		if(!fixedProbFlag$sample14) {
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(bias, 1.0, 1.0);
-				cv$accumulator = cv$distributionAccumulator;
-				logProbability$var11 = cv$distributionAccumulator;
-				logProbability$sample14 = cv$distributionAccumulator;
-			}
-			logProbability$bias = (logProbability$bias + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample14 = fixedFlag$sample14;
-		} else {
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				cv$accumulator = logProbability$sample14;
-				logProbability$var11 = logProbability$sample14;
-			}
-			logProbability$bias = (logProbability$bias + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		if(Double.isNaN(guard)) {
+			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(bias, 1.0, 1.0);
+			cv$accumulator = cv$distributionAccumulator;
+			logProbability$var11 = cv$distributionAccumulator;
+			logProbability$sample14 = cv$distributionAccumulator;
 		}
+		logProbability$bias = (logProbability$bias + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample16() {
-		if(!fixedProbFlag$sample16) {
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				double cv$distributionAccumulator = Math.log((flip?bias:(1.0 - bias)));
-				cv$accumulator = cv$distributionAccumulator;
-				logProbability$bernoulli = cv$distributionAccumulator;
-				logProbability$sample16 = cv$distributionAccumulator;
-			}
-			logProbability$flip = (logProbability$flip + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample16 = fixedFlag$sample14;
-		} else {
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				cv$accumulator = logProbability$sample16;
-				logProbability$bernoulli = logProbability$sample16;
-			}
-			logProbability$flip = (logProbability$flip + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		if(Double.isNaN(guard)) {
+			double cv$distributionAccumulator = Math.log((flip?bias:(1.0 - bias)));
+			cv$accumulator = cv$distributionAccumulator;
+			logProbability$bernoulli = cv$distributionAccumulator;
+			logProbability$sample16 = cv$distributionAccumulator;
 		}
+		logProbability$flip = (logProbability$flip + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void sample14() {
@@ -168,42 +124,40 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void forwardGeneration() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
 
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	@Override
 	public final void forwardGenerationPrime() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	@Override
 	public final void gibbsRound() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			sample14();
 		system$gibbsForward = !system$gibbsForward;
 	}
@@ -216,19 +170,15 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$$evidence = 0.0;
 		logProbability$var11 = Double.NaN;
 		logProbability$bias = 0.0;
-		if(!fixedProbFlag$sample14)
-			logProbability$sample14 = Double.NaN;
+		logProbability$sample14 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flip = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	@Override
 	public final void logEvidenceProbabilities() {
 		initializeLogProbabilityFields();
-		if(fixedFlag$sample14)
-			logProbabilityValue$sample14();
 		logProbabilityValue$sample16();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$MultiThreadCPU_optimisedModelSingle.java
@@ -8,9 +8,6 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	
 	// Declare the variables for the model.
 	private double bias;
-	private boolean fixedFlag$sample14 = false;
-	private boolean fixedProbFlag$sample14 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean flip;
 	private boolean flipMeasured;
 	private double guard;
@@ -35,41 +32,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for bias.
 	@Override
 	public final void set$bias(double cv$value) {
-		// Set flags for all the side effects of bias including if probabilities need to be
-		// updated.
 		bias = cv$value;
-		
-		// Unset the fixed probability flag for sample 14 as it depends on bias.
-		fixedProbFlag$sample14 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on bias.
-		fixedProbFlag$sample16 = false;
-	}
-
-	// Getter for fixedFlag$sample14.
-	@Override
-	public final boolean get$fixedFlag$sample14() {
-		return fixedFlag$sample14;
-	}
-
-	// Setter for fixedFlag$sample14.
-	@Override
-	public final void set$fixedFlag$sample14(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample14 including if probabilities
-		// need to be updated.
-		fixedFlag$sample14 = cv$value;
-		
-		// Should the probability of sample 14 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample14" with its value "cv$value".
-		fixedProbFlag$sample14 = (cv$value && fixedProbFlag$sample14);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample14" with its value "cv$value".
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	// Getter for flip.
@@ -135,185 +98,117 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Calculate the probability of the samples represented by sample14 using sampled
 	// values.
 	private final void logProbabilityValue$sample14() {
-		// Determine if we need to calculate the values for sample task 14 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample14) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
 			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			cv$sampleAccumulator = DistributionSampling.logProbabilityBeta(bias, 1.0, 1.0);
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var11 = cv$sampleAccumulator;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = DistributionSampling.logProbabilityBeta(bias, 1.0, 1.0);
-			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var11 = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$bias = cv$sampleAccumulator;
-			}
-			
-			// Add probability to model
+			// Store the random variable instance probability
 			// 
 			// Add the probability of this instance of the random variable to the probability
 			// of all instances of the random variable.
 			// 
 			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample14 = fixedFlag$sample14;
+			logProbability$bias = cv$sampleAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$var11 = logProbability$bias;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$bias);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$bias);
-		}
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
 			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			cv$sampleAccumulator = Math.log((flip?bias:(1.0 - bias)));
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$bernoulli = cv$sampleAccumulator;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = Math.log((flip?bias:(1.0 - bias)));
-			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$bernoulli = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$flip = cv$sampleAccumulator;
-			}
-			
-			// Add probability to model
+			// Store the random variable instance probability
 			// 
 			// Add the probability of this instance of the random variable to the probability
 			// of all instances of the random variable.
 			// 
 			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = fixedFlag$sample14;
+			logProbability$flip = cv$sampleAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$bernoulli = logProbability$flip;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$flip);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$flip);
-		}
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -356,8 +251,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void forwardGeneration() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -367,7 +261,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
@@ -376,8 +270,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void forwardGenerationPrime() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -386,7 +279,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
@@ -395,7 +288,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
@@ -403,7 +296,7 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void gibbsRound() {
 		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			sample14();
 		
 		// Reverse the direction of execution for the next iteration
@@ -426,11 +319,9 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var11 = Double.NaN;
-		if(!fixedProbFlag$sample14)
-			logProbability$bias = Double.NaN;
+		logProbability$bias = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
-		if(!fixedProbFlag$sample16)
-			logProbability$flip = Double.NaN;
+		logProbability$flip = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -440,8 +331,6 @@ class Flip1CoinMK16$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample14)
-			logProbabilityValue$sample14();
 		logProbabilityValue$sample16();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$SingleThreadCPU_model.java
@@ -8,9 +8,6 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	
 	// Declare the variables for the model.
 	private double bias;
-	private boolean fixedFlag$sample14 = false;
-	private boolean fixedProbFlag$sample14 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean flip;
 	private boolean flipMeasured;
 	private double guard;
@@ -37,37 +34,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Setter for bias.
 	@Override
 	public final void set$bias(double cv$value) {
-		// Set flags for all the side effects of bias including if probabilities need to be
-		// updated.
 		bias = cv$value;
-		
-		// Unset the fixed probability flag for sample 14 as it depends on bias.
-		fixedProbFlag$sample14 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on bias.
-		fixedProbFlag$sample16 = false;
-	}
-
-	// Getter for fixedFlag$sample14.
-	@Override
-	public final boolean get$fixedFlag$sample14() {
-		return fixedFlag$sample14;
-	}
-
-	// Setter for fixedFlag$sample14.
-	@Override
-	public final void set$fixedFlag$sample14(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample14 including if probabilities
-		// need to be updated.
-		fixedFlag$sample14 = cv$value;
-		
-		// Should the probability of sample 14 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample14 = (fixedFlag$sample14 && fixedProbFlag$sample14);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample16 = (fixedFlag$sample14 && fixedProbFlag$sample16);
 	}
 
 	// Getter for flip.
@@ -133,226 +100,149 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Calculate the probability of the samples represented by sample14 using sampled
 	// values.
 	private final void logProbabilityValue$sample14() {
-		// Determine if we need to calculate the values for sample task 14 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample14) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = bias;
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = bias;
 					{
-						{
-							double var9 = 1.0;
-							double var10 = 1.0;
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var9, var10));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var9 = 1.0;
+						double var10 = 1.0;
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var9, var10));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var11 = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample14 = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$bias = (logProbability$bias + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var11 = cv$sampleAccumulator;
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample14 = fixedFlag$sample14;
+			// Store the sample task probability
+			logProbability$sample14 = cv$sampleProbability;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample14;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var11 = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$bias = (logProbability$bias + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$bias = (logProbability$bias + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				boolean cv$sampleValue = flip;
 				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = flip;
 					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?bias:(1.0 - bias))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?bias:(1.0 - bias))));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$bernoulli = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample16 = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$flip = (logProbability$flip + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = fixedFlag$sample14;
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$bernoulli = cv$sampleAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample16 = cv$sampleProbability;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample16;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$bernoulli = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$flip = (logProbability$flip + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$flip = (logProbability$flip + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -410,8 +300,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void forwardGeneration() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -421,10 +310,8 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -432,8 +319,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void forwardGenerationPrime() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -442,10 +328,8 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -453,10 +337,8 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -464,17 +346,13 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void gibbsRound() {
 		// Infer the samples in chronological order.
 		if(system$gibbsForward) {
-			if(Double.isNaN(guard)) {
-				if(!fixedFlag$sample14)
-					sample14();
-			}
+			if(Double.isNaN(guard))
+				sample14();
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			if(Double.isNaN(guard)) {
-				if(!fixedFlag$sample14)
-					sample14();
-			}
+			if(Double.isNaN(guard))
+				sample14();
 		}
 		
 		// Reverse the direction of execution for the next iteration
@@ -498,12 +376,10 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$$evidence = 0.0;
 		logProbability$var11 = Double.NaN;
 		logProbability$bias = 0.0;
-		if(!fixedProbFlag$sample14)
-			logProbability$sample14 = Double.NaN;
+		logProbability$sample14 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flip = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -513,8 +389,6 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample14)
-			logProbabilityValue$sample14();
 		logProbabilityValue$sample16();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$SingleThreadCPU_modelNoComments.java
@@ -6,9 +6,6 @@ import org.sandwood.runtime.model.ExecutionTarget;
 
 class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements Flip1CoinMK16$CoreInterface {
 	private double bias;
-	private boolean fixedFlag$sample14 = false;
-	private boolean fixedProbFlag$sample14 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean flip;
 	private boolean flipMeasured;
 	private double guard;
@@ -34,20 +31,6 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void set$bias(double cv$value) {
 		bias = cv$value;
-		fixedProbFlag$sample14 = false;
-		fixedProbFlag$sample16 = false;
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample14() {
-		return fixedFlag$sample14;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample14(boolean cv$value) {
-		fixedFlag$sample14 = cv$value;
-		fixedProbFlag$sample14 = (fixedFlag$sample14 && fixedProbFlag$sample14);
-		fixedProbFlag$sample16 = (fixedFlag$sample14 && fixedProbFlag$sample16);
 	}
 
 	@Override
@@ -101,121 +84,84 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	}
 
 	private final void logProbabilityValue$sample14() {
-		if(!fixedProbFlag$sample14) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				double cv$sampleValue = bias;
 				{
-					double cv$sampleValue = bias;
 					{
-						{
-							double var9 = 1.0;
-							double var10 = 1.0;
-							double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var9, var10));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var9 = 1.0;
+						double var10 = 1.0;
+						double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var9, var10));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var11 = cv$sampleAccumulator;
-				logProbability$sample14 = cv$sampleProbability;
 			}
-			logProbability$bias = (logProbability$bias + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample14 = fixedFlag$sample14;
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample14;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var11 = cv$rvAccumulator;
-			}
-			logProbability$bias = (logProbability$bias + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var11 = cv$sampleAccumulator;
+			logProbability$sample14 = cv$sampleProbability;
 		}
+		logProbability$bias = (logProbability$bias + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample16() {
-		if(!fixedProbFlag$sample16) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				boolean cv$sampleValue = flip;
 				{
-					boolean cv$sampleValue = flip;
 					{
-						{
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?bias:(1.0 - bias))));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?bias:(1.0 - bias))));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$bernoulli = cv$sampleAccumulator;
-				logProbability$sample16 = cv$sampleProbability;
 			}
-			logProbability$flip = (logProbability$flip + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample16 = fixedFlag$sample14;
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample16;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$bernoulli = cv$rvAccumulator;
-			}
-			logProbability$flip = (logProbability$flip + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$bernoulli = cv$sampleAccumulator;
+			logProbability$sample16 = cv$sampleProbability;
 		}
+		logProbability$flip = (logProbability$flip + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void sample14() {
@@ -254,57 +200,45 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void forwardGeneration() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
 
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	@Override
 	public final void forwardGenerationPrime() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	@Override
 	public final void gibbsRound() {
 		if(system$gibbsForward) {
-			if(Double.isNaN(guard)) {
-				if(!fixedFlag$sample14)
-					sample14();
-			}
+			if(Double.isNaN(guard))
+				sample14();
 		} else {
-			if(Double.isNaN(guard)) {
-				if(!fixedFlag$sample14)
-					sample14();
-			}
+			if(Double.isNaN(guard))
+				sample14();
 		}
 		system$gibbsForward = !system$gibbsForward;
 	}
@@ -317,19 +251,15 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$$evidence = 0.0;
 		logProbability$var11 = Double.NaN;
 		logProbability$bias = 0.0;
-		if(!fixedProbFlag$sample14)
-			logProbability$sample14 = Double.NaN;
+		logProbability$sample14 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flip = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	@Override
 	public final void logEvidenceProbabilities() {
 		initializeLogProbabilityFields();
-		if(fixedFlag$sample14)
-			logProbabilityValue$sample14();
 		logProbabilityValue$sample16();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$SingleThreadCPU_modelSingle.java
@@ -8,9 +8,6 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	
 	// Declare the variables for the model.
 	private double bias;
-	private boolean fixedFlag$sample14 = false;
-	private boolean fixedProbFlag$sample14 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean flip;
 	private boolean flipMeasured;
 	private double guard;
@@ -35,37 +32,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Setter for bias.
 	@Override
 	public final void set$bias(double cv$value) {
-		// Set flags for all the side effects of bias including if probabilities need to be
-		// updated.
 		bias = cv$value;
-		
-		// Unset the fixed probability flag for sample 14 as it depends on bias.
-		fixedProbFlag$sample14 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on bias.
-		fixedProbFlag$sample16 = false;
-	}
-
-	// Getter for fixedFlag$sample14.
-	@Override
-	public final boolean get$fixedFlag$sample14() {
-		return fixedFlag$sample14;
-	}
-
-	// Setter for fixedFlag$sample14.
-	@Override
-	public final void set$fixedFlag$sample14(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample14 including if probabilities
-		// need to be updated.
-		fixedFlag$sample14 = cv$value;
-		
-		// Should the probability of sample 14 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample14 = (fixedFlag$sample14 && fixedProbFlag$sample14);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample16 = (fixedFlag$sample14 && fixedProbFlag$sample16);
 	}
 
 	// Getter for flip.
@@ -131,220 +98,151 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Calculate the probability of the samples represented by sample14 using sampled
 	// values.
 	private final void logProbabilityValue$sample14() {
-		// Determine if we need to calculate the values for sample task 14 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample14) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = bias;
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = bias;
 					{
-						{
-							double var9 = 1.0;
-							double var10 = 1.0;
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var9, var10));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var9 = 1.0;
+						double var10 = 1.0;
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var9, var10));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var11 = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$bias = cv$accumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample14 = fixedFlag$sample14;
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$bias;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var11 = cv$rvAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var11 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$bias = cv$accumulator;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				boolean cv$sampleValue = flip;
 				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = flip;
 					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?bias:(1.0 - bias))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?bias:(1.0 - bias))));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$bernoulli = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$flip = cv$accumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = fixedFlag$sample14;
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$flip;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$bernoulli = cv$rvAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$bernoulli = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$flip = cv$accumulator;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -402,8 +300,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void forwardGeneration() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -413,10 +310,8 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -424,8 +319,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void forwardGenerationPrime() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -434,10 +328,8 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -445,10 +337,8 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		}
+		if(Double.isNaN(guard))
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -456,17 +346,13 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void gibbsRound() {
 		// Infer the samples in chronological order.
 		if(system$gibbsForward) {
-			if(Double.isNaN(guard)) {
-				if(!fixedFlag$sample14)
-					sample14();
-			}
+			if(Double.isNaN(guard))
+				sample14();
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			if(Double.isNaN(guard)) {
-				if(!fixedFlag$sample14)
-					sample14();
-			}
+			if(Double.isNaN(guard))
+				sample14();
 		}
 		
 		// Reverse the direction of execution for the next iteration
@@ -489,11 +375,9 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var11 = Double.NaN;
-		if(!fixedProbFlag$sample14)
-			logProbability$bias = Double.NaN;
+		logProbability$bias = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
-		if(!fixedProbFlag$sample16)
-			logProbability$flip = Double.NaN;
+		logProbability$flip = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -503,8 +387,6 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample14)
-			logProbabilityValue$sample14();
 		logProbabilityValue$sample16();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$SingleThreadCPU_optimisedModel.java
@@ -8,9 +8,6 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	
 	// Declare the variables for the model.
 	private double bias;
-	private boolean fixedFlag$sample14 = false;
-	private boolean fixedProbFlag$sample14 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean flip;
 	private boolean flipMeasured;
 	private double guard;
@@ -37,41 +34,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Setter for bias.
 	@Override
 	public final void set$bias(double cv$value) {
-		// Set flags for all the side effects of bias including if probabilities need to be
-		// updated.
 		bias = cv$value;
-		
-		// Unset the fixed probability flag for sample 14 as it depends on bias.
-		fixedProbFlag$sample14 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on bias.
-		fixedProbFlag$sample16 = false;
-	}
-
-	// Getter for fixedFlag$sample14.
-	@Override
-	public final boolean get$fixedFlag$sample14() {
-		return fixedFlag$sample14;
-	}
-
-	// Setter for fixedFlag$sample14.
-	@Override
-	public final void set$fixedFlag$sample14(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample14 including if probabilities
-		// need to be updated.
-		fixedFlag$sample14 = cv$value;
-		
-		// Should the probability of sample 14 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample14" with its value "cv$value".
-		fixedProbFlag$sample14 = (cv$value && fixedProbFlag$sample14);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample14" with its value "cv$value".
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	// Getter for flip.
@@ -137,177 +100,118 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Calculate the probability of the samples represented by sample14 using sampled
 	// values.
 	private final void logProbabilityValue$sample14() {
-		// Determine if we need to calculate the values for sample task 14 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample14) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		if(Double.isNaN(guard)) {
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(bias, 1.0, 1.0);
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
 			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(bias, 1.0, 1.0);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = cv$distributionAccumulator;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var11 = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample14 = cv$distributionAccumulator;
-			}
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$bias = (logProbability$bias + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var11 = cv$distributionAccumulator;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample14 = fixedFlag$sample14;
+			// Store the sample task probability
+			logProbability$sample14 = cv$distributionAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				cv$accumulator = logProbability$sample14;
-				logProbability$var11 = logProbability$sample14;
-			}
-			
-			// Update the variable probability
-			logProbability$bias = (logProbability$bias + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$bias = (logProbability$bias + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		if(Double.isNaN(guard)) {
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = Math.log((flip?bias:(1.0 - bias)));
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
 			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = Math.log((flip?bias:(1.0 - bias)));
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = cv$distributionAccumulator;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$bernoulli = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample16 = cv$distributionAccumulator;
-			}
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$flip = (logProbability$flip + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$bernoulli = cv$distributionAccumulator;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = fixedFlag$sample14;
+			// Store the sample task probability
+			logProbability$sample16 = cv$distributionAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				cv$accumulator = logProbability$sample16;
-				logProbability$bernoulli = logProbability$sample16;
-			}
-			
-			// Update the variable probability
-			logProbability$flip = (logProbability$flip + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$flip = (logProbability$flip + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -350,8 +254,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void forwardGeneration() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -361,7 +264,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
@@ -370,8 +273,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void forwardGenerationPrime() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -380,7 +282,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
@@ -389,7 +291,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
@@ -397,7 +299,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void gibbsRound() {
 		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			sample14();
 		
 		// Reverse the direction of execution for the next iteration
@@ -421,12 +323,10 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$$evidence = 0.0;
 		logProbability$var11 = Double.NaN;
 		logProbability$bias = 0.0;
-		if(!fixedProbFlag$sample14)
-			logProbability$sample14 = Double.NaN;
+		logProbability$sample14 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flip = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -436,8 +336,6 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample14)
-			logProbabilityValue$sample14();
 		logProbabilityValue$sample16();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$SingleThreadCPU_optimisedModelNoComments.java
@@ -6,9 +6,6 @@ import org.sandwood.runtime.model.ExecutionTarget;
 
 class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements Flip1CoinMK16$CoreInterface {
 	private double bias;
-	private boolean fixedFlag$sample14 = false;
-	private boolean fixedProbFlag$sample14 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean flip;
 	private boolean flipMeasured;
 	private double guard;
@@ -34,20 +31,6 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void set$bias(double cv$value) {
 		bias = cv$value;
-		fixedProbFlag$sample14 = false;
-		fixedProbFlag$sample16 = false;
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample14() {
-		return fixedFlag$sample14;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample14(boolean cv$value) {
-		fixedFlag$sample14 = cv$value;
-		fixedProbFlag$sample14 = (cv$value && fixedProbFlag$sample14);
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	@Override
@@ -101,55 +84,28 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	}
 
 	private final void logProbabilityValue$sample14() {
-		if(!fixedProbFlag$sample14) {
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(bias, 1.0, 1.0);
-				cv$accumulator = cv$distributionAccumulator;
-				logProbability$var11 = cv$distributionAccumulator;
-				logProbability$sample14 = cv$distributionAccumulator;
-			}
-			logProbability$bias = (logProbability$bias + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample14 = fixedFlag$sample14;
-		} else {
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				cv$accumulator = logProbability$sample14;
-				logProbability$var11 = logProbability$sample14;
-			}
-			logProbability$bias = (logProbability$bias + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample14)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		if(Double.isNaN(guard)) {
+			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(bias, 1.0, 1.0);
+			cv$accumulator = cv$distributionAccumulator;
+			logProbability$var11 = cv$distributionAccumulator;
+			logProbability$sample14 = cv$distributionAccumulator;
 		}
+		logProbability$bias = (logProbability$bias + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample16() {
-		if(!fixedProbFlag$sample16) {
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				double cv$distributionAccumulator = Math.log((flip?bias:(1.0 - bias)));
-				cv$accumulator = cv$distributionAccumulator;
-				logProbability$bernoulli = cv$distributionAccumulator;
-				logProbability$sample16 = cv$distributionAccumulator;
-			}
-			logProbability$flip = (logProbability$flip + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample16 = fixedFlag$sample14;
-		} else {
-			double cv$accumulator = 0.0;
-			if(Double.isNaN(guard)) {
-				cv$accumulator = logProbability$sample16;
-				logProbability$bernoulli = logProbability$sample16;
-			}
-			logProbability$flip = (logProbability$flip + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		if(Double.isNaN(guard)) {
+			double cv$distributionAccumulator = Math.log((flip?bias:(1.0 - bias)));
+			cv$accumulator = cv$distributionAccumulator;
+			logProbability$bernoulli = cv$distributionAccumulator;
+			logProbability$sample16 = cv$distributionAccumulator;
 		}
+		logProbability$flip = (logProbability$flip + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void sample14() {
@@ -168,42 +124,40 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void forwardGeneration() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
 
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	@Override
 	public final void forwardGenerationPrime() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
 	@Override
 	public final void gibbsRound() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			sample14();
 		system$gibbsForward = !system$gibbsForward;
 	}
@@ -216,19 +170,15 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$$evidence = 0.0;
 		logProbability$var11 = Double.NaN;
 		logProbability$bias = 0.0;
-		if(!fixedProbFlag$sample14)
-			logProbability$sample14 = Double.NaN;
+		logProbability$sample14 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flip = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	@Override
 	public final void logEvidenceProbabilities() {
 		initializeLogProbabilityFields();
-		if(fixedFlag$sample14)
-			logProbabilityValue$sample14();
 		logProbabilityValue$sample16();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16$SingleThreadCPU_optimisedModelSingle.java
@@ -8,9 +8,6 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	
 	// Declare the variables for the model.
 	private double bias;
-	private boolean fixedFlag$sample14 = false;
-	private boolean fixedProbFlag$sample14 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean flip;
 	private boolean flipMeasured;
 	private double guard;
@@ -35,41 +32,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Setter for bias.
 	@Override
 	public final void set$bias(double cv$value) {
-		// Set flags for all the side effects of bias including if probabilities need to be
-		// updated.
 		bias = cv$value;
-		
-		// Unset the fixed probability flag for sample 14 as it depends on bias.
-		fixedProbFlag$sample14 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on bias.
-		fixedProbFlag$sample16 = false;
-	}
-
-	// Getter for fixedFlag$sample14.
-	@Override
-	public final boolean get$fixedFlag$sample14() {
-		return fixedFlag$sample14;
-	}
-
-	// Setter for fixedFlag$sample14.
-	@Override
-	public final void set$fixedFlag$sample14(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample14 including if probabilities
-		// need to be updated.
-		fixedFlag$sample14 = cv$value;
-		
-		// Should the probability of sample 14 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample14" with its value "cv$value".
-		fixedProbFlag$sample14 = (cv$value && fixedProbFlag$sample14);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample14" with its value "cv$value".
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	// Getter for flip.
@@ -135,185 +98,117 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Calculate the probability of the samples represented by sample14 using sampled
 	// values.
 	private final void logProbabilityValue$sample14() {
-		// Determine if we need to calculate the values for sample task 14 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample14) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
 			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			cv$sampleAccumulator = DistributionSampling.logProbabilityBeta(bias, 1.0, 1.0);
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var11 = cv$sampleAccumulator;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = DistributionSampling.logProbabilityBeta(bias, 1.0, 1.0);
-			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var11 = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$bias = cv$sampleAccumulator;
-			}
-			
-			// Add probability to model
+			// Store the random variable instance probability
 			// 
 			// Add the probability of this instance of the random variable to the probability
 			// of all instances of the random variable.
 			// 
 			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample14 = fixedFlag$sample14;
+			logProbability$bias = cv$sampleAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$var11 = logProbability$bias;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$bias);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample14)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$bias);
-		}
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(Double.isNaN(guard)) {
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
 			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			cv$sampleAccumulator = Math.log((flip?bias:(1.0 - bias)));
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$bernoulli = cv$sampleAccumulator;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard)) {
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = Math.log((flip?bias:(1.0 - bias)));
-			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$bernoulli = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$flip = cv$sampleAccumulator;
-			}
-			
-			// Add probability to model
+			// Store the random variable instance probability
 			// 
 			// Add the probability of this instance of the random variable to the probability
 			// of all instances of the random variable.
 			// 
 			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = fixedFlag$sample14;
+			logProbability$flip = cv$sampleAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(Double.isNaN(guard))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$bernoulli = logProbability$flip;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$flip);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$flip);
-		}
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -356,8 +251,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void forwardGeneration() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -367,7 +261,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
@@ -376,8 +270,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void forwardGenerationPrime() {
 		if(Double.isNaN(guard)) {
-			if(!fixedFlag$sample14)
-				bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
+			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 			flip = DistributionSampling.sampleBernoulli(RNG$, bias);
 		}
 	}
@@ -386,7 +279,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
@@ -395,7 +288,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
 	}
 
@@ -403,7 +296,7 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void gibbsRound() {
 		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if((Double.isNaN(guard) && !fixedFlag$sample14))
+		if(Double.isNaN(guard))
 			sample14();
 		
 		// Reverse the direction of execution for the next iteration
@@ -426,11 +319,9 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var11 = Double.NaN;
-		if(!fixedProbFlag$sample14)
-			logProbability$bias = Double.NaN;
+		logProbability$bias = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
-		if(!fixedProbFlag$sample16)
-			logProbability$flip = Double.NaN;
+		logProbability$flip = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -440,8 +331,6 @@ class Flip1CoinMK16$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample14)
-			logProbabilityValue$sample14();
 		logProbabilityValue$sample16();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -32,17 +33,12 @@ public class Flip1CoinMK16 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample14(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample14())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -68,7 +64,7 @@ public class Flip1CoinMK16 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -192,9 +188,6 @@ public class Flip1CoinMK16 extends Model {
         //ComputedVariables
         if($bias.isSet())
             newCore.set$bias(oldCore.get$bias());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample14(oldCore.get$fixedFlag$sample14());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -32,17 +33,12 @@ public class Flip1CoinMK16 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample14(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample14())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -68,7 +64,7 @@ public class Flip1CoinMK16 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -192,9 +188,6 @@ public class Flip1CoinMK16 extends Model {
         //ComputedVariables
         if($bias.isSet())
             newCore.set$bias(oldCore.get$bias());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample14(oldCore.get$fixedFlag$sample14());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -32,17 +33,12 @@ public class Flip1CoinMK16 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample14(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample14())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -68,7 +64,7 @@ public class Flip1CoinMK16 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -192,9 +188,6 @@ public class Flip1CoinMK16 extends Model {
         //ComputedVariables
         if($bias.isSet())
             newCore.set$bias(oldCore.get$bias());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample14(oldCore.get$fixedFlag$sample14());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -32,17 +33,12 @@ public class Flip1CoinMK16 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample14(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample14())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -68,7 +64,7 @@ public class Flip1CoinMK16 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -192,9 +188,6 @@ public class Flip1CoinMK16 extends Model {
         //ComputedVariables
         if($bias.isSet())
             newCore.set$bias(oldCore.get$bias());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample14(oldCore.get$fixedFlag$sample14());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -32,17 +33,12 @@ public class Flip1CoinMK16 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample14(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample14())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -68,7 +64,7 @@ public class Flip1CoinMK16 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -192,9 +188,6 @@ public class Flip1CoinMK16 extends Model {
         //ComputedVariables
         if($bias.isSet())
             newCore.set$bias(oldCore.get$bias());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample14(oldCore.get$fixedFlag$sample14());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK16/Flip1CoinMK16_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -32,17 +33,12 @@ public class Flip1CoinMK16 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample14(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample14())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -68,7 +64,7 @@ public class Flip1CoinMK16 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -192,9 +188,6 @@ public class Flip1CoinMK16 extends Model {
         //ComputedVariables
         if($bias.isSet())
             newCore.set$bias(oldCore.get$bias());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample14(oldCore.get$fixedFlag$sample14());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK17/Flip1CoinMK17_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK17/Flip1CoinMK17_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK17 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK17/Flip1CoinMK17_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK17/Flip1CoinMK17_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK17 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK17/Flip1CoinMK17_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK17/Flip1CoinMK17_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK17 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK17/Flip1CoinMK17_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK17/Flip1CoinMK17_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK17 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK17/Flip1CoinMK17_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK17/Flip1CoinMK17_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK17 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK17/Flip1CoinMK17_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK17/Flip1CoinMK17_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK17 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK18/Flip1CoinMK18_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK18/Flip1CoinMK18_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Flip1CoinMK18 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK18/Flip1CoinMK18_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK18/Flip1CoinMK18_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Flip1CoinMK18 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK18/Flip1CoinMK18_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK18/Flip1CoinMK18_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Flip1CoinMK18 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK18/Flip1CoinMK18_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK18/Flip1CoinMK18_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Flip1CoinMK18 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK18/Flip1CoinMK18_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK18/Flip1CoinMK18_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Flip1CoinMK18 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK18/Flip1CoinMK18_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK18/Flip1CoinMK18_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Flip1CoinMK18 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Flip1CoinMK19 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Flip1CoinMK19 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Flip1CoinMK19 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Flip1CoinMK19 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Flip1CoinMK19 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK19/Flip1CoinMK19_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Flip1CoinMK19 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1b/Flip1CoinMK1b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1b/Flip1CoinMK1b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1b/Flip1CoinMK1b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1b/Flip1CoinMK1b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1b/Flip1CoinMK1b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1b/Flip1CoinMK1b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1b/Flip1CoinMK1b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1b/Flip1CoinMK1b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1b/Flip1CoinMK1b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1b/Flip1CoinMK1b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1b/Flip1CoinMK1b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1b/Flip1CoinMK1b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$CoreInterface_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$CoreInterface_model.java
@@ -14,12 +14,6 @@ interface Flip1CoinMK1c$CoreInterface extends org.sandwood.runtime.internal.mode
 	// Setter for b.
 	public void set$b(double cv$value);
 
-	// Getter for fixedFlag$sample6.
-	public boolean get$fixedFlag$sample6();
-
-	// Setter for fixedFlag$sample6.
-	public void set$fixedFlag$sample6(boolean cv$value);
-
 	// Getter for flips.
 	public boolean[] get$flips();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$CoreInterface_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$CoreInterface_modelNoComments.java
@@ -5,8 +5,6 @@ interface Flip1CoinMK1c$CoreInterface extends org.sandwood.runtime.internal.mode
 	public void set$a(double cv$value);
 	public double get$b();
 	public void set$b(double cv$value);
-	public boolean get$fixedFlag$sample6();
-	public void set$fixedFlag$sample6(boolean cv$value);
 	public boolean[] get$flips();
 	public boolean[] get$flipsMeasured();
 	public void set$flipsMeasured(boolean[] cv$value);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$CoreInterface_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$CoreInterface_modelSingle.java
@@ -14,12 +14,6 @@ interface Flip1CoinMK1c$CoreInterface extends org.sandwood.runtime.internal.mode
 	// Setter for b.
 	public void set$b(double cv$value);
 
-	// Getter for fixedFlag$sample6.
-	public boolean get$fixedFlag$sample6();
-
-	// Setter for fixedFlag$sample6.
-	public void set$fixedFlag$sample6(boolean cv$value);
-
 	// Getter for flips.
 	public boolean[] get$flips();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$CoreInterface_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$CoreInterface_optimisedModel.java
@@ -14,12 +14,6 @@ interface Flip1CoinMK1c$CoreInterface extends org.sandwood.runtime.internal.mode
 	// Setter for b.
 	public void set$b(double cv$value);
 
-	// Getter for fixedFlag$sample6.
-	public boolean get$fixedFlag$sample6();
-
-	// Setter for fixedFlag$sample6.
-	public void set$fixedFlag$sample6(boolean cv$value);
-
 	// Getter for flips.
 	public boolean[] get$flips();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$CoreInterface_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$CoreInterface_optimisedModelNoComments.java
@@ -5,8 +5,6 @@ interface Flip1CoinMK1c$CoreInterface extends org.sandwood.runtime.internal.mode
 	public void set$a(double cv$value);
 	public double get$b();
 	public void set$b(double cv$value);
-	public boolean get$fixedFlag$sample6();
-	public void set$fixedFlag$sample6(boolean cv$value);
 	public boolean[] get$flips();
 	public boolean[] get$flipsMeasured();
 	public void set$flipsMeasured(boolean[] cv$value);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$CoreInterface_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$CoreInterface_optimisedModelSingle.java
@@ -14,12 +14,6 @@ interface Flip1CoinMK1c$CoreInterface extends org.sandwood.runtime.internal.mode
 	// Setter for b.
 	public void set$b(double cv$value);
 
-	// Getter for fixedFlag$sample6.
-	public boolean get$fixedFlag$sample6();
-
-	// Setter for fixedFlag$sample6.
-	public void set$fixedFlag$sample6(boolean cv$value);
-
 	// Getter for flips.
 	public boolean[] get$flips();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$MultiThreadCPU_model.java
@@ -9,9 +9,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Declare the variables for the model.
 	private double a;
 	private double b;
-	private boolean fixedFlag$sample6 = false;
-	private boolean fixedProbFlag$sample19 = false;
-	private boolean fixedProbFlag$sample6 = false;
 	private boolean[] flips;
 	private boolean[] flipsMeasured;
 	private int length$flipsMeasured;
@@ -52,28 +49,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$b(double cv$value) {
 		b = cv$value;
-	}
-
-	// Getter for fixedFlag$sample6.
-	@Override
-	public final boolean get$fixedFlag$sample6() {
-		return fixedFlag$sample6;
-	}
-
-	// Setter for fixedFlag$sample6.
-	@Override
-	public final void set$fixedFlag$sample6(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample6 including if probabilities
-		// need to be updated.
-		fixedFlag$sample6 = cv$value;
-		
-		// Should the probability of sample 6 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample6 = (fixedFlag$sample6 && fixedProbFlag$sample6);
-		
-		// Should the probability of sample 19 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample19 = (fixedFlag$sample6 && fixedProbFlag$sample19);
 	}
 
 	// Getter for flips.
@@ -146,134 +121,22 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for var6.
 	@Override
 	public final void set$var6(double cv$value) {
-		// Set flags for all the side effects of var6 including if probabilities need to be
-		// updated.
 		var6 = cv$value;
-		
-		// Unset the fixed probability flag for sample 6 as it depends on var6.
-		fixedProbFlag$sample6 = false;
-		
-		// Unset the fixed probability flag for sample 19 as it depends on var6.
-		fixedProbFlag$sample19 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample19 using sampled
 	// values.
 	private final void logProbabilityValue$sample19() {
-		// Determine if we need to calculate the values for sample task 19 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample19) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
-				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = flips[var18];
-					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var6:(1.0 - var6))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
-						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-			}
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$bernoulli = cv$sampleAccumulator;
-			
-			// Store the random variable instance probability
-			logProbability$var19 = cv$sampleAccumulator;
-			
-			// Update the variable probability
-			logProbability$flips = (logProbability$flips + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample19 = fixedFlag$sample6;
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var19;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$bernoulli = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$flips = (logProbability$flips + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
-	}
-
-	// Calculate the probability of the samples represented by sample6 using sampled values.
-	private final void logProbabilityValue$sample6() {
-		// Determine if we need to calculate the values for sample task 6 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample6) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int var18 = 0; var18 < samples; var18 += 1) {
 			// An accumulator for log probabilities.
 			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
@@ -281,11 +144,11 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			double cv$probabilityReached = 0.0;
 			{
 				// The sample value to calculate the probability of generating
-				double cv$sampleValue = var6;
+				boolean cv$sampleValue = flips[var18];
 				{
 					{
 						// Store the value of the function call, so the function call is only made once.
-						double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, a, b));
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var6:(1.0 - var6))));
 						
 						// Add the probability of this sample task to the distribution accumulator.
 						if((cv$weightedProbability < cv$distributionAccumulator))
@@ -311,48 +174,88 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
 			double cv$sampleProbability = cv$distributionAccumulator;
 			
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
 			// Add the probability of this sample task to the sample task accumulator.
 			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$var5 = cv$sampleAccumulator;
-			
-			// Store the sample task probability
-			logProbability$var6 = cv$sampleProbability;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample6 = fixedFlag$sample6;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			double cv$sampleValue = logProbability$var6;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$var5 = cv$rvAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$bernoulli = cv$sampleAccumulator;
+		
+		// Store the random variable instance probability
+		logProbability$var19 = cv$sampleAccumulator;
+		
+		// Update the variable probability
+		logProbability$flips = (logProbability$flips + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+	}
+
+	// Calculate the probability of the samples represented by sample6 using sampled values.
+	private final void logProbabilityValue$sample6() {
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// An accumulator for log probabilities.
+		double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+		
+		// An accumulator for the distributed probability space covered.
+		double cv$probabilityReached = 0.0;
+		{
+			// The sample value to calculate the probability of generating
+			double cv$sampleValue = var6;
+			{
+				{
+					// Store the value of the function call, so the function call is only made once.
+					double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, a, b));
+					
+					// Add the probability of this sample task to the distribution accumulator.
+					if((cv$weightedProbability < cv$distributionAccumulator))
+						cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+					else {
+						// If the second value is -infinity.
+						if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+							cv$distributionAccumulator = cv$weightedProbability;
+						else
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+					}
+					
+					// Add the probability of this distribution configuration to the accumulator.
+					cv$probabilityReached = (cv$probabilityReached + 1.0);
+				}
+			}
 		}
+		if((cv$probabilityReached == 0.0))
+			// Return negative infinity if no distribution probability space is reached.
+			cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+		else
+			// Scale the probability relative to the observed distribution space.
+			cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+		double cv$sampleProbability = cv$distributionAccumulator;
+		
+		// Add the probability of this sample task to the sample task accumulator.
+		cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$var5 = cv$sampleAccumulator;
+		
+		// Store the sample task probability
+		logProbability$var6 = cv$sampleProbability;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -405,8 +308,7 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Method to execute the model code conventionally.
 	@Override
 	public final void forwardGeneration() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, samples, 1,
@@ -425,16 +327,14 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
 	// variables.
 	@Override
 	public final void forwardGenerationPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, samples, 1,
@@ -452,8 +352,7 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -461,23 +360,18 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute one round of Gibbs sampling.
 	@Override
 	public final void gibbsRound() {
 		// Infer the samples in chronological order.
-		if(system$gibbsForward) {
-			if(!fixedFlag$sample6)
-				sample6();
-		}
+		if(system$gibbsForward)
+			sample6();
 		// Infer the samples in reverse chronological order.
-		else {
-			if(!fixedFlag$sample6)
-				sample6();
-		}
+		else
+			sample6();
 		
 		// Reverse the direction of execution for the next iteration
 		system$gibbsForward = !system$gibbsForward;
@@ -501,12 +395,10 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var5 = 0.0;
-		if(!fixedProbFlag$sample6)
-			logProbability$var6 = Double.NaN;
+		logProbability$var6 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flips = 0.0;
-		if(!fixedProbFlag$sample19)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -516,8 +408,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample6)
-			logProbabilityValue$sample6();
 		logProbabilityValue$sample19();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$MultiThreadCPU_modelNoComments.java
@@ -7,9 +7,6 @@ import org.sandwood.runtime.model.ExecutionTarget;
 class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements Flip1CoinMK1c$CoreInterface {
 	private double a;
 	private double b;
-	private boolean fixedFlag$sample6 = false;
-	private boolean fixedProbFlag$sample19 = false;
-	private boolean fixedProbFlag$sample6 = false;
 	private boolean[] flips;
 	private boolean[] flipsMeasured;
 	private int length$flipsMeasured;
@@ -46,18 +43,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$b(double cv$value) {
 		b = cv$value;
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample6() {
-		return fixedFlag$sample6;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample6(boolean cv$value) {
-		fixedFlag$sample6 = cv$value;
-		fixedProbFlag$sample6 = (fixedFlag$sample6 && fixedProbFlag$sample6);
-		fixedProbFlag$sample19 = (fixedFlag$sample6 && fixedProbFlag$sample19);
 	}
 
 	@Override
@@ -118,77 +103,20 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$var6(double cv$value) {
 		var6 = cv$value;
-		fixedProbFlag$sample6 = false;
-		fixedProbFlag$sample19 = false;
 	}
 
 	private final void logProbabilityValue$sample19() {
-		if(!fixedProbFlag$sample19) {
-			double cv$accumulator = 0.0;
-			double cv$sampleAccumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1) {
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
-				{
-					boolean cv$sampleValue = flips[var18];
-					{
-						{
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var6:(1.0 - var6))));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
-						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-			}
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$bernoulli = cv$sampleAccumulator;
-			logProbability$var19 = cv$sampleAccumulator;
-			logProbability$flips = (logProbability$flips + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample19 = fixedFlag$sample6;
-		} else {
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1)
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var19;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$bernoulli = cv$rvAccumulator;
-			logProbability$flips = (logProbability$flips + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
-	}
-
-	private final void logProbabilityValue$sample6() {
-		if(!fixedProbFlag$sample6) {
-			double cv$accumulator = 0.0;
-			double cv$sampleAccumulator = 0.0;
+		double cv$accumulator = 0.0;
+		double cv$sampleAccumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int var18 = 0; var18 < samples; var18 += 1) {
 			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			double cv$probabilityReached = 0.0;
 			{
-				double cv$sampleValue = var6;
+				boolean cv$sampleValue = flips[var18];
 				{
 					{
-						double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, a, b));
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var6:(1.0 - var6))));
 						if((cv$weightedProbability < cv$distributionAccumulator))
 							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
 						else {
@@ -206,25 +134,49 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			else
 				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
 			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
 			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$var5 = cv$sampleAccumulator;
-			logProbability$var6 = cv$sampleProbability;
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample6 = fixedFlag$sample6;
-		} else {
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			double cv$sampleValue = logProbability$var6;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$var5 = cv$rvAccumulator;
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$bernoulli = cv$sampleAccumulator;
+		logProbability$var19 = cv$sampleAccumulator;
+		logProbability$flips = (logProbability$flips + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+	}
+
+	private final void logProbabilityValue$sample6() {
+		double cv$accumulator = 0.0;
+		double cv$sampleAccumulator = 0.0;
+		double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+		double cv$probabilityReached = 0.0;
+		{
+			double cv$sampleValue = var6;
+			{
+				{
+					double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, a, b));
+					if((cv$weightedProbability < cv$distributionAccumulator))
+						cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+					else {
+						if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+							cv$distributionAccumulator = cv$weightedProbability;
+						else
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+					}
+					cv$probabilityReached = (cv$probabilityReached + 1.0);
+				}
+			}
+		}
+		if((cv$probabilityReached == 0.0))
+			cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+		else
+			cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+		double cv$sampleProbability = cv$distributionAccumulator;
+		cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$var5 = cv$sampleAccumulator;
+		logProbability$var6 = cv$sampleProbability;
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void sample6() {
@@ -258,8 +210,7 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	@Override
 	public final void forwardGeneration() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		parallelFor(RNG$, 0, samples, 1,
 			(int forStart$var18, int forEnd$var18, int threadID$var18, org.sandwood.random.internal.Rng RNG$1) -> { 
 				for(int var18 = forStart$var18; var18 < forEnd$var18; var18 += 1)
@@ -270,14 +221,12 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	@Override
 	public final void forwardGenerationPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		parallelFor(RNG$, 0, samples, 1,
 			(int forStart$var18, int forEnd$var18, int threadID$var18, org.sandwood.random.internal.Rng RNG$1) -> { 
 				for(int var18 = forStart$var18; var18 < forEnd$var18; var18 += 1)
@@ -288,25 +237,20 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	@Override
 	public final void gibbsRound() {
-		if(system$gibbsForward) {
-			if(!fixedFlag$sample6)
-				sample6();
-		} else {
-			if(!fixedFlag$sample6)
-				sample6();
-		}
+		if(system$gibbsForward)
+			sample6();
+		else
+			sample6();
 		system$gibbsForward = !system$gibbsForward;
 	}
 
@@ -319,19 +263,15 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var5 = 0.0;
-		if(!fixedProbFlag$sample6)
-			logProbability$var6 = Double.NaN;
+		logProbability$var6 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flips = 0.0;
-		if(!fixedProbFlag$sample19)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	@Override
 	public final void logEvidenceProbabilities() {
 		initializeLogProbabilityFields();
-		if(fixedFlag$sample6)
-			logProbabilityValue$sample6();
 		logProbabilityValue$sample19();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$MultiThreadCPU_modelSingle.java
@@ -9,9 +9,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Declare the variables for the model.
 	private double a;
 	private double b;
-	private boolean fixedFlag$sample6 = false;
-	private boolean fixedProbFlag$sample19 = false;
-	private boolean fixedProbFlag$sample6 = false;
 	private boolean[] flips;
 	private boolean[] flipsMeasured;
 	private int length$flipsMeasured;
@@ -52,28 +49,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$b(double cv$value) {
 		b = cv$value;
-	}
-
-	// Getter for fixedFlag$sample6.
-	@Override
-	public final boolean get$fixedFlag$sample6() {
-		return fixedFlag$sample6;
-	}
-
-	// Setter for fixedFlag$sample6.
-	@Override
-	public final void set$fixedFlag$sample6(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample6 including if probabilities
-		// need to be updated.
-		fixedFlag$sample6 = cv$value;
-		
-		// Should the probability of sample 6 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample6 = (fixedFlag$sample6 && fixedProbFlag$sample6);
-		
-		// Should the probability of sample 19 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample19 = (fixedFlag$sample6 && fixedProbFlag$sample19);
 	}
 
 	// Getter for flips.
@@ -146,139 +121,22 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for var6.
 	@Override
 	public final void set$var6(double cv$value) {
-		// Set flags for all the side effects of var6 including if probabilities need to be
-		// updated.
 		var6 = cv$value;
-		
-		// Unset the fixed probability flag for sample 6 as it depends on var6.
-		fixedProbFlag$sample6 = false;
-		
-		// Unset the fixed probability flag for sample 19 as it depends on var6.
-		fixedProbFlag$sample19 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample19 using sampled
 	// values.
 	private final void logProbabilityValue$sample19() {
-		// Determine if we need to calculate the values for sample task 19 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample19) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
-				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = flips[var18];
-					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var6:(1.0 - var6))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
-						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-			}
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$bernoulli = cv$sampleAccumulator;
-			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$var19 = cv$sampleAccumulator;
-			
-			// Update the variable probability
-			logProbability$flips = (logProbability$flips + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample19 = fixedFlag$sample6;
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var19;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$bernoulli = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$flips = (logProbability$flips + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
-	}
-
-	// Calculate the probability of the samples represented by sample6 using sampled values.
-	private final void logProbabilityValue$sample6() {
-		// Determine if we need to calculate the values for sample task 6 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample6) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int var18 = 0; var18 < samples; var18 += 1) {
 			// An accumulator for log probabilities.
 			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
@@ -286,11 +144,11 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			double cv$probabilityReached = 0.0;
 			{
 				// The sample value to calculate the probability of generating
-				double cv$sampleValue = var6;
+				boolean cv$sampleValue = flips[var18];
 				{
 					{
 						// Store the value of the function call, so the function call is only made once.
-						double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, a, b));
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var6:(1.0 - var6))));
 						
 						// Add the probability of this sample task to the distribution accumulator.
 						if((cv$weightedProbability < cv$distributionAccumulator))
@@ -316,48 +174,92 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
 			double cv$sampleProbability = cv$distributionAccumulator;
 			
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
 			// Add the probability of this sample task to the sample task accumulator.
 			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$var5 = cv$sampleAccumulator;
-			
-			// Store the sample task probability
-			logProbability$var6 = cv$sampleProbability;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample6 = fixedFlag$sample6;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			double cv$sampleValue = logProbability$var6;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$var5 = cv$rvAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$bernoulli = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$var19 = cv$sampleAccumulator;
+		
+		// Update the variable probability
+		logProbability$flips = (logProbability$flips + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+	}
+
+	// Calculate the probability of the samples represented by sample6 using sampled values.
+	private final void logProbabilityValue$sample6() {
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// An accumulator for log probabilities.
+		double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+		
+		// An accumulator for the distributed probability space covered.
+		double cv$probabilityReached = 0.0;
+		{
+			// The sample value to calculate the probability of generating
+			double cv$sampleValue = var6;
+			{
+				{
+					// Store the value of the function call, so the function call is only made once.
+					double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, a, b));
+					
+					// Add the probability of this sample task to the distribution accumulator.
+					if((cv$weightedProbability < cv$distributionAccumulator))
+						cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+					else {
+						// If the second value is -infinity.
+						if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+							cv$distributionAccumulator = cv$weightedProbability;
+						else
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+					}
+					
+					// Add the probability of this distribution configuration to the accumulator.
+					cv$probabilityReached = (cv$probabilityReached + 1.0);
+				}
+			}
 		}
+		if((cv$probabilityReached == 0.0))
+			// Return negative infinity if no distribution probability space is reached.
+			cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+		else
+			// Scale the probability relative to the observed distribution space.
+			cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+		double cv$sampleProbability = cv$distributionAccumulator;
+		
+		// Add the probability of this sample task to the sample task accumulator.
+		cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$var5 = cv$sampleAccumulator;
+		
+		// Store the sample task probability
+		logProbability$var6 = cv$sampleProbability;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -410,8 +312,7 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Method to execute the model code conventionally.
 	@Override
 	public final void forwardGeneration() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, samples, 1,
@@ -430,16 +331,14 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
 	// variables.
 	@Override
 	public final void forwardGenerationPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, samples, 1,
@@ -457,8 +356,7 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -466,23 +364,18 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute one round of Gibbs sampling.
 	@Override
 	public final void gibbsRound() {
 		// Infer the samples in chronological order.
-		if(system$gibbsForward) {
-			if(!fixedFlag$sample6)
-				sample6();
-		}
+		if(system$gibbsForward)
+			sample6();
 		// Infer the samples in reverse chronological order.
-		else {
-			if(!fixedFlag$sample6)
-				sample6();
-		}
+		else
+			sample6();
 		
 		// Reverse the direction of execution for the next iteration
 		system$gibbsForward = !system$gibbsForward;
@@ -506,12 +399,10 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var5 = 0.0;
-		if(!fixedProbFlag$sample6)
-			logProbability$var6 = Double.NaN;
+		logProbability$var6 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flips = 0.0;
-		if(!fixedProbFlag$sample19)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -521,8 +412,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample6)
-			logProbabilityValue$sample6();
 		logProbabilityValue$sample19();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$MultiThreadCPU_optimisedModel.java
@@ -9,9 +9,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Declare the variables for the model.
 	private double a;
 	private double b;
-	private boolean fixedFlag$sample6 = false;
-	private boolean fixedProbFlag$sample19 = false;
-	private boolean fixedProbFlag$sample6 = false;
 	private boolean[] flips;
 	private boolean[] flipsMeasured;
 	private int length$flipsMeasured;
@@ -52,32 +49,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$b(double cv$value) {
 		b = cv$value;
-	}
-
-	// Getter for fixedFlag$sample6.
-	@Override
-	public final boolean get$fixedFlag$sample6() {
-		return fixedFlag$sample6;
-	}
-
-	// Setter for fixedFlag$sample6.
-	@Override
-	public final void set$fixedFlag$sample6(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample6 including if probabilities
-		// need to be updated.
-		fixedFlag$sample6 = cv$value;
-		
-		// Should the probability of sample 6 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample6" with its value "cv$value".
-		fixedProbFlag$sample6 = (cv$value && fixedProbFlag$sample6);
-		
-		// Should the probability of sample 19 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample6" with its value "cv$value".
-		fixedProbFlag$sample19 = (cv$value && fixedProbFlag$sample19);
 	}
 
 	// Getter for flips.
@@ -150,110 +121,17 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for var6.
 	@Override
 	public final void set$var6(double cv$value) {
-		// Set flags for all the side effects of var6 including if probabilities need to be
-		// updated.
 		var6 = cv$value;
-		
-		// Unset the fixed probability flag for sample 6 as it depends on var6.
-		fixedProbFlag$sample6 = false;
-		
-		// Unset the fixed probability flag for sample 19 as it depends on var6.
-		fixedProbFlag$sample19 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample19 using sampled
 	// values.
 	private final void logProbabilityValue$sample19() {
-		// Determine if we need to calculate the values for sample task 19 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample19) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			for(int var18 = 0; var18 < samples; var18 += 1)
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((flips[var18]?var6:(1.0 - var6))));
-			logProbability$bernoulli = cv$sampleAccumulator;
-			
-			// Store the random variable instance probability
-			logProbability$var19 = cv$sampleAccumulator;
-			
-			// Update the variable probability
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$flips = (logProbability$flips + cv$sampleAccumulator);
-			
-			// Add probability to model
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample19 = fixedFlag$sample6;
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			logProbability$bernoulli = logProbability$var19;
-			
-			// Update the variable probability
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$flips = (logProbability$flips + logProbability$var19);
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var19);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var19);
-		}
-	}
-
-	// Calculate the probability of the samples represented by sample6 using sampled values.
-	private final void logProbabilityValue$sample6() {
-		// Determine if we need to calculate the values for sample task 6 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample6) {
-			// Generating probabilities for sample task
-			// Variable declaration of cv$distributionAccumulator moved.
-			// Declaration comment was:
-			// Variable declaration of cv$distributionAccumulator moved.
-			// Declaration comment was:
-			// An accumulator for log probabilities.
-			// 
-			// Store the value of the function call, so the function call is only made once.
-			// 
-			// The sample value to calculate the probability of generating
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		for(int var18 = 0; var18 < samples; var18 += 1)
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
 			// Scale the probability relative to the observed distribution space.
 			// 
@@ -268,70 +146,86 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Store the value of the function call, so the function call is only made once.
 			// 
 			// The sample value to calculate the probability of generating
-			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(var6, a, b);
-			
-			// Add the probability of this sample task to the sample task accumulator.
-			// 
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			logProbability$var5 = cv$distributionAccumulator;
-			
-			// Store the sample task probability
-			logProbability$var6 = cv$distributionAccumulator;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			// Declaration comment was:
-			// Accumulator for probabilities of instances of the random variable
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			// 
-			// Add the probability of this sample task to the sample task accumulator.
-			// 
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				// Variable declaration of cv$accumulator moved.
-				// Declaration comment was:
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$$evidence = (logProbability$$evidence + cv$distributionAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample6 = fixedFlag$sample6;
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			logProbability$var5 = logProbability$var6;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var6);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$var6);
-		}
+			cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((flips[var18]?var6:(1.0 - var6))));
+		logProbability$bernoulli = cv$sampleAccumulator;
+		
+		// Store the random variable instance probability
+		logProbability$var19 = cv$sampleAccumulator;
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$flips = (logProbability$flips + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+	}
+
+	// Calculate the probability of the samples represented by sample6 using sampled values.
+	private final void logProbabilityValue$sample6() {
+		// Generating probabilities for sample task
+		// Variable declaration of cv$distributionAccumulator moved.
+		// Declaration comment was:
+		// Variable declaration of cv$distributionAccumulator moved.
+		// Declaration comment was:
+		// An accumulator for log probabilities.
+		// 
+		// Store the value of the function call, so the function call is only made once.
+		// 
+		// The sample value to calculate the probability of generating
+		// 
+		// Scale the probability relative to the observed distribution space.
+		// 
+		// Add the probability of this distribution configuration to the accumulator.
+		// 
+		// An accumulator for the distributed probability space covered.
+		// 
+		// Variable declaration of cv$distributionAccumulator moved.
+		// Declaration comment was:
+		// An accumulator for log probabilities.
+		// 
+		// Store the value of the function call, so the function call is only made once.
+		// 
+		// The sample value to calculate the probability of generating
+		double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(var6, a, b);
+		
+		// Add the probability of this sample task to the sample task accumulator.
+		// 
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		logProbability$var5 = cv$distributionAccumulator;
+		
+		// Store the sample task probability
+		logProbability$var6 = cv$distributionAccumulator;
+		
+		// Add probability to model
+		// 
+		// Variable declaration of cv$accumulator moved.
+		// Declaration comment was:
+		// Accumulator for probabilities of instances of the random variable
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		// 
+		// Add the probability of this sample task to the sample task accumulator.
+		// 
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -377,8 +271,7 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Method to execute the model code conventionally.
 	@Override
 	public final void forwardGeneration() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, samples, 1,
@@ -397,16 +290,14 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
 	// variables.
 	@Override
 	public final void forwardGenerationPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, samples, 1,
@@ -424,8 +315,7 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -433,16 +323,13 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute one round of Gibbs sampling.
 	@Override
 	public final void gibbsRound() {
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample6)
-			sample6();
+		sample6();
 		
 		// Reverse the direction of execution for the next iteration
 		system$gibbsForward = !system$gibbsForward;
@@ -466,12 +353,10 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var5 = 0.0;
-		if(!fixedProbFlag$sample6)
-			logProbability$var6 = Double.NaN;
+		logProbability$var6 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flips = 0.0;
-		if(!fixedProbFlag$sample19)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -481,8 +366,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample6)
-			logProbabilityValue$sample6();
 		logProbabilityValue$sample19();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$MultiThreadCPU_optimisedModelNoComments.java
@@ -7,9 +7,6 @@ import org.sandwood.runtime.model.ExecutionTarget;
 class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements Flip1CoinMK1c$CoreInterface {
 	private double a;
 	private double b;
-	private boolean fixedFlag$sample6 = false;
-	private boolean fixedProbFlag$sample19 = false;
-	private boolean fixedProbFlag$sample6 = false;
 	private boolean[] flips;
 	private boolean[] flipsMeasured;
 	private int length$flipsMeasured;
@@ -46,18 +43,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$b(double cv$value) {
 		b = cv$value;
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample6() {
-		return fixedFlag$sample6;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample6(boolean cv$value) {
-		fixedFlag$sample6 = cv$value;
-		fixedProbFlag$sample6 = (cv$value && fixedProbFlag$sample6);
-		fixedProbFlag$sample19 = (cv$value && fixedProbFlag$sample19);
 	}
 
 	@Override
@@ -118,44 +103,24 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$var6(double cv$value) {
 		var6 = cv$value;
-		fixedProbFlag$sample6 = false;
-		fixedProbFlag$sample19 = false;
 	}
 
 	private final void logProbabilityValue$sample19() {
-		if(!fixedProbFlag$sample19) {
-			double cv$sampleAccumulator = 0.0;
-			for(int var18 = 0; var18 < samples; var18 += 1)
-				cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((flips[var18]?var6:(1.0 - var6))));
-			logProbability$bernoulli = cv$sampleAccumulator;
-			logProbability$var19 = cv$sampleAccumulator;
-			logProbability$flips = (logProbability$flips + cv$sampleAccumulator);
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			fixedProbFlag$sample19 = fixedFlag$sample6;
-		} else {
-			logProbability$bernoulli = logProbability$var19;
-			logProbability$flips = (logProbability$flips + logProbability$var19);
-			logProbability$$model = (logProbability$$model + logProbability$var19);
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var19);
-		}
+		double cv$sampleAccumulator = 0.0;
+		for(int var18 = 0; var18 < samples; var18 += 1)
+			cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((flips[var18]?var6:(1.0 - var6))));
+		logProbability$bernoulli = cv$sampleAccumulator;
+		logProbability$var19 = cv$sampleAccumulator;
+		logProbability$flips = (logProbability$flips + cv$sampleAccumulator);
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	private final void logProbabilityValue$sample6() {
-		if(!fixedProbFlag$sample6) {
-			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(var6, a, b);
-			logProbability$var5 = cv$distributionAccumulator;
-			logProbability$var6 = cv$distributionAccumulator;
-			logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$distributionAccumulator);
-			fixedProbFlag$sample6 = fixedFlag$sample6;
-		} else {
-			logProbability$var5 = logProbability$var6;
-			logProbability$$model = (logProbability$$model + logProbability$var6);
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + logProbability$var6);
-		}
+		double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(var6, a, b);
+		logProbability$var5 = cv$distributionAccumulator;
+		logProbability$var6 = cv$distributionAccumulator;
+		logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
 	}
 
 	private final void sample6() {
@@ -179,8 +144,7 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	@Override
 	public final void forwardGeneration() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		parallelFor(RNG$, 0, samples, 1,
 			(int forStart$var18, int forEnd$var18, int threadID$var18, org.sandwood.random.internal.Rng RNG$1) -> { 
 				for(int var18 = forStart$var18; var18 < forEnd$var18; var18 += 1)
@@ -191,14 +155,12 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	@Override
 	public final void forwardGenerationPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		parallelFor(RNG$, 0, samples, 1,
 			(int forStart$var18, int forEnd$var18, int threadID$var18, org.sandwood.random.internal.Rng RNG$1) -> { 
 				for(int var18 = forStart$var18; var18 < forEnd$var18; var18 += 1)
@@ -209,20 +171,17 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	@Override
 	public final void gibbsRound() {
-		if(!fixedFlag$sample6)
-			sample6();
+		sample6();
 		system$gibbsForward = !system$gibbsForward;
 	}
 
@@ -235,19 +194,15 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var5 = 0.0;
-		if(!fixedProbFlag$sample6)
-			logProbability$var6 = Double.NaN;
+		logProbability$var6 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flips = 0.0;
-		if(!fixedProbFlag$sample19)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	@Override
 	public final void logEvidenceProbabilities() {
 		initializeLogProbabilityFields();
-		if(fixedFlag$sample6)
-			logProbabilityValue$sample6();
 		logProbabilityValue$sample19();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$MultiThreadCPU_optimisedModelSingle.java
@@ -9,9 +9,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Declare the variables for the model.
 	private double a;
 	private double b;
-	private boolean fixedFlag$sample6 = false;
-	private boolean fixedProbFlag$sample19 = false;
-	private boolean fixedProbFlag$sample6 = false;
 	private boolean[] flips;
 	private boolean[] flipsMeasured;
 	private int length$flipsMeasured;
@@ -52,32 +49,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$b(double cv$value) {
 		b = cv$value;
-	}
-
-	// Getter for fixedFlag$sample6.
-	@Override
-	public final boolean get$fixedFlag$sample6() {
-		return fixedFlag$sample6;
-	}
-
-	// Setter for fixedFlag$sample6.
-	@Override
-	public final void set$fixedFlag$sample6(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample6 including if probabilities
-		// need to be updated.
-		fixedFlag$sample6 = cv$value;
-		
-		// Should the probability of sample 6 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample6" with its value "cv$value".
-		fixedProbFlag$sample6 = (cv$value && fixedProbFlag$sample6);
-		
-		// Should the probability of sample 19 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample6" with its value "cv$value".
-		fixedProbFlag$sample19 = (cv$value && fixedProbFlag$sample19);
 	}
 
 	// Getter for flips.
@@ -150,127 +121,23 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for var6.
 	@Override
 	public final void set$var6(double cv$value) {
-		// Set flags for all the side effects of var6 including if probabilities need to be
-		// updated.
 		var6 = cv$value;
-		
-		// Unset the fixed probability flag for sample 6 as it depends on var6.
-		fixedProbFlag$sample6 = false;
-		
-		// Unset the fixed probability flag for sample 19 as it depends on var6.
-		fixedProbFlag$sample19 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample19 using sampled
 	// values.
 	private final void logProbabilityValue$sample19() {
-		// Determine if we need to calculate the values for sample task 19 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample19) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int var18 = 0; var18 < samples; var18 += 1) {
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1) {
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((flips[var18]?var6:(1.0 - var6))));
-			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$bernoulli = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				logProbability$var19 = cv$sampleAccumulator;
-			}
-			
-			// Update the variable probability
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$flips = (logProbability$flips + cv$sampleAccumulator);
-			
-			// Add probability to model
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample19 = fixedFlag$sample6;
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if((0 < samples))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$bernoulli = logProbability$var19;
-			
-			// Update the variable probability
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$flips = (logProbability$flips + logProbability$var19);
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var19);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var19);
-		}
-	}
-
-	// Calculate the probability of the samples represented by sample6 using sampled values.
-	private final void logProbabilityValue$sample6() {
-		// Determine if we need to calculate the values for sample task 6 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample6) {
-			// Generating probabilities for sample task
-			// Variable declaration of cv$distributionAccumulator moved.
-			// Declaration comment was:
-			// Variable declaration of cv$distributionAccumulator moved.
-			// Declaration comment was:
-			// An accumulator for log probabilities.
-			// 
-			// Store the value of the function call, so the function call is only made once.
-			// 
-			// The sample value to calculate the probability of generating
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
 			// Scale the probability relative to the observed distribution space.
 			// 
@@ -285,70 +152,91 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 			// Store the value of the function call, so the function call is only made once.
 			// 
 			// The sample value to calculate the probability of generating
-			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(var6, a, b);
-			
-			// Add the probability of this sample task to the sample task accumulator.
-			// 
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			logProbability$var5 = cv$distributionAccumulator;
-			
-			// Store the sample task probability
-			logProbability$var6 = cv$distributionAccumulator;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			// Declaration comment was:
-			// Accumulator for probabilities of instances of the random variable
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			// 
-			// Add the probability of this sample task to the sample task accumulator.
-			// 
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				// Variable declaration of cv$accumulator moved.
-				// Declaration comment was:
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$$evidence = (logProbability$$evidence + cv$distributionAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample6 = fixedFlag$sample6;
+			cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((flips[var18]?var6:(1.0 - var6))));
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			logProbability$var5 = logProbability$var6;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$bernoulli = cv$sampleAccumulator;
 			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var6);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$var6);
+			// Store the random variable instance probability
+			logProbability$var19 = cv$sampleAccumulator;
 		}
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$flips = (logProbability$flips + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+	}
+
+	// Calculate the probability of the samples represented by sample6 using sampled values.
+	private final void logProbabilityValue$sample6() {
+		// Generating probabilities for sample task
+		// Variable declaration of cv$distributionAccumulator moved.
+		// Declaration comment was:
+		// Variable declaration of cv$distributionAccumulator moved.
+		// Declaration comment was:
+		// An accumulator for log probabilities.
+		// 
+		// Store the value of the function call, so the function call is only made once.
+		// 
+		// The sample value to calculate the probability of generating
+		// 
+		// Scale the probability relative to the observed distribution space.
+		// 
+		// Add the probability of this distribution configuration to the accumulator.
+		// 
+		// An accumulator for the distributed probability space covered.
+		// 
+		// Variable declaration of cv$distributionAccumulator moved.
+		// Declaration comment was:
+		// An accumulator for log probabilities.
+		// 
+		// Store the value of the function call, so the function call is only made once.
+		// 
+		// The sample value to calculate the probability of generating
+		double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(var6, a, b);
+		
+		// Add the probability of this sample task to the sample task accumulator.
+		// 
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		logProbability$var5 = cv$distributionAccumulator;
+		
+		// Store the sample task probability
+		logProbability$var6 = cv$distributionAccumulator;
+		
+		// Add probability to model
+		// 
+		// Variable declaration of cv$accumulator moved.
+		// Declaration comment was:
+		// Accumulator for probabilities of instances of the random variable
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		// 
+		// Add the probability of this sample task to the sample task accumulator.
+		// 
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -394,8 +282,7 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Method to execute the model code conventionally.
 	@Override
 	public final void forwardGeneration() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, samples, 1,
@@ -414,16 +301,14 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
 	// variables.
 	@Override
 	public final void forwardGenerationPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, samples, 1,
@@ -441,8 +326,7 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -450,16 +334,13 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute one round of Gibbs sampling.
 	@Override
 	public final void gibbsRound() {
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample6)
-			sample6();
+		sample6();
 		
 		// Reverse the direction of execution for the next iteration
 		system$gibbsForward = !system$gibbsForward;
@@ -483,12 +364,10 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var5 = 0.0;
-		if(!fixedProbFlag$sample6)
-			logProbability$var6 = Double.NaN;
+		logProbability$var6 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flips = 0.0;
-		if(!fixedProbFlag$sample19)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -498,8 +377,6 @@ class Flip1CoinMK1c$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample6)
-			logProbabilityValue$sample6();
 		logProbabilityValue$sample19();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$SingleThreadCPU_model.java
@@ -9,9 +9,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Declare the variables for the model.
 	private double a;
 	private double b;
-	private boolean fixedFlag$sample6 = false;
-	private boolean fixedProbFlag$sample19 = false;
-	private boolean fixedProbFlag$sample6 = false;
 	private boolean[] flips;
 	private boolean[] flipsMeasured;
 	private int length$flipsMeasured;
@@ -52,28 +49,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void set$b(double cv$value) {
 		b = cv$value;
-	}
-
-	// Getter for fixedFlag$sample6.
-	@Override
-	public final boolean get$fixedFlag$sample6() {
-		return fixedFlag$sample6;
-	}
-
-	// Setter for fixedFlag$sample6.
-	@Override
-	public final void set$fixedFlag$sample6(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample6 including if probabilities
-		// need to be updated.
-		fixedFlag$sample6 = cv$value;
-		
-		// Should the probability of sample 6 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample6 = (fixedFlag$sample6 && fixedProbFlag$sample6);
-		
-		// Should the probability of sample 19 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample19 = (fixedFlag$sample6 && fixedProbFlag$sample19);
 	}
 
 	// Getter for flips.
@@ -146,134 +121,22 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Setter for var6.
 	@Override
 	public final void set$var6(double cv$value) {
-		// Set flags for all the side effects of var6 including if probabilities need to be
-		// updated.
 		var6 = cv$value;
-		
-		// Unset the fixed probability flag for sample 6 as it depends on var6.
-		fixedProbFlag$sample6 = false;
-		
-		// Unset the fixed probability flag for sample 19 as it depends on var6.
-		fixedProbFlag$sample19 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample19 using sampled
 	// values.
 	private final void logProbabilityValue$sample19() {
-		// Determine if we need to calculate the values for sample task 19 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample19) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
-				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = flips[var18];
-					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var6:(1.0 - var6))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
-						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-			}
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$bernoulli = cv$sampleAccumulator;
-			
-			// Store the random variable instance probability
-			logProbability$var19 = cv$sampleAccumulator;
-			
-			// Update the variable probability
-			logProbability$flips = (logProbability$flips + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample19 = fixedFlag$sample6;
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var19;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$bernoulli = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$flips = (logProbability$flips + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
-	}
-
-	// Calculate the probability of the samples represented by sample6 using sampled values.
-	private final void logProbabilityValue$sample6() {
-		// Determine if we need to calculate the values for sample task 6 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample6) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int var18 = 0; var18 < samples; var18 += 1) {
 			// An accumulator for log probabilities.
 			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
@@ -281,11 +144,11 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			double cv$probabilityReached = 0.0;
 			{
 				// The sample value to calculate the probability of generating
-				double cv$sampleValue = var6;
+				boolean cv$sampleValue = flips[var18];
 				{
 					{
 						// Store the value of the function call, so the function call is only made once.
-						double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, a, b));
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var6:(1.0 - var6))));
 						
 						// Add the probability of this sample task to the distribution accumulator.
 						if((cv$weightedProbability < cv$distributionAccumulator))
@@ -311,48 +174,88 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
 			double cv$sampleProbability = cv$distributionAccumulator;
 			
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
 			// Add the probability of this sample task to the sample task accumulator.
 			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$var5 = cv$sampleAccumulator;
-			
-			// Store the sample task probability
-			logProbability$var6 = cv$sampleProbability;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample6 = fixedFlag$sample6;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			double cv$sampleValue = logProbability$var6;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$var5 = cv$rvAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$bernoulli = cv$sampleAccumulator;
+		
+		// Store the random variable instance probability
+		logProbability$var19 = cv$sampleAccumulator;
+		
+		// Update the variable probability
+		logProbability$flips = (logProbability$flips + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+	}
+
+	// Calculate the probability of the samples represented by sample6 using sampled values.
+	private final void logProbabilityValue$sample6() {
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// An accumulator for log probabilities.
+		double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+		
+		// An accumulator for the distributed probability space covered.
+		double cv$probabilityReached = 0.0;
+		{
+			// The sample value to calculate the probability of generating
+			double cv$sampleValue = var6;
+			{
+				{
+					// Store the value of the function call, so the function call is only made once.
+					double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, a, b));
+					
+					// Add the probability of this sample task to the distribution accumulator.
+					if((cv$weightedProbability < cv$distributionAccumulator))
+						cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+					else {
+						// If the second value is -infinity.
+						if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+							cv$distributionAccumulator = cv$weightedProbability;
+						else
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+					}
+					
+					// Add the probability of this distribution configuration to the accumulator.
+					cv$probabilityReached = (cv$probabilityReached + 1.0);
+				}
+			}
 		}
+		if((cv$probabilityReached == 0.0))
+			// Return negative infinity if no distribution probability space is reached.
+			cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+		else
+			// Scale the probability relative to the observed distribution space.
+			cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+		double cv$sampleProbability = cv$distributionAccumulator;
+		
+		// Add the probability of this sample task to the sample task accumulator.
+		cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$var5 = cv$sampleAccumulator;
+		
+		// Store the sample task probability
+		logProbability$var6 = cv$sampleProbability;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -405,8 +308,7 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Method to execute the model code conventionally.
 	@Override
 	public final void forwardGeneration() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		for(int var18 = 0; var18 < samples; var18 += 1)
 			flips[var18] = DistributionSampling.sampleBernoulli(RNG$, var6);
 	}
@@ -416,16 +318,14 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
 	// variables.
 	@Override
 	public final void forwardGenerationPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		for(int var18 = 0; var18 < samples; var18 += 1)
 			flips[var18] = DistributionSampling.sampleBernoulli(RNG$, var6);
 	}
@@ -434,8 +334,7 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -443,23 +342,18 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute one round of Gibbs sampling.
 	@Override
 	public final void gibbsRound() {
 		// Infer the samples in chronological order.
-		if(system$gibbsForward) {
-			if(!fixedFlag$sample6)
-				sample6();
-		}
+		if(system$gibbsForward)
+			sample6();
 		// Infer the samples in reverse chronological order.
-		else {
-			if(!fixedFlag$sample6)
-				sample6();
-		}
+		else
+			sample6();
 		
 		// Reverse the direction of execution for the next iteration
 		system$gibbsForward = !system$gibbsForward;
@@ -483,12 +377,10 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var5 = 0.0;
-		if(!fixedProbFlag$sample6)
-			logProbability$var6 = Double.NaN;
+		logProbability$var6 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flips = 0.0;
-		if(!fixedProbFlag$sample19)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -498,8 +390,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample6)
-			logProbabilityValue$sample6();
 		logProbabilityValue$sample19();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$SingleThreadCPU_modelNoComments.java
@@ -7,9 +7,6 @@ import org.sandwood.runtime.model.ExecutionTarget;
 class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements Flip1CoinMK1c$CoreInterface {
 	private double a;
 	private double b;
-	private boolean fixedFlag$sample6 = false;
-	private boolean fixedProbFlag$sample19 = false;
-	private boolean fixedProbFlag$sample6 = false;
 	private boolean[] flips;
 	private boolean[] flipsMeasured;
 	private int length$flipsMeasured;
@@ -46,18 +43,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void set$b(double cv$value) {
 		b = cv$value;
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample6() {
-		return fixedFlag$sample6;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample6(boolean cv$value) {
-		fixedFlag$sample6 = cv$value;
-		fixedProbFlag$sample6 = (fixedFlag$sample6 && fixedProbFlag$sample6);
-		fixedProbFlag$sample19 = (fixedFlag$sample6 && fixedProbFlag$sample19);
 	}
 
 	@Override
@@ -118,77 +103,20 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void set$var6(double cv$value) {
 		var6 = cv$value;
-		fixedProbFlag$sample6 = false;
-		fixedProbFlag$sample19 = false;
 	}
 
 	private final void logProbabilityValue$sample19() {
-		if(!fixedProbFlag$sample19) {
-			double cv$accumulator = 0.0;
-			double cv$sampleAccumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1) {
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
-				{
-					boolean cv$sampleValue = flips[var18];
-					{
-						{
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var6:(1.0 - var6))));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
-						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-			}
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$bernoulli = cv$sampleAccumulator;
-			logProbability$var19 = cv$sampleAccumulator;
-			logProbability$flips = (logProbability$flips + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample19 = fixedFlag$sample6;
-		} else {
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1)
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var19;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$bernoulli = cv$rvAccumulator;
-			logProbability$flips = (logProbability$flips + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
-	}
-
-	private final void logProbabilityValue$sample6() {
-		if(!fixedProbFlag$sample6) {
-			double cv$accumulator = 0.0;
-			double cv$sampleAccumulator = 0.0;
+		double cv$accumulator = 0.0;
+		double cv$sampleAccumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int var18 = 0; var18 < samples; var18 += 1) {
 			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			double cv$probabilityReached = 0.0;
 			{
-				double cv$sampleValue = var6;
+				boolean cv$sampleValue = flips[var18];
 				{
 					{
-						double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, a, b));
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var6:(1.0 - var6))));
 						if((cv$weightedProbability < cv$distributionAccumulator))
 							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
 						else {
@@ -206,25 +134,49 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			else
 				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
 			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
 			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$var5 = cv$sampleAccumulator;
-			logProbability$var6 = cv$sampleProbability;
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample6 = fixedFlag$sample6;
-		} else {
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			double cv$sampleValue = logProbability$var6;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$var5 = cv$rvAccumulator;
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$bernoulli = cv$sampleAccumulator;
+		logProbability$var19 = cv$sampleAccumulator;
+		logProbability$flips = (logProbability$flips + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+	}
+
+	private final void logProbabilityValue$sample6() {
+		double cv$accumulator = 0.0;
+		double cv$sampleAccumulator = 0.0;
+		double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+		double cv$probabilityReached = 0.0;
+		{
+			double cv$sampleValue = var6;
+			{
+				{
+					double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, a, b));
+					if((cv$weightedProbability < cv$distributionAccumulator))
+						cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+					else {
+						if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+							cv$distributionAccumulator = cv$weightedProbability;
+						else
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+					}
+					cv$probabilityReached = (cv$probabilityReached + 1.0);
+				}
+			}
+		}
+		if((cv$probabilityReached == 0.0))
+			cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+		else
+			cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+		double cv$sampleProbability = cv$distributionAccumulator;
+		cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$var5 = cv$sampleAccumulator;
+		logProbability$var6 = cv$sampleProbability;
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void sample6() {
@@ -258,47 +210,39 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 
 	@Override
 	public final void forwardGeneration() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		for(int var18 = 0; var18 < samples; var18 += 1)
 			flips[var18] = DistributionSampling.sampleBernoulli(RNG$, var6);
 	}
 
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	@Override
 	public final void forwardGenerationPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		for(int var18 = 0; var18 < samples; var18 += 1)
 			flips[var18] = DistributionSampling.sampleBernoulli(RNG$, var6);
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	@Override
 	public final void gibbsRound() {
-		if(system$gibbsForward) {
-			if(!fixedFlag$sample6)
-				sample6();
-		} else {
-			if(!fixedFlag$sample6)
-				sample6();
-		}
+		if(system$gibbsForward)
+			sample6();
+		else
+			sample6();
 		system$gibbsForward = !system$gibbsForward;
 	}
 
@@ -311,19 +255,15 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var5 = 0.0;
-		if(!fixedProbFlag$sample6)
-			logProbability$var6 = Double.NaN;
+		logProbability$var6 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flips = 0.0;
-		if(!fixedProbFlag$sample19)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	@Override
 	public final void logEvidenceProbabilities() {
 		initializeLogProbabilityFields();
-		if(fixedFlag$sample6)
-			logProbabilityValue$sample6();
 		logProbabilityValue$sample19();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$SingleThreadCPU_modelSingle.java
@@ -9,9 +9,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Declare the variables for the model.
 	private double a;
 	private double b;
-	private boolean fixedFlag$sample6 = false;
-	private boolean fixedProbFlag$sample19 = false;
-	private boolean fixedProbFlag$sample6 = false;
 	private boolean[] flips;
 	private boolean[] flipsMeasured;
 	private int length$flipsMeasured;
@@ -52,28 +49,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void set$b(double cv$value) {
 		b = cv$value;
-	}
-
-	// Getter for fixedFlag$sample6.
-	@Override
-	public final boolean get$fixedFlag$sample6() {
-		return fixedFlag$sample6;
-	}
-
-	// Setter for fixedFlag$sample6.
-	@Override
-	public final void set$fixedFlag$sample6(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample6 including if probabilities
-		// need to be updated.
-		fixedFlag$sample6 = cv$value;
-		
-		// Should the probability of sample 6 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample6 = (fixedFlag$sample6 && fixedProbFlag$sample6);
-		
-		// Should the probability of sample 19 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample19 = (fixedFlag$sample6 && fixedProbFlag$sample19);
 	}
 
 	// Getter for flips.
@@ -146,139 +121,22 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Setter for var6.
 	@Override
 	public final void set$var6(double cv$value) {
-		// Set flags for all the side effects of var6 including if probabilities need to be
-		// updated.
 		var6 = cv$value;
-		
-		// Unset the fixed probability flag for sample 6 as it depends on var6.
-		fixedProbFlag$sample6 = false;
-		
-		// Unset the fixed probability flag for sample 19 as it depends on var6.
-		fixedProbFlag$sample19 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample19 using sampled
 	// values.
 	private final void logProbabilityValue$sample19() {
-		// Determine if we need to calculate the values for sample task 19 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample19) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
-				{
-					// The sample value to calculate the probability of generating
-					boolean cv$sampleValue = flips[var18];
-					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var6:(1.0 - var6))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
-						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-			}
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$bernoulli = cv$sampleAccumulator;
-			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$var19 = cv$sampleAccumulator;
-			
-			// Update the variable probability
-			logProbability$flips = (logProbability$flips + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample19 = fixedFlag$sample6;
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var19;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$bernoulli = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$flips = (logProbability$flips + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
-	}
-
-	// Calculate the probability of the samples represented by sample6 using sampled values.
-	private final void logProbabilityValue$sample6() {
-		// Determine if we need to calculate the values for sample task 6 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample6) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int var18 = 0; var18 < samples; var18 += 1) {
 			// An accumulator for log probabilities.
 			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
@@ -286,11 +144,11 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			double cv$probabilityReached = 0.0;
 			{
 				// The sample value to calculate the probability of generating
-				double cv$sampleValue = var6;
+				boolean cv$sampleValue = flips[var18];
 				{
 					{
 						// Store the value of the function call, so the function call is only made once.
-						double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, a, b));
+						double cv$weightedProbability = (Math.log(1.0) + Math.log((cv$sampleValue?var6:(1.0 - var6))));
 						
 						// Add the probability of this sample task to the distribution accumulator.
 						if((cv$weightedProbability < cv$distributionAccumulator))
@@ -316,48 +174,92 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
 			double cv$sampleProbability = cv$distributionAccumulator;
 			
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
 			// Add the probability of this sample task to the sample task accumulator.
 			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			logProbability$var5 = cv$sampleAccumulator;
-			
-			// Store the sample task probability
-			logProbability$var6 = cv$sampleProbability;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample6 = fixedFlag$sample6;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			double cv$sampleValue = logProbability$var6;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			logProbability$var5 = cv$rvAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$bernoulli = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$var19 = cv$sampleAccumulator;
+		
+		// Update the variable probability
+		logProbability$flips = (logProbability$flips + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+	}
+
+	// Calculate the probability of the samples represented by sample6 using sampled values.
+	private final void logProbabilityValue$sample6() {
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// An accumulator for log probabilities.
+		double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+		
+		// An accumulator for the distributed probability space covered.
+		double cv$probabilityReached = 0.0;
+		{
+			// The sample value to calculate the probability of generating
+			double cv$sampleValue = var6;
+			{
+				{
+					// Store the value of the function call, so the function call is only made once.
+					double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, a, b));
+					
+					// Add the probability of this sample task to the distribution accumulator.
+					if((cv$weightedProbability < cv$distributionAccumulator))
+						cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+					else {
+						// If the second value is -infinity.
+						if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+							cv$distributionAccumulator = cv$weightedProbability;
+						else
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+					}
+					
+					// Add the probability of this distribution configuration to the accumulator.
+					cv$probabilityReached = (cv$probabilityReached + 1.0);
+				}
+			}
 		}
+		if((cv$probabilityReached == 0.0))
+			// Return negative infinity if no distribution probability space is reached.
+			cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+		else
+			// Scale the probability relative to the observed distribution space.
+			cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+		double cv$sampleProbability = cv$distributionAccumulator;
+		
+		// Add the probability of this sample task to the sample task accumulator.
+		cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		logProbability$var5 = cv$sampleAccumulator;
+		
+		// Store the sample task probability
+		logProbability$var6 = cv$sampleProbability;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -410,8 +312,7 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Method to execute the model code conventionally.
 	@Override
 	public final void forwardGeneration() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		for(int var18 = 0; var18 < samples; var18 += 1)
 			flips[var18] = DistributionSampling.sampleBernoulli(RNG$, var6);
 	}
@@ -421,16 +322,14 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
 	// variables.
 	@Override
 	public final void forwardGenerationPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		for(int var18 = 0; var18 < samples; var18 += 1)
 			flips[var18] = DistributionSampling.sampleBernoulli(RNG$, var6);
 	}
@@ -439,8 +338,7 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -448,23 +346,18 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute one round of Gibbs sampling.
 	@Override
 	public final void gibbsRound() {
 		// Infer the samples in chronological order.
-		if(system$gibbsForward) {
-			if(!fixedFlag$sample6)
-				sample6();
-		}
+		if(system$gibbsForward)
+			sample6();
 		// Infer the samples in reverse chronological order.
-		else {
-			if(!fixedFlag$sample6)
-				sample6();
-		}
+		else
+			sample6();
 		
 		// Reverse the direction of execution for the next iteration
 		system$gibbsForward = !system$gibbsForward;
@@ -488,12 +381,10 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var5 = 0.0;
-		if(!fixedProbFlag$sample6)
-			logProbability$var6 = Double.NaN;
+		logProbability$var6 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flips = 0.0;
-		if(!fixedProbFlag$sample19)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -503,8 +394,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample6)
-			logProbabilityValue$sample6();
 		logProbabilityValue$sample19();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$SingleThreadCPU_optimisedModel.java
@@ -9,9 +9,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Declare the variables for the model.
 	private double a;
 	private double b;
-	private boolean fixedFlag$sample6 = false;
-	private boolean fixedProbFlag$sample19 = false;
-	private boolean fixedProbFlag$sample6 = false;
 	private boolean[] flips;
 	private boolean[] flipsMeasured;
 	private int length$flipsMeasured;
@@ -52,32 +49,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void set$b(double cv$value) {
 		b = cv$value;
-	}
-
-	// Getter for fixedFlag$sample6.
-	@Override
-	public final boolean get$fixedFlag$sample6() {
-		return fixedFlag$sample6;
-	}
-
-	// Setter for fixedFlag$sample6.
-	@Override
-	public final void set$fixedFlag$sample6(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample6 including if probabilities
-		// need to be updated.
-		fixedFlag$sample6 = cv$value;
-		
-		// Should the probability of sample 6 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample6" with its value "cv$value".
-		fixedProbFlag$sample6 = (cv$value && fixedProbFlag$sample6);
-		
-		// Should the probability of sample 19 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample6" with its value "cv$value".
-		fixedProbFlag$sample19 = (cv$value && fixedProbFlag$sample19);
 	}
 
 	// Getter for flips.
@@ -150,110 +121,17 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Setter for var6.
 	@Override
 	public final void set$var6(double cv$value) {
-		// Set flags for all the side effects of var6 including if probabilities need to be
-		// updated.
 		var6 = cv$value;
-		
-		// Unset the fixed probability flag for sample 6 as it depends on var6.
-		fixedProbFlag$sample6 = false;
-		
-		// Unset the fixed probability flag for sample 19 as it depends on var6.
-		fixedProbFlag$sample19 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample19 using sampled
 	// values.
 	private final void logProbabilityValue$sample19() {
-		// Determine if we need to calculate the values for sample task 19 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample19) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			for(int var18 = 0; var18 < samples; var18 += 1)
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((flips[var18]?var6:(1.0 - var6))));
-			logProbability$bernoulli = cv$sampleAccumulator;
-			
-			// Store the random variable instance probability
-			logProbability$var19 = cv$sampleAccumulator;
-			
-			// Update the variable probability
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$flips = (logProbability$flips + cv$sampleAccumulator);
-			
-			// Add probability to model
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample19 = fixedFlag$sample6;
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			logProbability$bernoulli = logProbability$var19;
-			
-			// Update the variable probability
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$flips = (logProbability$flips + logProbability$var19);
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var19);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var19);
-		}
-	}
-
-	// Calculate the probability of the samples represented by sample6 using sampled values.
-	private final void logProbabilityValue$sample6() {
-		// Determine if we need to calculate the values for sample task 6 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample6) {
-			// Generating probabilities for sample task
-			// Variable declaration of cv$distributionAccumulator moved.
-			// Declaration comment was:
-			// Variable declaration of cv$distributionAccumulator moved.
-			// Declaration comment was:
-			// An accumulator for log probabilities.
-			// 
-			// Store the value of the function call, so the function call is only made once.
-			// 
-			// The sample value to calculate the probability of generating
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		for(int var18 = 0; var18 < samples; var18 += 1)
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
 			// Scale the probability relative to the observed distribution space.
 			// 
@@ -268,70 +146,86 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			// Store the value of the function call, so the function call is only made once.
 			// 
 			// The sample value to calculate the probability of generating
-			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(var6, a, b);
-			
-			// Add the probability of this sample task to the sample task accumulator.
-			// 
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			logProbability$var5 = cv$distributionAccumulator;
-			
-			// Store the sample task probability
-			logProbability$var6 = cv$distributionAccumulator;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			// Declaration comment was:
-			// Accumulator for probabilities of instances of the random variable
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			// 
-			// Add the probability of this sample task to the sample task accumulator.
-			// 
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				// Variable declaration of cv$accumulator moved.
-				// Declaration comment was:
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$$evidence = (logProbability$$evidence + cv$distributionAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample6 = fixedFlag$sample6;
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			logProbability$var5 = logProbability$var6;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var6);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$var6);
-		}
+			cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((flips[var18]?var6:(1.0 - var6))));
+		logProbability$bernoulli = cv$sampleAccumulator;
+		
+		// Store the random variable instance probability
+		logProbability$var19 = cv$sampleAccumulator;
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$flips = (logProbability$flips + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+	}
+
+	// Calculate the probability of the samples represented by sample6 using sampled values.
+	private final void logProbabilityValue$sample6() {
+		// Generating probabilities for sample task
+		// Variable declaration of cv$distributionAccumulator moved.
+		// Declaration comment was:
+		// Variable declaration of cv$distributionAccumulator moved.
+		// Declaration comment was:
+		// An accumulator for log probabilities.
+		// 
+		// Store the value of the function call, so the function call is only made once.
+		// 
+		// The sample value to calculate the probability of generating
+		// 
+		// Scale the probability relative to the observed distribution space.
+		// 
+		// Add the probability of this distribution configuration to the accumulator.
+		// 
+		// An accumulator for the distributed probability space covered.
+		// 
+		// Variable declaration of cv$distributionAccumulator moved.
+		// Declaration comment was:
+		// An accumulator for log probabilities.
+		// 
+		// Store the value of the function call, so the function call is only made once.
+		// 
+		// The sample value to calculate the probability of generating
+		double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(var6, a, b);
+		
+		// Add the probability of this sample task to the sample task accumulator.
+		// 
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		logProbability$var5 = cv$distributionAccumulator;
+		
+		// Store the sample task probability
+		logProbability$var6 = cv$distributionAccumulator;
+		
+		// Add probability to model
+		// 
+		// Variable declaration of cv$accumulator moved.
+		// Declaration comment was:
+		// Accumulator for probabilities of instances of the random variable
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		// 
+		// Add the probability of this sample task to the sample task accumulator.
+		// 
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -377,8 +271,7 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Method to execute the model code conventionally.
 	@Override
 	public final void forwardGeneration() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		for(int var18 = 0; var18 < samples; var18 += 1)
 			flips[var18] = DistributionSampling.sampleBernoulli(RNG$, var6);
 	}
@@ -388,16 +281,14 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
 	// variables.
 	@Override
 	public final void forwardGenerationPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		for(int var18 = 0; var18 < samples; var18 += 1)
 			flips[var18] = DistributionSampling.sampleBernoulli(RNG$, var6);
 	}
@@ -406,8 +297,7 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -415,16 +305,13 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute one round of Gibbs sampling.
 	@Override
 	public final void gibbsRound() {
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample6)
-			sample6();
+		sample6();
 		
 		// Reverse the direction of execution for the next iteration
 		system$gibbsForward = !system$gibbsForward;
@@ -448,12 +335,10 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var5 = 0.0;
-		if(!fixedProbFlag$sample6)
-			logProbability$var6 = Double.NaN;
+		logProbability$var6 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flips = 0.0;
-		if(!fixedProbFlag$sample19)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -463,8 +348,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample6)
-			logProbabilityValue$sample6();
 		logProbabilityValue$sample19();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$SingleThreadCPU_optimisedModelNoComments.java
@@ -7,9 +7,6 @@ import org.sandwood.runtime.model.ExecutionTarget;
 class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements Flip1CoinMK1c$CoreInterface {
 	private double a;
 	private double b;
-	private boolean fixedFlag$sample6 = false;
-	private boolean fixedProbFlag$sample19 = false;
-	private boolean fixedProbFlag$sample6 = false;
 	private boolean[] flips;
 	private boolean[] flipsMeasured;
 	private int length$flipsMeasured;
@@ -46,18 +43,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void set$b(double cv$value) {
 		b = cv$value;
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample6() {
-		return fixedFlag$sample6;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample6(boolean cv$value) {
-		fixedFlag$sample6 = cv$value;
-		fixedProbFlag$sample6 = (cv$value && fixedProbFlag$sample6);
-		fixedProbFlag$sample19 = (cv$value && fixedProbFlag$sample19);
 	}
 
 	@Override
@@ -118,44 +103,24 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void set$var6(double cv$value) {
 		var6 = cv$value;
-		fixedProbFlag$sample6 = false;
-		fixedProbFlag$sample19 = false;
 	}
 
 	private final void logProbabilityValue$sample19() {
-		if(!fixedProbFlag$sample19) {
-			double cv$sampleAccumulator = 0.0;
-			for(int var18 = 0; var18 < samples; var18 += 1)
-				cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((flips[var18]?var6:(1.0 - var6))));
-			logProbability$bernoulli = cv$sampleAccumulator;
-			logProbability$var19 = cv$sampleAccumulator;
-			logProbability$flips = (logProbability$flips + cv$sampleAccumulator);
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			fixedProbFlag$sample19 = fixedFlag$sample6;
-		} else {
-			logProbability$bernoulli = logProbability$var19;
-			logProbability$flips = (logProbability$flips + logProbability$var19);
-			logProbability$$model = (logProbability$$model + logProbability$var19);
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var19);
-		}
+		double cv$sampleAccumulator = 0.0;
+		for(int var18 = 0; var18 < samples; var18 += 1)
+			cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((flips[var18]?var6:(1.0 - var6))));
+		logProbability$bernoulli = cv$sampleAccumulator;
+		logProbability$var19 = cv$sampleAccumulator;
+		logProbability$flips = (logProbability$flips + cv$sampleAccumulator);
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	private final void logProbabilityValue$sample6() {
-		if(!fixedProbFlag$sample6) {
-			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(var6, a, b);
-			logProbability$var5 = cv$distributionAccumulator;
-			logProbability$var6 = cv$distributionAccumulator;
-			logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + cv$distributionAccumulator);
-			fixedProbFlag$sample6 = fixedFlag$sample6;
-		} else {
-			logProbability$var5 = logProbability$var6;
-			logProbability$$model = (logProbability$$model + logProbability$var6);
-			if(fixedFlag$sample6)
-				logProbability$$evidence = (logProbability$$evidence + logProbability$var6);
-		}
+		double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(var6, a, b);
+		logProbability$var5 = cv$distributionAccumulator;
+		logProbability$var6 = cv$distributionAccumulator;
+		logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
 	}
 
 	private final void sample6() {
@@ -179,42 +144,36 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 
 	@Override
 	public final void forwardGeneration() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		for(int var18 = 0; var18 < samples; var18 += 1)
 			flips[var18] = DistributionSampling.sampleBernoulli(RNG$, var6);
 	}
 
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	@Override
 	public final void forwardGenerationPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		for(int var18 = 0; var18 < samples; var18 += 1)
 			flips[var18] = DistributionSampling.sampleBernoulli(RNG$, var6);
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	@Override
 	public final void gibbsRound() {
-		if(!fixedFlag$sample6)
-			sample6();
+		sample6();
 		system$gibbsForward = !system$gibbsForward;
 	}
 
@@ -227,19 +186,15 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var5 = 0.0;
-		if(!fixedProbFlag$sample6)
-			logProbability$var6 = Double.NaN;
+		logProbability$var6 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flips = 0.0;
-		if(!fixedProbFlag$sample19)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	@Override
 	public final void logEvidenceProbabilities() {
 		initializeLogProbabilityFields();
-		if(fixedFlag$sample6)
-			logProbabilityValue$sample6();
 		logProbabilityValue$sample19();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c$SingleThreadCPU_optimisedModelSingle.java
@@ -9,9 +9,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Declare the variables for the model.
 	private double a;
 	private double b;
-	private boolean fixedFlag$sample6 = false;
-	private boolean fixedProbFlag$sample19 = false;
-	private boolean fixedProbFlag$sample6 = false;
 	private boolean[] flips;
 	private boolean[] flipsMeasured;
 	private int length$flipsMeasured;
@@ -52,32 +49,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final void set$b(double cv$value) {
 		b = cv$value;
-	}
-
-	// Getter for fixedFlag$sample6.
-	@Override
-	public final boolean get$fixedFlag$sample6() {
-		return fixedFlag$sample6;
-	}
-
-	// Setter for fixedFlag$sample6.
-	@Override
-	public final void set$fixedFlag$sample6(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample6 including if probabilities
-		// need to be updated.
-		fixedFlag$sample6 = cv$value;
-		
-		// Should the probability of sample 6 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample6" with its value "cv$value".
-		fixedProbFlag$sample6 = (cv$value && fixedProbFlag$sample6);
-		
-		// Should the probability of sample 19 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample6" with its value "cv$value".
-		fixedProbFlag$sample19 = (cv$value && fixedProbFlag$sample19);
 	}
 
 	// Getter for flips.
@@ -150,127 +121,23 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Setter for var6.
 	@Override
 	public final void set$var6(double cv$value) {
-		// Set flags for all the side effects of var6 including if probabilities need to be
-		// updated.
 		var6 = cv$value;
-		
-		// Unset the fixed probability flag for sample 6 as it depends on var6.
-		fixedProbFlag$sample6 = false;
-		
-		// Unset the fixed probability flag for sample 19 as it depends on var6.
-		fixedProbFlag$sample19 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample19 using sampled
 	// values.
 	private final void logProbabilityValue$sample19() {
-		// Determine if we need to calculate the values for sample task 19 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample19) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int var18 = 0; var18 < samples; var18 += 1) {
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int var18 = 0; var18 < samples; var18 += 1) {
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((flips[var18]?var6:(1.0 - var6))));
-			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$bernoulli = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				logProbability$var19 = cv$sampleAccumulator;
-			}
-			
-			// Update the variable probability
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$flips = (logProbability$flips + cv$sampleAccumulator);
-			
-			// Add probability to model
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample19 = fixedFlag$sample6;
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if((0 < samples))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$bernoulli = logProbability$var19;
-			
-			// Update the variable probability
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$flips = (logProbability$flips + logProbability$var19);
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var19);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var19);
-		}
-	}
-
-	// Calculate the probability of the samples represented by sample6 using sampled values.
-	private final void logProbabilityValue$sample6() {
-		// Determine if we need to calculate the values for sample task 6 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample6) {
-			// Generating probabilities for sample task
-			// Variable declaration of cv$distributionAccumulator moved.
-			// Declaration comment was:
-			// Variable declaration of cv$distributionAccumulator moved.
-			// Declaration comment was:
-			// An accumulator for log probabilities.
-			// 
-			// Store the value of the function call, so the function call is only made once.
-			// 
-			// The sample value to calculate the probability of generating
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
 			// Scale the probability relative to the observed distribution space.
 			// 
@@ -285,70 +152,91 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 			// Store the value of the function call, so the function call is only made once.
 			// 
 			// The sample value to calculate the probability of generating
-			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(var6, a, b);
-			
-			// Add the probability of this sample task to the sample task accumulator.
-			// 
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			logProbability$var5 = cv$distributionAccumulator;
-			
-			// Store the sample task probability
-			logProbability$var6 = cv$distributionAccumulator;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			// Declaration comment was:
-			// Accumulator for probabilities of instances of the random variable
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			// 
-			// Add the probability of this sample task to the sample task accumulator.
-			// 
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				// Variable declaration of cv$accumulator moved.
-				// Declaration comment was:
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$$evidence = (logProbability$$evidence + cv$distributionAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample6 = fixedFlag$sample6;
+			cv$sampleAccumulator = (cv$sampleAccumulator + Math.log((flips[var18]?var6:(1.0 - var6))));
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			logProbability$var5 = logProbability$var6;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$bernoulli = cv$sampleAccumulator;
 			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var6);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample6)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$var6);
+			// Store the random variable instance probability
+			logProbability$var19 = cv$sampleAccumulator;
 		}
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$flips = (logProbability$flips + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+	}
+
+	// Calculate the probability of the samples represented by sample6 using sampled values.
+	private final void logProbabilityValue$sample6() {
+		// Generating probabilities for sample task
+		// Variable declaration of cv$distributionAccumulator moved.
+		// Declaration comment was:
+		// Variable declaration of cv$distributionAccumulator moved.
+		// Declaration comment was:
+		// An accumulator for log probabilities.
+		// 
+		// Store the value of the function call, so the function call is only made once.
+		// 
+		// The sample value to calculate the probability of generating
+		// 
+		// Scale the probability relative to the observed distribution space.
+		// 
+		// Add the probability of this distribution configuration to the accumulator.
+		// 
+		// An accumulator for the distributed probability space covered.
+		// 
+		// Variable declaration of cv$distributionAccumulator moved.
+		// Declaration comment was:
+		// An accumulator for log probabilities.
+		// 
+		// Store the value of the function call, so the function call is only made once.
+		// 
+		// The sample value to calculate the probability of generating
+		double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(var6, a, b);
+		
+		// Add the probability of this sample task to the sample task accumulator.
+		// 
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		logProbability$var5 = cv$distributionAccumulator;
+		
+		// Store the sample task probability
+		logProbability$var6 = cv$distributionAccumulator;
+		
+		// Add probability to model
+		// 
+		// Variable declaration of cv$accumulator moved.
+		// Declaration comment was:
+		// Accumulator for probabilities of instances of the random variable
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		// 
+		// Add the probability of this sample task to the sample task accumulator.
+		// 
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -394,8 +282,7 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Method to execute the model code conventionally.
 	@Override
 	public final void forwardGeneration() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		for(int var18 = 0; var18 < samples; var18 += 1)
 			flips[var18] = DistributionSampling.sampleBernoulli(RNG$, var6);
 	}
@@ -405,16 +292,14 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// and stored.
 	@Override
 	public final void forwardGenerationDistributionsNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
 	// variables.
 	@Override
 	public final void forwardGenerationPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 		for(int var18 = 0; var18 < samples; var18 += 1)
 			flips[var18] = DistributionSampling.sampleBernoulli(RNG$, var6);
 	}
@@ -423,8 +308,7 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// observed values. Distributions are collapsed to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputs() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -432,16 +316,13 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// to single values.
 	@Override
 	public final void forwardGenerationValuesNoOutputsPrime() {
-		if(!fixedFlag$sample6)
-			var6 = DistributionSampling.sampleBeta(RNG$, a, b);
+		var6 = DistributionSampling.sampleBeta(RNG$, a, b);
 	}
 
 	// Method to execute one round of Gibbs sampling.
 	@Override
 	public final void gibbsRound() {
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample6)
-			sample6();
+		sample6();
 		
 		// Reverse the direction of execution for the next iteration
 		system$gibbsForward = !system$gibbsForward;
@@ -465,12 +346,10 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$$model = 0.0;
 		logProbability$$evidence = 0.0;
 		logProbability$var5 = 0.0;
-		if(!fixedProbFlag$sample6)
-			logProbability$var6 = Double.NaN;
+		logProbability$var6 = Double.NaN;
 		logProbability$bernoulli = Double.NaN;
 		logProbability$flips = 0.0;
-		if(!fixedProbFlag$sample19)
-			logProbability$var19 = Double.NaN;
+		logProbability$var19 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -480,8 +359,6 @@ class Flip1CoinMK1c$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 		initializeLogProbabilityFields();
 		
 		// Call each method in turn to generate the new probability values.
-		if(fixedFlag$sample6)
-			logProbabilityValue$sample6();
 		logProbabilityValue$sample19();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class Flip1CoinMK1c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -63,17 +64,12 @@ public class Flip1CoinMK1c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample6(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample6())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -245,9 +241,6 @@ public class Flip1CoinMK1c extends Model {
         //ComputedVariables
         if($var6.isSet())
             newCore.set$var6(oldCore.get$var6());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample6(oldCore.get$fixedFlag$sample6());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class Flip1CoinMK1c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -63,17 +64,12 @@ public class Flip1CoinMK1c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample6(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample6())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -245,9 +241,6 @@ public class Flip1CoinMK1c extends Model {
         //ComputedVariables
         if($var6.isSet())
             newCore.set$var6(oldCore.get$var6());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample6(oldCore.get$fixedFlag$sample6());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class Flip1CoinMK1c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -63,17 +64,12 @@ public class Flip1CoinMK1c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample6(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample6())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -245,9 +241,6 @@ public class Flip1CoinMK1c extends Model {
         //ComputedVariables
         if($var6.isSet())
             newCore.set$var6(oldCore.get$var6());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample6(oldCore.get$fixedFlag$sample6());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class Flip1CoinMK1c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -63,17 +64,12 @@ public class Flip1CoinMK1c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample6(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample6())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -245,9 +241,6 @@ public class Flip1CoinMK1c extends Model {
         //ComputedVariables
         if($var6.isSet())
             newCore.set$var6(oldCore.get$var6());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample6(oldCore.get$fixedFlag$sample6());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class Flip1CoinMK1c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -63,17 +64,12 @@ public class Flip1CoinMK1c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample6(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample6())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -245,9 +241,6 @@ public class Flip1CoinMK1c extends Model {
         //ComputedVariables
         if($var6.isSet())
             newCore.set$var6(oldCore.get$var6());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample6(oldCore.get$fixedFlag$sample6());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK1c/Flip1CoinMK1c_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class Flip1CoinMK1c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -63,17 +64,12 @@ public class Flip1CoinMK1c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample6(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample6())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -245,9 +241,6 @@ public class Flip1CoinMK1c extends Model {
         //ComputedVariables
         if($var6.isSet())
             newCore.set$var6(oldCore.get$var6());
-
-        //Set fixed flags
-        newCore.set$fixedFlag$sample6(oldCore.get$fixedFlag$sample6());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2/Flip1CoinMK2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2/Flip1CoinMK2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2/Flip1CoinMK2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2/Flip1CoinMK2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2/Flip1CoinMK2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2/Flip1CoinMK2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2/Flip1CoinMK2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2/Flip1CoinMK2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2/Flip1CoinMK2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2/Flip1CoinMK2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2/Flip1CoinMK2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2/Flip1CoinMK2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$CoreInterface_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$CoreInterface_model.java
@@ -14,6 +14,18 @@ interface Flip1CoinMK20$CoreInterface extends org.sandwood.runtime.internal.mode
 	// Getter for count2.
 	public int get$count2();
 
+	// Getter for fixedFlag$sample11.
+	public boolean get$fixedFlag$sample11();
+
+	// Setter for fixedFlag$sample11.
+	public void set$fixedFlag$sample11(boolean cv$value);
+
+	// Getter for fixedFlag$sample12.
+	public boolean get$fixedFlag$sample12();
+
+	// Setter for fixedFlag$sample12.
+	public void set$fixedFlag$sample12(boolean cv$value);
+
 	// Getter for fixedFlag$sample8.
 	public boolean get$fixedFlag$sample8();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$CoreInterface_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$CoreInterface_modelNoComments.java
@@ -5,6 +5,10 @@ interface Flip1CoinMK20$CoreInterface extends org.sandwood.runtime.internal.mode
 	public void set$bias(double cv$value);
 	public int get$count1();
 	public int get$count2();
+	public boolean get$fixedFlag$sample11();
+	public void set$fixedFlag$sample11(boolean cv$value);
+	public boolean get$fixedFlag$sample12();
+	public void set$fixedFlag$sample12(boolean cv$value);
 	public boolean get$fixedFlag$sample8();
 	public void set$fixedFlag$sample8(boolean cv$value);
 	public double get$logProbability$bias();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$CoreInterface_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$CoreInterface_modelSingle.java
@@ -14,6 +14,18 @@ interface Flip1CoinMK20$CoreInterface extends org.sandwood.runtime.internal.mode
 	// Getter for count2.
 	public int get$count2();
 
+	// Getter for fixedFlag$sample11.
+	public boolean get$fixedFlag$sample11();
+
+	// Setter for fixedFlag$sample11.
+	public void set$fixedFlag$sample11(boolean cv$value);
+
+	// Getter for fixedFlag$sample12.
+	public boolean get$fixedFlag$sample12();
+
+	// Setter for fixedFlag$sample12.
+	public void set$fixedFlag$sample12(boolean cv$value);
+
 	// Getter for fixedFlag$sample8.
 	public boolean get$fixedFlag$sample8();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$CoreInterface_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$CoreInterface_optimisedModel.java
@@ -14,6 +14,18 @@ interface Flip1CoinMK20$CoreInterface extends org.sandwood.runtime.internal.mode
 	// Getter for count2.
 	public int get$count2();
 
+	// Getter for fixedFlag$sample11.
+	public boolean get$fixedFlag$sample11();
+
+	// Setter for fixedFlag$sample11.
+	public void set$fixedFlag$sample11(boolean cv$value);
+
+	// Getter for fixedFlag$sample12.
+	public boolean get$fixedFlag$sample12();
+
+	// Setter for fixedFlag$sample12.
+	public void set$fixedFlag$sample12(boolean cv$value);
+
 	// Getter for fixedFlag$sample8.
 	public boolean get$fixedFlag$sample8();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$CoreInterface_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$CoreInterface_optimisedModelNoComments.java
@@ -5,6 +5,10 @@ interface Flip1CoinMK20$CoreInterface extends org.sandwood.runtime.internal.mode
 	public void set$bias(double cv$value);
 	public int get$count1();
 	public int get$count2();
+	public boolean get$fixedFlag$sample11();
+	public void set$fixedFlag$sample11(boolean cv$value);
+	public boolean get$fixedFlag$sample12();
+	public void set$fixedFlag$sample12(boolean cv$value);
 	public boolean get$fixedFlag$sample8();
 	public void set$fixedFlag$sample8(boolean cv$value);
 	public double get$logProbability$bias();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$CoreInterface_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$CoreInterface_optimisedModelSingle.java
@@ -14,6 +14,18 @@ interface Flip1CoinMK20$CoreInterface extends org.sandwood.runtime.internal.mode
 	// Getter for count2.
 	public int get$count2();
 
+	// Getter for fixedFlag$sample11.
+	public boolean get$fixedFlag$sample11();
+
+	// Setter for fixedFlag$sample11.
+	public void set$fixedFlag$sample11(boolean cv$value);
+
+	// Getter for fixedFlag$sample12.
+	public boolean get$fixedFlag$sample12();
+
+	// Setter for fixedFlag$sample12.
+	public void set$fixedFlag$sample12(boolean cv$value);
+
 	// Getter for fixedFlag$sample8.
 	public boolean get$fixedFlag$sample8();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$MultiThreadCPU_model.java
@@ -10,6 +10,8 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	private double bias;
 	private int count1;
 	private int count2;
+	private boolean fixedFlag$sample11 = false;
+	private boolean fixedFlag$sample12 = false;
 	private boolean fixedFlag$sample8 = false;
 	private boolean fixedProbFlag$sample11 = false;
 	private boolean fixedProbFlag$sample12 = false;
@@ -63,6 +65,30 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final int get$count2() {
 		return count2;
+	}
+
+	// Getter for fixedFlag$sample11.
+	@Override
+	public final boolean get$fixedFlag$sample11() {
+		return fixedFlag$sample11;
+	}
+
+	// Setter for fixedFlag$sample11.
+	@Override
+	public final void set$fixedFlag$sample11(boolean cv$value) {
+		fixedFlag$sample11 = cv$value;
+	}
+
+	// Getter for fixedFlag$sample12.
+	@Override
+	public final boolean get$fixedFlag$sample12() {
+		return fixedFlag$sample12;
+	}
+
+	// Setter for fixedFlag$sample12.
+	@Override
+	public final void set$fixedFlag$sample12(boolean cv$value) {
+		fixedFlag$sample12 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample8.
@@ -502,9 +528,12 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGeneration() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		total = (count1 + count2);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!(fixedFlag$sample11 && fixedFlag$sample12))
+			total = (count1 + count2);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -522,8 +551,10 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationPrime() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
 		total = (count1 + count2);
 	}
 
@@ -642,6 +673,10 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample11 = false;
+		fixedFlag$sample12 = false;
+		
 		// Propagating values back from observations into the models intermediate variables.
 		{
 			count1 = obs1;

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$MultiThreadCPU_modelNoComments.java
@@ -8,6 +8,8 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	private double bias;
 	private int count1;
 	private int count2;
+	private boolean fixedFlag$sample11 = false;
+	private boolean fixedFlag$sample12 = false;
 	private boolean fixedFlag$sample8 = false;
 	private boolean fixedProbFlag$sample11 = false;
 	private boolean fixedProbFlag$sample12 = false;
@@ -49,6 +51,26 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final int get$count2() {
 		return count2;
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample11() {
+		return fixedFlag$sample11;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample11(boolean cv$value) {
+		fixedFlag$sample11 = cv$value;
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample12() {
+		return fixedFlag$sample12;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample12(boolean cv$value) {
+		fixedFlag$sample12 = cv$value;
 	}
 
 	@Override
@@ -314,9 +336,12 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGeneration() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		total = (count1 + count2);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!(fixedFlag$sample11 && fixedFlag$sample12))
+			total = (count1 + count2);
 	}
 
 	@Override
@@ -329,8 +354,10 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationPrime() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
 		total = (count1 + count2);
 	}
 
@@ -401,6 +428,8 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	@Override
 	public final void propagateObservedValues() {
+		fixedFlag$sample11 = false;
+		fixedFlag$sample12 = false;
 		{
 			count1 = obs1;
 			count2 = obs2;

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$MultiThreadCPU_modelSingle.java
@@ -10,6 +10,8 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	private double bias;
 	private int count1;
 	private int count2;
+	private boolean fixedFlag$sample11 = false;
+	private boolean fixedFlag$sample12 = false;
 	private boolean fixedFlag$sample8 = false;
 	private boolean fixedProbFlag$sample11 = false;
 	private boolean fixedProbFlag$sample12 = false;
@@ -63,6 +65,30 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final int get$count2() {
 		return count2;
+	}
+
+	// Getter for fixedFlag$sample11.
+	@Override
+	public final boolean get$fixedFlag$sample11() {
+		return fixedFlag$sample11;
+	}
+
+	// Setter for fixedFlag$sample11.
+	@Override
+	public final void set$fixedFlag$sample11(boolean cv$value) {
+		fixedFlag$sample11 = cv$value;
+	}
+
+	// Getter for fixedFlag$sample12.
+	@Override
+	public final boolean get$fixedFlag$sample12() {
+		return fixedFlag$sample12;
+	}
+
+	// Setter for fixedFlag$sample12.
+	@Override
+	public final void set$fixedFlag$sample12(boolean cv$value) {
+		fixedFlag$sample12 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample8.
@@ -502,9 +528,12 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGeneration() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		total = (count1 + count2);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!(fixedFlag$sample11 && fixedFlag$sample12))
+			total = (count1 + count2);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -522,8 +551,10 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationPrime() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
 		total = (count1 + count2);
 	}
 
@@ -642,6 +673,10 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample11 = false;
+		fixedFlag$sample12 = false;
+		
 		// Propagating values back from observations into the models intermediate variables.
 		{
 			count1 = obs1;

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$MultiThreadCPU_optimisedModel.java
@@ -10,6 +10,8 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	private double bias;
 	private int count1;
 	private int count2;
+	private boolean fixedFlag$sample11 = false;
+	private boolean fixedFlag$sample12 = false;
 	private boolean fixedFlag$sample8 = false;
 	private boolean fixedProbFlag$sample11 = false;
 	private boolean fixedProbFlag$sample12 = false;
@@ -63,6 +65,30 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final int get$count2() {
 		return count2;
+	}
+
+	// Getter for fixedFlag$sample11.
+	@Override
+	public final boolean get$fixedFlag$sample11() {
+		return fixedFlag$sample11;
+	}
+
+	// Setter for fixedFlag$sample11.
+	@Override
+	public final void set$fixedFlag$sample11(boolean cv$value) {
+		fixedFlag$sample11 = cv$value;
+	}
+
+	// Getter for fixedFlag$sample12.
+	@Override
+	public final boolean get$fixedFlag$sample12() {
+		return fixedFlag$sample12;
+	}
+
+	// Setter for fixedFlag$sample12.
+	@Override
+	public final void set$fixedFlag$sample12(boolean cv$value) {
+		fixedFlag$sample12 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample8.
@@ -477,9 +503,12 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGeneration() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		total = (count1 + count2);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if((!fixedFlag$sample11 || !fixedFlag$sample12))
+			total = (count1 + count2);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -497,8 +526,10 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationPrime() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
 		total = (count1 + count2);
 	}
 
@@ -610,6 +641,10 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample11 = false;
+		fixedFlag$sample12 = false;
+		
 		// Propagating values back from observations into the models intermediate variables.
 		count1 = obs1;
 		count2 = obs2;

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$MultiThreadCPU_optimisedModelNoComments.java
@@ -8,6 +8,8 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	private double bias;
 	private int count1;
 	private int count2;
+	private boolean fixedFlag$sample11 = false;
+	private boolean fixedFlag$sample12 = false;
 	private boolean fixedFlag$sample8 = false;
 	private boolean fixedProbFlag$sample11 = false;
 	private boolean fixedProbFlag$sample12 = false;
@@ -49,6 +51,26 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final int get$count2() {
 		return count2;
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample11() {
+		return fixedFlag$sample11;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample11(boolean cv$value) {
+		fixedFlag$sample11 = cv$value;
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample12() {
+		return fixedFlag$sample12;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample12(boolean cv$value) {
+		fixedFlag$sample12 = cv$value;
 	}
 
 	@Override
@@ -180,9 +202,12 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGeneration() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		total = (count1 + count2);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if((!fixedFlag$sample11 || !fixedFlag$sample12))
+			total = (count1 + count2);
 	}
 
 	@Override
@@ -195,8 +220,10 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationPrime() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
 		total = (count1 + count2);
 	}
 
@@ -262,6 +289,8 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	@Override
 	public final void propagateObservedValues() {
+		fixedFlag$sample11 = false;
+		fixedFlag$sample12 = false;
 		count1 = obs1;
 		count2 = obs2;
 		total = (obs1 + obs2);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$MultiThreadCPU_optimisedModelSingle.java
@@ -10,6 +10,8 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	private double bias;
 	private int count1;
 	private int count2;
+	private boolean fixedFlag$sample11 = false;
+	private boolean fixedFlag$sample12 = false;
 	private boolean fixedFlag$sample8 = false;
 	private boolean fixedProbFlag$sample11 = false;
 	private boolean fixedProbFlag$sample12 = false;
@@ -63,6 +65,30 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final int get$count2() {
 		return count2;
+	}
+
+	// Getter for fixedFlag$sample11.
+	@Override
+	public final boolean get$fixedFlag$sample11() {
+		return fixedFlag$sample11;
+	}
+
+	// Setter for fixedFlag$sample11.
+	@Override
+	public final void set$fixedFlag$sample11(boolean cv$value) {
+		fixedFlag$sample11 = cv$value;
+	}
+
+	// Getter for fixedFlag$sample12.
+	@Override
+	public final boolean get$fixedFlag$sample12() {
+		return fixedFlag$sample12;
+	}
+
+	// Setter for fixedFlag$sample12.
+	@Override
+	public final void set$fixedFlag$sample12(boolean cv$value) {
+		fixedFlag$sample12 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample8.
@@ -477,9 +503,12 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGeneration() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		total = (count1 + count2);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if((!fixedFlag$sample11 || !fixedFlag$sample12))
+			total = (count1 + count2);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -497,8 +526,10 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void forwardGenerationPrime() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
 		total = (count1 + count2);
 	}
 
@@ -610,6 +641,10 @@ class Flip1CoinMK20$MultiThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample11 = false;
+		fixedFlag$sample12 = false;
+		
 		// Propagating values back from observations into the models intermediate variables.
 		count1 = obs1;
 		count2 = obs2;

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$SingleThreadCPU_model.java
@@ -10,6 +10,8 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	private double bias;
 	private int count1;
 	private int count2;
+	private boolean fixedFlag$sample11 = false;
+	private boolean fixedFlag$sample12 = false;
 	private boolean fixedFlag$sample8 = false;
 	private boolean fixedProbFlag$sample11 = false;
 	private boolean fixedProbFlag$sample12 = false;
@@ -63,6 +65,30 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final int get$count2() {
 		return count2;
+	}
+
+	// Getter for fixedFlag$sample11.
+	@Override
+	public final boolean get$fixedFlag$sample11() {
+		return fixedFlag$sample11;
+	}
+
+	// Setter for fixedFlag$sample11.
+	@Override
+	public final void set$fixedFlag$sample11(boolean cv$value) {
+		fixedFlag$sample11 = cv$value;
+	}
+
+	// Getter for fixedFlag$sample12.
+	@Override
+	public final boolean get$fixedFlag$sample12() {
+		return fixedFlag$sample12;
+	}
+
+	// Setter for fixedFlag$sample12.
+	@Override
+	public final void set$fixedFlag$sample12(boolean cv$value) {
+		fixedFlag$sample12 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample8.
@@ -502,9 +528,12 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGeneration() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		total = (count1 + count2);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!(fixedFlag$sample11 && fixedFlag$sample12))
+			total = (count1 + count2);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -522,8 +551,10 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationPrime() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
 		total = (count1 + count2);
 	}
 
@@ -642,6 +673,10 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample11 = false;
+		fixedFlag$sample12 = false;
+		
 		// Propagating values back from observations into the models intermediate variables.
 		{
 			count1 = obs1;

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$SingleThreadCPU_modelNoComments.java
@@ -8,6 +8,8 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	private double bias;
 	private int count1;
 	private int count2;
+	private boolean fixedFlag$sample11 = false;
+	private boolean fixedFlag$sample12 = false;
 	private boolean fixedFlag$sample8 = false;
 	private boolean fixedProbFlag$sample11 = false;
 	private boolean fixedProbFlag$sample12 = false;
@@ -49,6 +51,26 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final int get$count2() {
 		return count2;
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample11() {
+		return fixedFlag$sample11;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample11(boolean cv$value) {
+		fixedFlag$sample11 = cv$value;
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample12() {
+		return fixedFlag$sample12;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample12(boolean cv$value) {
+		fixedFlag$sample12 = cv$value;
 	}
 
 	@Override
@@ -314,9 +336,12 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGeneration() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		total = (count1 + count2);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!(fixedFlag$sample11 && fixedFlag$sample12))
+			total = (count1 + count2);
 	}
 
 	@Override
@@ -329,8 +354,10 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationPrime() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
 		total = (count1 + count2);
 	}
 
@@ -401,6 +428,8 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 
 	@Override
 	public final void propagateObservedValues() {
+		fixedFlag$sample11 = false;
+		fixedFlag$sample12 = false;
 		{
 			count1 = obs1;
 			count2 = obs2;

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$SingleThreadCPU_modelSingle.java
@@ -10,6 +10,8 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	private double bias;
 	private int count1;
 	private int count2;
+	private boolean fixedFlag$sample11 = false;
+	private boolean fixedFlag$sample12 = false;
 	private boolean fixedFlag$sample8 = false;
 	private boolean fixedProbFlag$sample11 = false;
 	private boolean fixedProbFlag$sample12 = false;
@@ -63,6 +65,30 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final int get$count2() {
 		return count2;
+	}
+
+	// Getter for fixedFlag$sample11.
+	@Override
+	public final boolean get$fixedFlag$sample11() {
+		return fixedFlag$sample11;
+	}
+
+	// Setter for fixedFlag$sample11.
+	@Override
+	public final void set$fixedFlag$sample11(boolean cv$value) {
+		fixedFlag$sample11 = cv$value;
+	}
+
+	// Getter for fixedFlag$sample12.
+	@Override
+	public final boolean get$fixedFlag$sample12() {
+		return fixedFlag$sample12;
+	}
+
+	// Setter for fixedFlag$sample12.
+	@Override
+	public final void set$fixedFlag$sample12(boolean cv$value) {
+		fixedFlag$sample12 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample8.
@@ -502,9 +528,12 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGeneration() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		total = (count1 + count2);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!(fixedFlag$sample11 && fixedFlag$sample12))
+			total = (count1 + count2);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -522,8 +551,10 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationPrime() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
 		total = (count1 + count2);
 	}
 
@@ -642,6 +673,10 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample11 = false;
+		fixedFlag$sample12 = false;
+		
 		// Propagating values back from observations into the models intermediate variables.
 		{
 			count1 = obs1;

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$SingleThreadCPU_optimisedModel.java
@@ -10,6 +10,8 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	private double bias;
 	private int count1;
 	private int count2;
+	private boolean fixedFlag$sample11 = false;
+	private boolean fixedFlag$sample12 = false;
 	private boolean fixedFlag$sample8 = false;
 	private boolean fixedProbFlag$sample11 = false;
 	private boolean fixedProbFlag$sample12 = false;
@@ -63,6 +65,30 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final int get$count2() {
 		return count2;
+	}
+
+	// Getter for fixedFlag$sample11.
+	@Override
+	public final boolean get$fixedFlag$sample11() {
+		return fixedFlag$sample11;
+	}
+
+	// Setter for fixedFlag$sample11.
+	@Override
+	public final void set$fixedFlag$sample11(boolean cv$value) {
+		fixedFlag$sample11 = cv$value;
+	}
+
+	// Getter for fixedFlag$sample12.
+	@Override
+	public final boolean get$fixedFlag$sample12() {
+		return fixedFlag$sample12;
+	}
+
+	// Setter for fixedFlag$sample12.
+	@Override
+	public final void set$fixedFlag$sample12(boolean cv$value) {
+		fixedFlag$sample12 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample8.
@@ -477,9 +503,12 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGeneration() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		total = (count1 + count2);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if((!fixedFlag$sample11 || !fixedFlag$sample12))
+			total = (count1 + count2);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -497,8 +526,10 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationPrime() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
 		total = (count1 + count2);
 	}
 
@@ -610,6 +641,10 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample11 = false;
+		fixedFlag$sample12 = false;
+		
 		// Propagating values back from observations into the models intermediate variables.
 		count1 = obs1;
 		count2 = obs2;

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$SingleThreadCPU_optimisedModelNoComments.java
@@ -8,6 +8,8 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	private double bias;
 	private int count1;
 	private int count2;
+	private boolean fixedFlag$sample11 = false;
+	private boolean fixedFlag$sample12 = false;
 	private boolean fixedFlag$sample8 = false;
 	private boolean fixedProbFlag$sample11 = false;
 	private boolean fixedProbFlag$sample12 = false;
@@ -49,6 +51,26 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final int get$count2() {
 		return count2;
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample11() {
+		return fixedFlag$sample11;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample11(boolean cv$value) {
+		fixedFlag$sample11 = cv$value;
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample12() {
+		return fixedFlag$sample12;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample12(boolean cv$value) {
+		fixedFlag$sample12 = cv$value;
 	}
 
 	@Override
@@ -180,9 +202,12 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGeneration() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		total = (count1 + count2);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if((!fixedFlag$sample11 || !fixedFlag$sample12))
+			total = (count1 + count2);
 	}
 
 	@Override
@@ -195,8 +220,10 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationPrime() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
 		total = (count1 + count2);
 	}
 
@@ -262,6 +289,8 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 
 	@Override
 	public final void propagateObservedValues() {
+		fixedFlag$sample11 = false;
+		fixedFlag$sample12 = false;
 		count1 = obs1;
 		count2 = obs2;
 		total = (obs1 + obs2);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20$SingleThreadCPU_optimisedModelSingle.java
@@ -10,6 +10,8 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	private double bias;
 	private int count1;
 	private int count2;
+	private boolean fixedFlag$sample11 = false;
+	private boolean fixedFlag$sample12 = false;
 	private boolean fixedFlag$sample8 = false;
 	private boolean fixedProbFlag$sample11 = false;
 	private boolean fixedProbFlag$sample12 = false;
@@ -63,6 +65,30 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	@Override
 	public final int get$count2() {
 		return count2;
+	}
+
+	// Getter for fixedFlag$sample11.
+	@Override
+	public final boolean get$fixedFlag$sample11() {
+		return fixedFlag$sample11;
+	}
+
+	// Setter for fixedFlag$sample11.
+	@Override
+	public final void set$fixedFlag$sample11(boolean cv$value) {
+		fixedFlag$sample11 = cv$value;
+	}
+
+	// Getter for fixedFlag$sample12.
+	@Override
+	public final boolean get$fixedFlag$sample12() {
+		return fixedFlag$sample12;
+	}
+
+	// Setter for fixedFlag$sample12.
+	@Override
+	public final void set$fixedFlag$sample12(boolean cv$value) {
+		fixedFlag$sample12 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample8.
@@ -477,9 +503,12 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGeneration() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		total = (count1 + count2);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if((!fixedFlag$sample11 || !fixedFlag$sample12))
+			total = (count1 + count2);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -497,8 +526,10 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	public final void forwardGenerationPrime() {
 		if(!fixedFlag$sample8)
 			bias = DistributionSampling.sampleBeta(RNG$, 1.0, 1.0);
-		count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
-		count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample11)
+			count1 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
+		if(!fixedFlag$sample12)
+			count2 = DistributionSampling.sampleBinomial(RNG$, bias, 100);
 		total = (count1 + count2);
 	}
 
@@ -610,6 +641,10 @@ class Flip1CoinMK20$SingleThreadCPU extends org.sandwood.runtime.internal.model.
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample11 = false;
+		fixedFlag$sample12 = false;
+		
 		// Propagating values back from observations into the models intermediate variables.
 		count1 = obs1;
 		count2 = obs2;

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -130,7 +131,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -130,7 +131,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -130,7 +131,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -130,7 +131,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -130,7 +131,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK20/Flip1CoinMK20_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -130,7 +131,7 @@ public class Flip1CoinMK20 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2b/Flip1CoinMK2b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2b/Flip1CoinMK2b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2b/Flip1CoinMK2b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2b/Flip1CoinMK2b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2b/Flip1CoinMK2b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2b/Flip1CoinMK2b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2b/Flip1CoinMK2b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2b/Flip1CoinMK2b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2b/Flip1CoinMK2b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2b/Flip1CoinMK2b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2b/Flip1CoinMK2b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK2b/Flip1CoinMK2b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK3/Flip1CoinMK3_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK3/Flip1CoinMK3_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK3/Flip1CoinMK3_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK3/Flip1CoinMK3_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK3/Flip1CoinMK3_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK3/Flip1CoinMK3_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK3/Flip1CoinMK3_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK3/Flip1CoinMK3_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK3/Flip1CoinMK3_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK3/Flip1CoinMK3_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK3/Flip1CoinMK3_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK3/Flip1CoinMK3_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK4/Flip1CoinMK4_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK4/Flip1CoinMK4_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK4/Flip1CoinMK4_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK4/Flip1CoinMK4_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK4/Flip1CoinMK4_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK4/Flip1CoinMK4_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK4/Flip1CoinMK4_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK4/Flip1CoinMK4_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK4/Flip1CoinMK4_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK4/Flip1CoinMK4_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK4/Flip1CoinMK4_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK4/Flip1CoinMK4_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK5/Flip1CoinMK5_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK5/Flip1CoinMK5_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK5/Flip1CoinMK5_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK5/Flip1CoinMK5_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK5/Flip1CoinMK5_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK5/Flip1CoinMK5_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK5/Flip1CoinMK5_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK5/Flip1CoinMK5_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK5/Flip1CoinMK5_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK5/Flip1CoinMK5_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK5/Flip1CoinMK5_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK5/Flip1CoinMK5_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK6/Flip1CoinMK6_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK6/Flip1CoinMK6_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK6/Flip1CoinMK6_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK6/Flip1CoinMK6_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK6/Flip1CoinMK6_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK6/Flip1CoinMK6_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK6/Flip1CoinMK6_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK6/Flip1CoinMK6_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK6/Flip1CoinMK6_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK6/Flip1CoinMK6_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK6/Flip1CoinMK6_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK6/Flip1CoinMK6_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -99,7 +100,7 @@ public class Flip1CoinMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK7/Flip1CoinMK7_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK7/Flip1CoinMK7_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK7/Flip1CoinMK7_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK7/Flip1CoinMK7_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK7/Flip1CoinMK7_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK7/Flip1CoinMK7_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK7/Flip1CoinMK7_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK7/Flip1CoinMK7_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK7/Flip1CoinMK7_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK7/Flip1CoinMK7_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK7/Flip1CoinMK7_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK7/Flip1CoinMK7_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK8/Flip1CoinMK8_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK8/Flip1CoinMK8_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK8/Flip1CoinMK8_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK8/Flip1CoinMK8_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK8/Flip1CoinMK8_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK8/Flip1CoinMK8_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK8/Flip1CoinMK8_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK8/Flip1CoinMK8_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK8/Flip1CoinMK8_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK8/Flip1CoinMK8_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK8/Flip1CoinMK8_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK8/Flip1CoinMK8_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK9/Flip1CoinMK9_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK9/Flip1CoinMK9_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK9 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK9/Flip1CoinMK9_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK9/Flip1CoinMK9_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK9 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK9/Flip1CoinMK9_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK9/Flip1CoinMK9_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK9 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK9/Flip1CoinMK9_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK9/Flip1CoinMK9_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK9 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK9/Flip1CoinMK9_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK9/Flip1CoinMK9_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK9 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK9/Flip1CoinMK9_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip1CoinMK9/Flip1CoinMK9_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Flip1CoinMK9 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK1/Flip2CoinsMK1_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK1/Flip2CoinsMK1_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK1/Flip2CoinsMK1_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK1/Flip2CoinsMK1_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK1/Flip2CoinsMK1_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK1/Flip2CoinsMK1_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK1/Flip2CoinsMK1_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK1/Flip2CoinsMK1_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK1/Flip2CoinsMK1_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK1/Flip2CoinsMK1_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK1/Flip2CoinsMK1_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK1/Flip2CoinsMK1_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK10/Flip2CoinsMK10_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK10/Flip2CoinsMK10_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK10 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK10/Flip2CoinsMK10_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK10/Flip2CoinsMK10_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK10 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK10/Flip2CoinsMK10_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK10/Flip2CoinsMK10_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK10 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK10/Flip2CoinsMK10_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK10/Flip2CoinsMK10_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK10 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK10/Flip2CoinsMK10_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK10/Flip2CoinsMK10_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK10 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK10/Flip2CoinsMK10_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK10/Flip2CoinsMK10_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK10 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK11/Flip2CoinsMK11_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK11/Flip2CoinsMK11_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK11 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK11/Flip2CoinsMK11_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK11/Flip2CoinsMK11_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK11 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK11/Flip2CoinsMK11_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK11/Flip2CoinsMK11_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK11 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK11/Flip2CoinsMK11_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK11/Flip2CoinsMK11_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK11 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK11/Flip2CoinsMK11_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK11/Flip2CoinsMK11_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK11 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK11/Flip2CoinsMK11_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK11/Flip2CoinsMK11_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK11 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK12/Flip2CoinsMK12_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK12/Flip2CoinsMK12_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK12/Flip2CoinsMK12_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK12/Flip2CoinsMK12_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK12/Flip2CoinsMK12_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK12/Flip2CoinsMK12_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK12/Flip2CoinsMK12_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK12/Flip2CoinsMK12_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK12/Flip2CoinsMK12_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK12/Flip2CoinsMK12_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK12/Flip2CoinsMK12_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK12/Flip2CoinsMK12_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class Flip2CoinsMK12 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK2/Flip2CoinsMK2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK2/Flip2CoinsMK2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK2/Flip2CoinsMK2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK2/Flip2CoinsMK2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK2/Flip2CoinsMK2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK2/Flip2CoinsMK2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK2/Flip2CoinsMK2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK2/Flip2CoinsMK2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK2/Flip2CoinsMK2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK2/Flip2CoinsMK2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK2/Flip2CoinsMK2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK2/Flip2CoinsMK2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK3/Flip2CoinsMK3_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK3/Flip2CoinsMK3_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK3/Flip2CoinsMK3_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK3/Flip2CoinsMK3_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK3/Flip2CoinsMK3_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK3/Flip2CoinsMK3_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK3/Flip2CoinsMK3_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK3/Flip2CoinsMK3_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK3/Flip2CoinsMK3_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK3/Flip2CoinsMK3_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK3/Flip2CoinsMK3_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK3/Flip2CoinsMK3_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK4/Flip2CoinsMK4_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK4/Flip2CoinsMK4_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK4/Flip2CoinsMK4_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK4/Flip2CoinsMK4_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK4/Flip2CoinsMK4_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK4/Flip2CoinsMK4_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK4/Flip2CoinsMK4_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK4/Flip2CoinsMK4_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK4/Flip2CoinsMK4_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK4/Flip2CoinsMK4_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK4/Flip2CoinsMK4_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK4/Flip2CoinsMK4_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5/Flip2CoinsMK5_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5/Flip2CoinsMK5_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5/Flip2CoinsMK5_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5/Flip2CoinsMK5_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5/Flip2CoinsMK5_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5/Flip2CoinsMK5_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5/Flip2CoinsMK5_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5/Flip2CoinsMK5_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5/Flip2CoinsMK5_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5/Flip2CoinsMK5_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5/Flip2CoinsMK5_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5/Flip2CoinsMK5_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5b/Flip2CoinsMK5b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5b/Flip2CoinsMK5b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK5b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5b/Flip2CoinsMK5b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5b/Flip2CoinsMK5b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK5b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5b/Flip2CoinsMK5b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5b/Flip2CoinsMK5b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK5b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5b/Flip2CoinsMK5b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5b/Flip2CoinsMK5b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK5b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5b/Flip2CoinsMK5b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5b/Flip2CoinsMK5b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK5b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5b/Flip2CoinsMK5b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK5b/Flip2CoinsMK5b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK5b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK6/Flip2CoinsMK6_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK6/Flip2CoinsMK6_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK6/Flip2CoinsMK6_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK6/Flip2CoinsMK6_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK6/Flip2CoinsMK6_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK6/Flip2CoinsMK6_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK6/Flip2CoinsMK6_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK6/Flip2CoinsMK6_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK6/Flip2CoinsMK6_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK6/Flip2CoinsMK6_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK6/Flip2CoinsMK6_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK6/Flip2CoinsMK6_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK7/Flip2CoinsMK7_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK7/Flip2CoinsMK7_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK7/Flip2CoinsMK7_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK7/Flip2CoinsMK7_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK7/Flip2CoinsMK7_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK7/Flip2CoinsMK7_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK7/Flip2CoinsMK7_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK7/Flip2CoinsMK7_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK7/Flip2CoinsMK7_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK7/Flip2CoinsMK7_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK7/Flip2CoinsMK7_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK7/Flip2CoinsMK7_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK8/Flip2CoinsMK8_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK8/Flip2CoinsMK8_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK8/Flip2CoinsMK8_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK8/Flip2CoinsMK8_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK8/Flip2CoinsMK8_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK8/Flip2CoinsMK8_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK8/Flip2CoinsMK8_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK8/Flip2CoinsMK8_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK8/Flip2CoinsMK8_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK8/Flip2CoinsMK8_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK8/Flip2CoinsMK8_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK8/Flip2CoinsMK8_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK9/Flip2CoinsMK9_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK9/Flip2CoinsMK9_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK9 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK9/Flip2CoinsMK9_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK9/Flip2CoinsMK9_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK9 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK9/Flip2CoinsMK9_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK9/Flip2CoinsMK9_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK9 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK9/Flip2CoinsMK9_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK9/Flip2CoinsMK9_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK9 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK9/Flip2CoinsMK9_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK9/Flip2CoinsMK9_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK9 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK9/Flip2CoinsMK9_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Flip2CoinsMK9/Flip2CoinsMK9_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class Flip2CoinsMK9 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$CoreInterface_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$CoreInterface_model.java
@@ -23,12 +23,6 @@ interface GaussianMixtureTest$CoreInterface extends org.sandwood.runtime.interna
 	// Setter for fixedFlag$sample52.
 	public void set$fixedFlag$sample52(boolean cv$value);
 
-	// Getter for fixedFlag$sample68.
-	public boolean get$fixedFlag$sample68();
-
-	// Setter for fixedFlag$sample68.
-	public void set$fixedFlag$sample68(boolean cv$value);
-
 	// Getter for k.
 	public int get$k();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$CoreInterface_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$CoreInterface_modelNoComments.java
@@ -8,8 +8,6 @@ interface GaussianMixtureTest$CoreInterface extends org.sandwood.runtime.interna
 	public void set$fixedFlag$sample34(boolean cv$value);
 	public boolean get$fixedFlag$sample52();
 	public void set$fixedFlag$sample52(boolean cv$value);
-	public boolean get$fixedFlag$sample68();
-	public void set$fixedFlag$sample68(boolean cv$value);
 	public int get$k();
 	public int get$length$xMeasured();
 	public void set$length$xMeasured(int cv$value);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$CoreInterface_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$CoreInterface_modelSingle.java
@@ -23,12 +23,6 @@ interface GaussianMixtureTest$CoreInterface extends org.sandwood.runtime.interna
 	// Setter for fixedFlag$sample52.
 	public void set$fixedFlag$sample52(boolean cv$value);
 
-	// Getter for fixedFlag$sample68.
-	public boolean get$fixedFlag$sample68();
-
-	// Setter for fixedFlag$sample68.
-	public void set$fixedFlag$sample68(boolean cv$value);
-
 	// Getter for k.
 	public int get$k();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$CoreInterface_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$CoreInterface_optimisedModel.java
@@ -23,12 +23,6 @@ interface GaussianMixtureTest$CoreInterface extends org.sandwood.runtime.interna
 	// Setter for fixedFlag$sample52.
 	public void set$fixedFlag$sample52(boolean cv$value);
 
-	// Getter for fixedFlag$sample68.
-	public boolean get$fixedFlag$sample68();
-
-	// Setter for fixedFlag$sample68.
-	public void set$fixedFlag$sample68(boolean cv$value);
-
 	// Getter for k.
 	public int get$k();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$CoreInterface_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$CoreInterface_optimisedModelNoComments.java
@@ -8,8 +8,6 @@ interface GaussianMixtureTest$CoreInterface extends org.sandwood.runtime.interna
 	public void set$fixedFlag$sample34(boolean cv$value);
 	public boolean get$fixedFlag$sample52();
 	public void set$fixedFlag$sample52(boolean cv$value);
-	public boolean get$fixedFlag$sample68();
-	public void set$fixedFlag$sample68(boolean cv$value);
 	public int get$k();
 	public int get$length$xMeasured();
 	public void set$length$xMeasured(int cv$value);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$CoreInterface_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$CoreInterface_optimisedModelSingle.java
@@ -23,12 +23,6 @@ interface GaussianMixtureTest$CoreInterface extends org.sandwood.runtime.interna
 	// Setter for fixedFlag$sample52.
 	public void set$fixedFlag$sample52(boolean cv$value);
 
-	// Getter for fixedFlag$sample68.
-	public boolean get$fixedFlag$sample68();
-
-	// Setter for fixedFlag$sample68.
-	public void set$fixedFlag$sample68(boolean cv$value);
-
 	// Getter for k.
 	public int get$k();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$MultiThreadCPU_model.java
@@ -14,12 +14,9 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	private boolean fixedFlag$sample17 = false;
 	private boolean fixedFlag$sample34 = false;
 	private boolean fixedFlag$sample52 = false;
-	private boolean fixedFlag$sample68 = false;
 	private boolean fixedProbFlag$sample17 = false;
 	private boolean fixedProbFlag$sample34 = false;
 	private boolean fixedProbFlag$sample52 = false;
-	private boolean fixedProbFlag$sample68 = false;
-	private boolean fixedProbFlag$sample72 = false;
 	private int k;
 	private int length$xMeasured;
 	private double logProbability$$evidence;
@@ -72,10 +69,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// Should the probability of sample 17 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample17 = (fixedFlag$sample17 && fixedProbFlag$sample17);
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample68 = (fixedFlag$sample17 && fixedProbFlag$sample68);
 	}
 
 	// Getter for fixedFlag$sample34.
@@ -94,10 +87,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// Should the probability of sample 34 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample34 = (fixedFlag$sample34 && fixedProbFlag$sample34);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample72 = (fixedFlag$sample34 && fixedProbFlag$sample72);
 	}
 
 	// Getter for fixedFlag$sample52.
@@ -116,32 +105,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// Should the probability of sample 52 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample52 = (fixedFlag$sample52 && fixedProbFlag$sample52);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample72 = (fixedFlag$sample52 && fixedProbFlag$sample72);
-	}
-
-	// Getter for fixedFlag$sample68.
-	@Override
-	public final boolean get$fixedFlag$sample68() {
-		return fixedFlag$sample68;
-	}
-
-	// Setter for fixedFlag$sample68.
-	@Override
-	public final void set$fixedFlag$sample68(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample68 including if probabilities
-		// need to be updated.
-		fixedFlag$sample68 = cv$value;
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedProbFlag$sample68);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample72 = (fixedFlag$sample68 && fixedProbFlag$sample72);
 	}
 
 	// Getter for k.
@@ -220,9 +183,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 34 as it depends on mu.
 		fixedProbFlag$sample34 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on mu.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for phi.
@@ -241,9 +201,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 17 as it depends on phi.
 		fixedProbFlag$sample17 = false;
-		
-		// Unset the fixed probability flag for sample 68 as it depends on phi.
-		fixedProbFlag$sample68 = false;
 	}
 
 	// Getter for sigma.
@@ -262,9 +219,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 52 as it depends on sigma.
 		fixedProbFlag$sample52 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on sigma.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for x.
@@ -628,226 +582,149 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	// Calculate the probability of the samples represented by sample68 using sampled
 	// values.
 	private final void logProbabilityValue$sample68() {
-		// Determine if we need to calculate the values for sample task 68 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample68) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = z[((i$var66 - 0) / 1)];
 				{
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = z[((i$var66 - 0) / 1)];
 					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < k))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < k))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var67[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample68[((i$var66 - 0) / 1)] = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var67[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedFlag$sample17);
+			// Store the sample task probability
+			logProbability$sample68[((i$var66 - 0) / 1)] = cv$sampleProbability;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample68[((i$var66 - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var67[((i$var66 - 0) / 1)] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$z = (logProbability$z + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample72 using sampled
 	// values.
 	private final void logProbabilityValue$sample72() {
-		// Determine if we need to calculate the values for sample task 72 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample72) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = x[i$var66];
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = x[i$var66];
 					{
-						{
-							double var69 = mu[z[((i$var66 - 0) / 1)]];
-							double var70 = sigma[z[((i$var66 - 0) / 1)]];
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var69) / Math.sqrt(var70))) - (0.5 * Math.log(var70))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var69 = mu[z[((i$var66 - 0) / 1)]];
+						double var70 = sigma[z[((i$var66 - 0) / 1)]];
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var69) / Math.sqrt(var70))) - (0.5 * Math.log(var70))));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var71[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample72[((i$var66 - 0) / 1)] = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$x = (logProbability$x + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample72 = ((fixedFlag$sample34 && fixedFlag$sample52) && fixedFlag$sample68);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var71[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample72[((i$var66 - 0) / 1)] = cv$sampleProbability;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample72[((i$var66 - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var71[((i$var66 - 0) / 1)] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$x = (logProbability$x + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$x = (logProbability$x + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -1347,12 +1224,9 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			x = new double[length$xMeasured];
 		}
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample68) {
-			// Constructor for z
-			{
-				z = new int[((((length$xMeasured - 1) - 0) / 1) + 1)];
-			}
+		// Constructor for z
+		{
+			z = new int[((((length$xMeasured - 1) - 0) / 1) + 1)];
 		}
 		
 		// Constructor for logProbability$var67
@@ -1418,8 +1292,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
 					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 						x[i$var66] = ((Math.sqrt(sigma[z[((i$var66 - 0) / 1)]]) * DistributionSampling.sampleGaussian(RNG$1)) + mu[z[((i$var66 - 0) / 1)]]);
 					}
 			}
@@ -1466,10 +1339,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 				
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
-					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
-					}
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 			}
 		);
 	}
@@ -1514,8 +1385,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
 					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 						x[i$var66] = ((Math.sqrt(sigma[z[((i$var66 - 0) / 1)]]) * DistributionSampling.sampleGaussian(RNG$1)) + mu[z[((i$var66 - 0) / 1)]]);
 					}
 			}
@@ -1561,10 +1431,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 				
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
-					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
-					}
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 			}
 		);
 	}
@@ -1609,10 +1477,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 				
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
-					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
-					}
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 			}
 		);
 	}
@@ -1657,10 +1523,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					
 						// Inner loop for running batches of iterations, each batch has its own random number
 						// generator.
-						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-							if(!fixedFlag$sample68)
-								sample68(i$var66, threadID$i$var66, RNG$1);
-						}
+						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+							sample68(i$var66, threadID$i$var66, RNG$1);
 				}
 			);
 		}
@@ -1672,10 +1536,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					
 						// Inner loop for running batches of iterations, each batch has its own random number
 						// generator.
-						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-							if(!fixedFlag$sample68)
-								sample68(i$var66, threadID$i$var66, RNG$1);
-						}
+						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+							sample68(i$var66, threadID$i$var66, RNG$1);
 				}
 			);
 			
@@ -1754,17 +1616,13 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var67[((i$var66 - 0) / 1)] = Double.NaN;
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample68[((i$var66 - 0) / 1)] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample68[((i$var66 - 0) / 1)] = Double.NaN;
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var71[((i$var66 - 0) / 1)] = Double.NaN;
 		logProbability$x = 0.0;
-		if(!fixedProbFlag$sample72) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample72[((i$var66 - 0) / 1)] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample72[((i$var66 - 0) / 1)] = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -1780,8 +1638,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			logProbabilityValue$sample34();
 		if(fixedFlag$sample52)
 			logProbabilityValue$sample52();
-		if(fixedFlag$sample68)
-			logProbabilityValue$sample68();
 		logProbabilityValue$sample72();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$MultiThreadCPU_modelNoComments.java
@@ -12,12 +12,9 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	private boolean fixedFlag$sample17 = false;
 	private boolean fixedFlag$sample34 = false;
 	private boolean fixedFlag$sample52 = false;
-	private boolean fixedFlag$sample68 = false;
 	private boolean fixedProbFlag$sample17 = false;
 	private boolean fixedProbFlag$sample34 = false;
 	private boolean fixedProbFlag$sample52 = false;
-	private boolean fixedProbFlag$sample68 = false;
-	private boolean fixedProbFlag$sample72 = false;
 	private int k;
 	private int length$xMeasured;
 	private double logProbability$$evidence;
@@ -62,7 +59,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$fixedFlag$sample17(boolean cv$value) {
 		fixedFlag$sample17 = cv$value;
 		fixedProbFlag$sample17 = (fixedFlag$sample17 && fixedProbFlag$sample17);
-		fixedProbFlag$sample68 = (fixedFlag$sample17 && fixedProbFlag$sample68);
 	}
 
 	@Override
@@ -74,7 +70,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$fixedFlag$sample34(boolean cv$value) {
 		fixedFlag$sample34 = cv$value;
 		fixedProbFlag$sample34 = (fixedFlag$sample34 && fixedProbFlag$sample34);
-		fixedProbFlag$sample72 = (fixedFlag$sample34 && fixedProbFlag$sample72);
 	}
 
 	@Override
@@ -86,19 +81,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$fixedFlag$sample52(boolean cv$value) {
 		fixedFlag$sample52 = cv$value;
 		fixedProbFlag$sample52 = (fixedFlag$sample52 && fixedProbFlag$sample52);
-		fixedProbFlag$sample72 = (fixedFlag$sample52 && fixedProbFlag$sample72);
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample68() {
-		return fixedFlag$sample68;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample68(boolean cv$value) {
-		fixedFlag$sample68 = cv$value;
-		fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedProbFlag$sample68);
-		fixedProbFlag$sample72 = (fixedFlag$sample68 && fixedProbFlag$sample72);
 	}
 
 	@Override
@@ -160,7 +142,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$mu(double[] cv$value) {
 		mu = cv$value;
 		fixedProbFlag$sample34 = false;
-		fixedProbFlag$sample72 = false;
 	}
 
 	@Override
@@ -172,7 +153,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$phi(double[] cv$value) {
 		phi = cv$value;
 		fixedProbFlag$sample17 = false;
-		fixedProbFlag$sample68 = false;
 	}
 
 	@Override
@@ -184,7 +164,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$sigma(double[] cv$value) {
 		sigma = cv$value;
 		fixedProbFlag$sample52 = false;
-		fixedProbFlag$sample72 = false;
 	}
 
 	@Override
@@ -382,121 +361,84 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	}
 
 	private final void logProbabilityValue$sample68() {
-		if(!fixedProbFlag$sample68) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				int cv$sampleValue = z[((i$var66 - 0) / 1)];
 				{
-					int cv$sampleValue = z[((i$var66 - 0) / 1)];
 					{
-						{
-							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < k))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < k))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var67[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
-				logProbability$sample68[((i$var66 - 0) / 1)] = cv$sampleProbability;
 			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedFlag$sample17);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample68[((i$var66 - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var67[((i$var66 - 0) / 1)] = cv$rvAccumulator;
-			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var67[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
+			logProbability$sample68[((i$var66 - 0) / 1)] = cv$sampleProbability;
 		}
+		logProbability$z = (logProbability$z + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample72() {
-		if(!fixedProbFlag$sample72) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				double cv$sampleValue = x[i$var66];
 				{
-					double cv$sampleValue = x[i$var66];
 					{
-						{
-							double var69 = mu[z[((i$var66 - 0) / 1)]];
-							double var70 = sigma[z[((i$var66 - 0) / 1)]];
-							double cv$weightedProbability = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var69) / Math.sqrt(var70))) - (0.5 * Math.log(var70))));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var69 = mu[z[((i$var66 - 0) / 1)]];
+						double var70 = sigma[z[((i$var66 - 0) / 1)]];
+						double cv$weightedProbability = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var69) / Math.sqrt(var70))) - (0.5 * Math.log(var70))));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var71[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
-				logProbability$sample72[((i$var66 - 0) / 1)] = cv$sampleProbability;
 			}
-			logProbability$x = (logProbability$x + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample72 = ((fixedFlag$sample34 && fixedFlag$sample52) && fixedFlag$sample68);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample72[((i$var66 - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var71[((i$var66 - 0) / 1)] = cv$rvAccumulator;
-			}
-			logProbability$x = (logProbability$x + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var71[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
+			logProbability$sample72[((i$var66 - 0) / 1)] = cv$sampleProbability;
 		}
+		logProbability$x = (logProbability$x + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void sample17() {
@@ -794,10 +736,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		{
 			x = new double[length$xMeasured];
 		}
-		if(!fixedFlag$sample68) {
-			{
-				z = new int[((((length$xMeasured - 1) - 0) / 1) + 1)];
-			}
+		{
+			z = new int[((((length$xMeasured - 1) - 0) / 1) + 1)];
 		}
 		{
 			logProbability$var67 = new double[((((length$xMeasured - 1) - 0) / 1) + 1)];
@@ -837,8 +777,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		parallelFor(RNG$, 0, length$xMeasured, 1,
 			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
 				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 						x[i$var66] = ((Math.sqrt(sigma[z[((i$var66 - 0) / 1)]]) * DistributionSampling.sampleGaussian(RNG$1)) + mu[z[((i$var66 - 0) / 1)]]);
 					}
 			}
@@ -867,10 +806,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		);
 		parallelFor(RNG$, 0, length$xMeasured, 1,
 			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
-					}
+				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 			}
 		);
 	}
@@ -898,8 +835,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		parallelFor(RNG$, 0, length$xMeasured, 1,
 			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
 				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 						x[i$var66] = ((Math.sqrt(sigma[z[((i$var66 - 0) / 1)]]) * DistributionSampling.sampleGaussian(RNG$1)) + mu[z[((i$var66 - 0) / 1)]]);
 					}
 			}
@@ -928,10 +864,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		);
 		parallelFor(RNG$, 0, length$xMeasured, 1,
 			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
-					}
+				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 			}
 		);
 	}
@@ -958,10 +892,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		);
 		parallelFor(RNG$, 0, length$xMeasured, 1,
 			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
-					}
+				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 			}
 		);
 	}
@@ -989,19 +921,15 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			);
 			parallelFor(RNG$, 0, length$xMeasured, 1,
 				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-							if(!fixedFlag$sample68)
-								sample68(i$var66, threadID$i$var66, RNG$1);
-						}
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+							sample68(i$var66, threadID$i$var66, RNG$1);
 				}
 			);
 		} else {
 			parallelFor(RNG$, 0, length$xMeasured, 1,
 				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-							if(!fixedFlag$sample68)
-								sample68(i$var66, threadID$i$var66, RNG$1);
-						}
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+							sample68(i$var66, threadID$i$var66, RNG$1);
 				}
 			);
 			parallelFor(RNG$, 0, k, 1,
@@ -1054,17 +982,13 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var67[((i$var66 - 0) / 1)] = Double.NaN;
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample68[((i$var66 - 0) / 1)] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample68[((i$var66 - 0) / 1)] = Double.NaN;
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var71[((i$var66 - 0) / 1)] = Double.NaN;
 		logProbability$x = 0.0;
-		if(!fixedProbFlag$sample72) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample72[((i$var66 - 0) / 1)] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample72[((i$var66 - 0) / 1)] = Double.NaN;
 	}
 
 	@Override
@@ -1076,8 +1000,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			logProbabilityValue$sample34();
 		if(fixedFlag$sample52)
 			logProbabilityValue$sample52();
-		if(fixedFlag$sample68)
-			logProbabilityValue$sample68();
 		logProbabilityValue$sample72();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$MultiThreadCPU_modelSingle.java
@@ -14,12 +14,9 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	private boolean fixedFlag$sample17 = false;
 	private boolean fixedFlag$sample34 = false;
 	private boolean fixedFlag$sample52 = false;
-	private boolean fixedFlag$sample68 = false;
 	private boolean fixedProbFlag$sample17 = false;
 	private boolean fixedProbFlag$sample34 = false;
 	private boolean fixedProbFlag$sample52 = false;
-	private boolean fixedProbFlag$sample68 = false;
-	private boolean fixedProbFlag$sample72 = false;
 	private int k;
 	private int length$xMeasured;
 	private double logProbability$$evidence;
@@ -71,10 +68,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// Should the probability of sample 17 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample17 = (fixedFlag$sample17 && fixedProbFlag$sample17);
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample68 = (fixedFlag$sample17 && fixedProbFlag$sample68);
 	}
 
 	// Getter for fixedFlag$sample34.
@@ -93,10 +86,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// Should the probability of sample 34 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample34 = (fixedFlag$sample34 && fixedProbFlag$sample34);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample72 = (fixedFlag$sample34 && fixedProbFlag$sample72);
 	}
 
 	// Getter for fixedFlag$sample52.
@@ -115,32 +104,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// Should the probability of sample 52 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample52 = (fixedFlag$sample52 && fixedProbFlag$sample52);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample72 = (fixedFlag$sample52 && fixedProbFlag$sample72);
-	}
-
-	// Getter for fixedFlag$sample68.
-	@Override
-	public final boolean get$fixedFlag$sample68() {
-		return fixedFlag$sample68;
-	}
-
-	// Setter for fixedFlag$sample68.
-	@Override
-	public final void set$fixedFlag$sample68(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample68 including if probabilities
-		// need to be updated.
-		fixedFlag$sample68 = cv$value;
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedProbFlag$sample68);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample72 = (fixedFlag$sample68 && fixedProbFlag$sample72);
 	}
 
 	// Getter for k.
@@ -219,9 +182,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 34 as it depends on mu.
 		fixedProbFlag$sample34 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on mu.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for phi.
@@ -240,9 +200,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 17 as it depends on phi.
 		fixedProbFlag$sample17 = false;
-		
-		// Unset the fixed probability flag for sample 68 as it depends on phi.
-		fixedProbFlag$sample68 = false;
 	}
 
 	// Getter for sigma.
@@ -261,9 +218,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 52 as it depends on sigma.
 		fixedProbFlag$sample52 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on sigma.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for x.
@@ -637,226 +591,154 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	// Calculate the probability of the samples represented by sample68 using sampled
 	// values.
 	private final void logProbabilityValue$sample68() {
-		// Determine if we need to calculate the values for sample task 68 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample68) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = z[((i$var66 - 0) / 1)];
 				{
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = z[((i$var66 - 0) / 1)];
 					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < k))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < k))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var67 = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$z = cv$accumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedFlag$sample17);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$z;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var67 = cv$rvAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var67 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$z = cv$accumulator;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample72 using sampled
 	// values.
 	private final void logProbabilityValue$sample72() {
-		// Determine if we need to calculate the values for sample task 72 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample72) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = x[i$var66];
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = x[i$var66];
 					{
-						{
-							double var69 = mu[z[((i$var66 - 0) / 1)]];
-							double var70 = sigma[z[((i$var66 - 0) / 1)]];
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var69) / Math.sqrt(var70))) - (0.5 * Math.log(var70))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var69 = mu[z[((i$var66 - 0) / 1)]];
+						double var70 = sigma[z[((i$var66 - 0) / 1)]];
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var69) / Math.sqrt(var70))) - (0.5 * Math.log(var70))));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var71 = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$var72 = cv$accumulator;
-			
-			// Update the variable probability
-			logProbability$x = (logProbability$x + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample72 = ((fixedFlag$sample34 && fixedFlag$sample52) && fixedFlag$sample68);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var72;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var71 = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$x = (logProbability$x + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var71 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$var72 = cv$accumulator;
+		
+		// Update the variable probability
+		logProbability$x = (logProbability$x + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -1356,12 +1238,9 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			x = new double[length$xMeasured];
 		}
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample68) {
-			// Constructor for z
-			{
-				z = new int[((((length$xMeasured - 1) - 0) / 1) + 1)];
-			}
+		// Constructor for z
+		{
+			z = new int[((((length$xMeasured - 1) - 0) / 1) + 1)];
 		}
 		
 		// Allocate scratch space
@@ -1407,8 +1286,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
 					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 						x[i$var66] = ((Math.sqrt(sigma[z[((i$var66 - 0) / 1)]]) * DistributionSampling.sampleGaussian(RNG$1)) + mu[z[((i$var66 - 0) / 1)]]);
 					}
 			}
@@ -1455,10 +1333,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 				
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
-					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
-					}
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 			}
 		);
 	}
@@ -1503,8 +1379,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
 					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 						x[i$var66] = ((Math.sqrt(sigma[z[((i$var66 - 0) / 1)]]) * DistributionSampling.sampleGaussian(RNG$1)) + mu[z[((i$var66 - 0) / 1)]]);
 					}
 			}
@@ -1550,10 +1425,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 				
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
-					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
-					}
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 			}
 		);
 	}
@@ -1598,10 +1471,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 				
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
-					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
-					}
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$1, phi, k);
 			}
 		);
 	}
@@ -1646,10 +1517,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					
 						// Inner loop for running batches of iterations, each batch has its own random number
 						// generator.
-						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-							if(!fixedFlag$sample68)
-								sample68(i$var66, threadID$i$var66, RNG$1);
-						}
+						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+							sample68(i$var66, threadID$i$var66, RNG$1);
 				}
 			);
 		}
@@ -1661,10 +1530,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					
 						// Inner loop for running batches of iterations, each batch has its own random number
 						// generator.
-						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-							if(!fixedFlag$sample68)
-								sample68(i$var66, threadID$i$var66, RNG$1);
-						}
+						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+							sample68(i$var66, threadID$i$var66, RNG$1);
 				}
 			);
 			
@@ -1741,12 +1608,10 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		if(!fixedProbFlag$sample52)
 			logProbability$var52 = Double.NaN;
 		logProbability$var67 = Double.NaN;
-		if(!fixedProbFlag$sample68)
-			logProbability$z = Double.NaN;
+		logProbability$z = Double.NaN;
 		logProbability$var71 = Double.NaN;
 		logProbability$x = 0.0;
-		if(!fixedProbFlag$sample72)
-			logProbability$var72 = Double.NaN;
+		logProbability$var72 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -1762,8 +1627,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			logProbabilityValue$sample34();
 		if(fixedFlag$sample52)
 			logProbabilityValue$sample52();
-		if(fixedFlag$sample68)
-			logProbabilityValue$sample68();
 		logProbabilityValue$sample72();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$MultiThreadCPU_optimisedModel.java
@@ -14,12 +14,9 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	private boolean fixedFlag$sample17 = false;
 	private boolean fixedFlag$sample34 = false;
 	private boolean fixedFlag$sample52 = false;
-	private boolean fixedFlag$sample68 = false;
 	private boolean fixedProbFlag$sample17 = false;
 	private boolean fixedProbFlag$sample34 = false;
 	private boolean fixedProbFlag$sample52 = false;
-	private boolean fixedProbFlag$sample68 = false;
-	private boolean fixedProbFlag$sample72 = false;
 	private int length$xMeasured;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -73,12 +70,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// 
 		// Substituted "fixedFlag$sample17" with its value "cv$value".
 		fixedProbFlag$sample17 = (cv$value && fixedProbFlag$sample17);
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample17" with its value "cv$value".
-		fixedProbFlag$sample68 = (cv$value && fixedProbFlag$sample68);
 	}
 
 	// Getter for fixedFlag$sample34.
@@ -99,12 +90,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// 
 		// Substituted "fixedFlag$sample34" with its value "cv$value".
 		fixedProbFlag$sample34 = (cv$value && fixedProbFlag$sample34);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample34" with its value "cv$value".
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
 	}
 
 	// Getter for fixedFlag$sample52.
@@ -125,38 +110,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// 
 		// Substituted "fixedFlag$sample52" with its value "cv$value".
 		fixedProbFlag$sample52 = (cv$value && fixedProbFlag$sample52);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample52" with its value "cv$value".
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
-	}
-
-	// Getter for fixedFlag$sample68.
-	@Override
-	public final boolean get$fixedFlag$sample68() {
-		return fixedFlag$sample68;
-	}
-
-	// Setter for fixedFlag$sample68.
-	@Override
-	public final void set$fixedFlag$sample68(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample68 including if probabilities
-		// need to be updated.
-		fixedFlag$sample68 = cv$value;
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample68" with its value "cv$value".
-		fixedProbFlag$sample68 = (cv$value && fixedProbFlag$sample68);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample68" with its value "cv$value".
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
 	}
 
 	// Getter for k.
@@ -235,9 +188,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 34 as it depends on mu.
 		fixedProbFlag$sample34 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on mu.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for phi.
@@ -256,9 +206,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 17 as it depends on phi.
 		fixedProbFlag$sample17 = false;
-		
-		// Unset the fixed probability flag for sample 68 as it depends on phi.
-		fixedProbFlag$sample68 = false;
 	}
 
 	// Getter for sigma.
@@ -277,9 +224,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 52 as it depends on sigma.
 		fixedProbFlag$sample52 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on sigma.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for x.
@@ -581,178 +525,115 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	// Calculate the probability of the samples represented by sample68 using sampled
 	// values.
 	private final void logProbabilityValue$sample68() {
-		// Determine if we need to calculate the values for sample task 68 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample68) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// The sample value to calculate the probability of generating
-				int cv$sampleValue = z[i$var66];
-				
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < 5))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var67[i$var66] = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample68[i$var66] = cv$distributionAccumulator;
-			}
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			// The sample value to calculate the probability of generating
+			int cv$sampleValue = z[i$var66];
 			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < 5))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY);
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
 			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var67[i$var66] = cv$distributionAccumulator;
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedFlag$sample17);
+			// Store the sample task probability
+			logProbability$sample68[i$var66] = cv$distributionAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// Variable declaration of cv$rvAccumulator moved.
-				double cv$rvAccumulator = logProbability$sample68[i$var66];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var67[i$var66] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$z = (logProbability$z + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample72 using sampled
 	// values.
 	private final void logProbabilityValue$sample72() {
-		// Determine if we need to calculate the values for sample task 72 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample72) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double var70 = sigma[z[i$var66]];
-				
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = (DistributionSampling.logProbabilityGaussian(((x[i$var66] - mu[z[i$var66]]) / Math.sqrt(var70))) - (Math.log(var70) * 0.5));
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var71[i$var66] = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample72[i$var66] = cv$distributionAccumulator;
-			}
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			double var70 = sigma[z[i$var66]];
 			
-			// Update the variable probability
-			logProbability$x = (logProbability$x + cv$accumulator);
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = (DistributionSampling.logProbabilityGaussian(((x[i$var66] - mu[z[i$var66]]) / Math.sqrt(var70))) - (Math.log(var70) * 0.5));
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample72 = ((fixedFlag$sample34 && fixedFlag$sample52) && fixedFlag$sample68);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var71[i$var66] = cv$distributionAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample72[i$var66] = cv$distributionAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// Variable declaration of cv$rvAccumulator moved.
-				double cv$rvAccumulator = logProbability$sample72[i$var66];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var71[i$var66] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$x = (logProbability$x + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$x = (logProbability$x + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -1058,10 +939,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// Constructor for x
 		x = new double[length$xMeasured];
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample68)
-			// Constructor for z
-			z = new int[length$xMeasured];
+		// Constructor for z
+		z = new int[length$xMeasured];
 		
 		// Constructor for logProbability$var67
 		logProbability$var67 = new double[length$xMeasured];
@@ -1120,8 +999,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
 					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
 						x[i$var66] = ((Math.sqrt(sigma[z[i$var66]]) * DistributionSampling.sampleGaussian(RNG$1)) + mu[z[i$var66]]);
 					}
 			}
@@ -1164,19 +1042,16 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			);
 
 		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample68)
-			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-			parallelFor(RNG$, 0, length$xMeasured, 1,
-				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-					
-						// Inner loop for running batches of iterations, each batch has its own random number
-						// generator.
-						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
-				}
-			);
-
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, length$xMeasured, 1,
+			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+			}
+		);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -1221,8 +1096,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
 					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
 						x[i$var66] = ((Math.sqrt(sigma[z[i$var66]]) * DistributionSampling.sampleGaussian(RNG$1)) + mu[z[i$var66]]);
 					}
 			}
@@ -1264,19 +1138,16 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			);
 
 		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample68)
-			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-			parallelFor(RNG$, 0, length$xMeasured, 1,
-				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-					
-						// Inner loop for running batches of iterations, each batch has its own random number
-						// generator.
-						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
-				}
-			);
-
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, length$xMeasured, 1,
+			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+			}
+		);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -1315,19 +1186,16 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			);
 
 		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample68)
-			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-			parallelFor(RNG$, 0, length$xMeasured, 1,
-				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-					
-						// Inner loop for running batches of iterations, each batch has its own random number
-						// generator.
-						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
-				}
-			);
-
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, length$xMeasured, 1,
+			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+			}
+		);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -1366,35 +1234,29 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 				);
 
 			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample68)
-				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-				parallelFor(RNG$, 0, length$xMeasured, 1,
-					(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-						
-							// Inner loop for running batches of iterations, each batch has its own random number
-							// generator.
-							for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-								sample68(i$var66, threadID$i$var66, RNG$1);
-					}
-				);
-
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, length$xMeasured, 1,
+				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+							sample68(i$var66, threadID$i$var66, RNG$1);
+				}
+			);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample68)
-				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-				parallelFor(RNG$, 0, length$xMeasured, 1,
-					(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-						
-							// Inner loop for running batches of iterations, each batch has its own random number
-							// generator.
-							for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-								sample68(i$var66, threadID$i$var66, RNG$1);
-					}
-				);
-
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, length$xMeasured, 1,
+				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+							sample68(i$var66, threadID$i$var66, RNG$1);
+				}
+			);
 			
 			// Constraints moved from conditionals in inner loops/scopes/etc.
 			if(!fixedFlag$sample52)
@@ -1471,17 +1333,13 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var67[i$var66] = Double.NaN;
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample68[i$var66] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample68[i$var66] = Double.NaN;
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var71[i$var66] = Double.NaN;
 		logProbability$x = 0.0;
-		if(!fixedProbFlag$sample72) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample72[i$var66] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample72[i$var66] = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -1497,8 +1355,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			logProbabilityValue$sample34();
 		if(fixedFlag$sample52)
 			logProbabilityValue$sample52();
-		if(fixedFlag$sample68)
-			logProbabilityValue$sample68();
 		logProbabilityValue$sample72();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$MultiThreadCPU_optimisedModelNoComments.java
@@ -12,12 +12,9 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	private boolean fixedFlag$sample17 = false;
 	private boolean fixedFlag$sample34 = false;
 	private boolean fixedFlag$sample52 = false;
-	private boolean fixedFlag$sample68 = false;
 	private boolean fixedProbFlag$sample17 = false;
 	private boolean fixedProbFlag$sample34 = false;
 	private boolean fixedProbFlag$sample52 = false;
-	private boolean fixedProbFlag$sample68 = false;
-	private boolean fixedProbFlag$sample72 = false;
 	private int length$xMeasured;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -61,7 +58,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$fixedFlag$sample17(boolean cv$value) {
 		fixedFlag$sample17 = cv$value;
 		fixedProbFlag$sample17 = (cv$value && fixedProbFlag$sample17);
-		fixedProbFlag$sample68 = (cv$value && fixedProbFlag$sample68);
 	}
 
 	@Override
@@ -73,7 +69,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$fixedFlag$sample34(boolean cv$value) {
 		fixedFlag$sample34 = cv$value;
 		fixedProbFlag$sample34 = (cv$value && fixedProbFlag$sample34);
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
 	}
 
 	@Override
@@ -85,19 +80,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$fixedFlag$sample52(boolean cv$value) {
 		fixedFlag$sample52 = cv$value;
 		fixedProbFlag$sample52 = (cv$value && fixedProbFlag$sample52);
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample68() {
-		return fixedFlag$sample68;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample68(boolean cv$value) {
-		fixedFlag$sample68 = cv$value;
-		fixedProbFlag$sample68 = (cv$value && fixedProbFlag$sample68);
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
 	}
 
 	@Override
@@ -159,7 +141,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$mu(double[] cv$value) {
 		mu = cv$value;
 		fixedProbFlag$sample34 = false;
-		fixedProbFlag$sample72 = false;
 	}
 
 	@Override
@@ -171,7 +152,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$phi(double[] cv$value) {
 		phi = cv$value;
 		fixedProbFlag$sample17 = false;
-		fixedProbFlag$sample68 = false;
 	}
 
 	@Override
@@ -183,7 +163,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	public final void set$sigma(double[] cv$value) {
 		sigma = cv$value;
 		fixedProbFlag$sample52 = false;
-		fixedProbFlag$sample72 = false;
 	}
 
 	@Override
@@ -271,59 +250,30 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	}
 
 	private final void logProbabilityValue$sample68() {
-		if(!fixedProbFlag$sample68) {
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				int cv$sampleValue = z[i$var66];
-				double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < 5))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY);
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				logProbability$var67[i$var66] = cv$distributionAccumulator;
-				logProbability$sample68[i$var66] = cv$distributionAccumulator;
-			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedFlag$sample17);
-		} else {
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$rvAccumulator = logProbability$sample68[i$var66];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var67[i$var66] = cv$rvAccumulator;
-			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			int cv$sampleValue = z[i$var66];
+			double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < 5))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY);
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+			logProbability$var67[i$var66] = cv$distributionAccumulator;
+			logProbability$sample68[i$var66] = cv$distributionAccumulator;
 		}
+		logProbability$z = (logProbability$z + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample72() {
-		if(!fixedProbFlag$sample72) {
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double var70 = sigma[z[i$var66]];
-				double cv$distributionAccumulator = (DistributionSampling.logProbabilityGaussian(((x[i$var66] - mu[z[i$var66]]) / Math.sqrt(var70))) - (Math.log(var70) * 0.5));
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				logProbability$var71[i$var66] = cv$distributionAccumulator;
-				logProbability$sample72[i$var66] = cv$distributionAccumulator;
-			}
-			logProbability$x = (logProbability$x + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample72 = ((fixedFlag$sample34 && fixedFlag$sample52) && fixedFlag$sample68);
-		} else {
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$rvAccumulator = logProbability$sample72[i$var66];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var71[i$var66] = cv$rvAccumulator;
-			}
-			logProbability$x = (logProbability$x + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			double var70 = sigma[z[i$var66]];
+			double cv$distributionAccumulator = (DistributionSampling.logProbabilityGaussian(((x[i$var66] - mu[z[i$var66]]) / Math.sqrt(var70))) - (Math.log(var70) * 0.5));
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+			logProbability$var71[i$var66] = cv$distributionAccumulator;
+			logProbability$sample72[i$var66] = cv$distributionAccumulator;
 		}
+		logProbability$x = (logProbability$x + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void sample17() {
@@ -431,8 +381,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		if(!fixedFlag$sample52)
 			sigma = new double[5];
 		x = new double[length$xMeasured];
-		if(!fixedFlag$sample68)
-			z = new int[length$xMeasured];
+		z = new int[length$xMeasured];
 		logProbability$var67 = new double[length$xMeasured];
 		logProbability$sample68 = new double[length$xMeasured];
 		logProbability$var71 = new double[length$xMeasured];
@@ -463,8 +412,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		parallelFor(RNG$, 0, length$xMeasured, 1,
 			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
 				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
 						x[i$var66] = ((Math.sqrt(sigma[z[i$var66]]) * DistributionSampling.sampleGaussian(RNG$1)) + mu[z[i$var66]]);
 					}
 			}
@@ -491,14 +439,12 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 				}
 			);
 
-		if(!fixedFlag$sample68)
-			parallelFor(RNG$, 0, length$xMeasured, 1,
-				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
-				}
-			);
-
+		parallelFor(RNG$, 0, length$xMeasured, 1,
+			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+			}
+		);
 	}
 
 	@Override
@@ -524,8 +470,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		parallelFor(RNG$, 0, length$xMeasured, 1,
 			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
 				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
 						x[i$var66] = ((Math.sqrt(sigma[z[i$var66]]) * DistributionSampling.sampleGaussian(RNG$1)) + mu[z[i$var66]]);
 					}
 			}
@@ -552,14 +497,12 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 				}
 			);
 
-		if(!fixedFlag$sample68)
-			parallelFor(RNG$, 0, length$xMeasured, 1,
-				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
-				}
-			);
-
+		parallelFor(RNG$, 0, length$xMeasured, 1,
+			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+			}
+		);
 	}
 
 	@Override
@@ -582,14 +525,12 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 				}
 			);
 
-		if(!fixedFlag$sample68)
-			parallelFor(RNG$, 0, length$xMeasured, 1,
-				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
-				}
-			);
-
+		parallelFor(RNG$, 0, length$xMeasured, 1,
+			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+			}
+		);
 	}
 
 	@Override
@@ -613,23 +554,19 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					}
 				);
 
-			if(!fixedFlag$sample68)
-				parallelFor(RNG$, 0, length$xMeasured, 1,
-					(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-								sample68(i$var66, threadID$i$var66, RNG$1);
-					}
-				);
-
+			parallelFor(RNG$, 0, length$xMeasured, 1,
+				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+							sample68(i$var66, threadID$i$var66, RNG$1);
+				}
+			);
 		} else {
-			if(!fixedFlag$sample68)
-				parallelFor(RNG$, 0, length$xMeasured, 1,
-					(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-								sample68(i$var66, threadID$i$var66, RNG$1);
-					}
-				);
-
+			parallelFor(RNG$, 0, length$xMeasured, 1,
+				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+							sample68(i$var66, threadID$i$var66, RNG$1);
+				}
+			);
 			if(!fixedFlag$sample52)
 				parallelFor(RNG$, 0, 5, 1,
 					(int forStart$var51, int forEnd$var51, int threadID$var51, org.sandwood.random.internal.Rng RNG$1) -> { 
@@ -679,17 +616,13 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var67[i$var66] = Double.NaN;
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample68[i$var66] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample68[i$var66] = Double.NaN;
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var71[i$var66] = Double.NaN;
 		logProbability$x = 0.0;
-		if(!fixedProbFlag$sample72) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample72[i$var66] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample72[i$var66] = Double.NaN;
 	}
 
 	@Override
@@ -701,8 +634,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			logProbabilityValue$sample34();
 		if(fixedFlag$sample52)
 			logProbabilityValue$sample52();
-		if(fixedFlag$sample68)
-			logProbabilityValue$sample68();
 		logProbabilityValue$sample72();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$MultiThreadCPU_optimisedModelSingle.java
@@ -14,12 +14,9 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	private boolean fixedFlag$sample17 = false;
 	private boolean fixedFlag$sample34 = false;
 	private boolean fixedFlag$sample52 = false;
-	private boolean fixedFlag$sample68 = false;
 	private boolean fixedProbFlag$sample17 = false;
 	private boolean fixedProbFlag$sample34 = false;
 	private boolean fixedProbFlag$sample52 = false;
-	private boolean fixedProbFlag$sample68 = false;
-	private boolean fixedProbFlag$sample72 = false;
 	private int length$xMeasured;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -72,12 +69,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// 
 		// Substituted "fixedFlag$sample17" with its value "cv$value".
 		fixedProbFlag$sample17 = (cv$value && fixedProbFlag$sample17);
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample17" with its value "cv$value".
-		fixedProbFlag$sample68 = (cv$value && fixedProbFlag$sample68);
 	}
 
 	// Getter for fixedFlag$sample34.
@@ -98,12 +89,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// 
 		// Substituted "fixedFlag$sample34" with its value "cv$value".
 		fixedProbFlag$sample34 = (cv$value && fixedProbFlag$sample34);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample34" with its value "cv$value".
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
 	}
 
 	// Getter for fixedFlag$sample52.
@@ -124,38 +109,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// 
 		// Substituted "fixedFlag$sample52" with its value "cv$value".
 		fixedProbFlag$sample52 = (cv$value && fixedProbFlag$sample52);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample52" with its value "cv$value".
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
-	}
-
-	// Getter for fixedFlag$sample68.
-	@Override
-	public final boolean get$fixedFlag$sample68() {
-		return fixedFlag$sample68;
-	}
-
-	// Setter for fixedFlag$sample68.
-	@Override
-	public final void set$fixedFlag$sample68(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample68 including if probabilities
-		// need to be updated.
-		fixedFlag$sample68 = cv$value;
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample68" with its value "cv$value".
-		fixedProbFlag$sample68 = (cv$value && fixedProbFlag$sample68);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample68" with its value "cv$value".
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
 	}
 
 	// Getter for k.
@@ -234,9 +187,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 34 as it depends on mu.
 		fixedProbFlag$sample34 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on mu.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for phi.
@@ -255,9 +205,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 17 as it depends on phi.
 		fixedProbFlag$sample17 = false;
-		
-		// Unset the fixed probability flag for sample 68 as it depends on phi.
-		fixedProbFlag$sample68 = false;
 	}
 
 	// Getter for sigma.
@@ -276,9 +223,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		
 		// Unset the fixed probability flag for sample 52 as it depends on sigma.
 		fixedProbFlag$sample52 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on sigma.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for x.
@@ -602,197 +546,124 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 	// Calculate the probability of the samples represented by sample68 using sampled
 	// values.
 	private final void logProbabilityValue$sample68() {
-		// Determine if we need to calculate the values for sample task 68 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample68) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			// The sample value to calculate the probability of generating
+			int cv$sampleValue = z[i$var66];
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// The sample value to calculate the probability of generating
-				int cv$sampleValue = z[i$var66];
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < 5))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-			}
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var67 = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$z = cv$sampleAccumulator;
-			}
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < 5))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var67 = cv$sampleAccumulator;
 			
-			// Add probability to model
+			// Store the random variable instance probability
 			// 
 			// Add the probability of this instance of the random variable to the probability
 			// of all instances of the random variable.
 			// 
 			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedFlag$sample17);
+			logProbability$z = cv$sampleAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if((0 < length$xMeasured))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$var67 = logProbability$z;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$z);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$z);
-		}
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample72 using sampled
 	// values.
 	private final void logProbabilityValue$sample72() {
-		// Determine if we need to calculate the values for sample task 72 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample72) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			double var70 = sigma[z[i$var66]];
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double var70 = sigma[z[i$var66]];
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = ((cv$sampleAccumulator + DistributionSampling.logProbabilityGaussian(((x[i$var66] - mu[z[i$var66]]) / Math.sqrt(var70)))) - (Math.log(var70) * 0.5));
-			}
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var71 = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$var72 = cv$sampleAccumulator;
-			}
-			
-			// Update the variable probability
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Scale the probability relative to the observed distribution space.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$x = (logProbability$x + cv$sampleAccumulator);
-			
-			// Add probability to model
+			// Add the probability of this distribution configuration to the accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// An accumulator for the distributed probability space covered.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample72 = ((fixedFlag$sample34 && fixedFlag$sample52) && fixedFlag$sample68);
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			cv$sampleAccumulator = ((cv$sampleAccumulator + DistributionSampling.logProbabilityGaussian(((x[i$var66] - mu[z[i$var66]]) / Math.sqrt(var70)))) - (Math.log(var70) * 0.5));
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if((0 < length$xMeasured))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$var71 = logProbability$var72;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var71 = cv$sampleAccumulator;
 			
-			// Update the variable probability
+			// Store the random variable instance probability
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$x = (logProbability$x + logProbability$var72);
-			
-			// Add probability to model
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var72);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var72);
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$var72 = cv$sampleAccumulator;
 		}
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$x = (logProbability$x + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -1098,10 +969,8 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		// Constructor for x
 		x = new double[length$xMeasured];
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample68)
-			// Constructor for z
-			z = new int[length$xMeasured];
+		// Constructor for z
+		z = new int[length$xMeasured];
 		
 		// Allocate scratch space
 		allocateScratch();
@@ -1148,8 +1017,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
 					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
 						x[i$var66] = ((Math.sqrt(sigma[z[i$var66]]) * DistributionSampling.sampleGaussian(RNG$1)) + mu[z[i$var66]]);
 					}
 			}
@@ -1192,19 +1060,16 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			);
 
 		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample68)
-			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-			parallelFor(RNG$, 0, length$xMeasured, 1,
-				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-					
-						// Inner loop for running batches of iterations, each batch has its own random number
-						// generator.
-						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
-				}
-			);
-
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, length$xMeasured, 1,
+			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+			}
+		);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -1249,8 +1114,7 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
 					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1) {
-						if(!fixedFlag$sample68)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
 						x[i$var66] = ((Math.sqrt(sigma[z[i$var66]]) * DistributionSampling.sampleGaussian(RNG$1)) + mu[z[i$var66]]);
 					}
 			}
@@ -1292,19 +1156,16 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			);
 
 		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample68)
-			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-			parallelFor(RNG$, 0, length$xMeasured, 1,
-				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-					
-						// Inner loop for running batches of iterations, each batch has its own random number
-						// generator.
-						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
-				}
-			);
-
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, length$xMeasured, 1,
+			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+			}
+		);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -1343,19 +1204,16 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			);
 
 		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample68)
-			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-			parallelFor(RNG$, 0, length$xMeasured, 1,
-				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-					
-						// Inner loop for running batches of iterations, each batch has its own random number
-						// generator.
-						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-							z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
-				}
-			);
-
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, length$xMeasured, 1,
+			(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+						z[i$var66] = DistributionSampling.sampleCategorical(RNG$1, phi, 5);
+			}
+		);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -1394,35 +1252,29 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 				);
 
 			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample68)
-				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-				parallelFor(RNG$, 0, length$xMeasured, 1,
-					(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-						
-							// Inner loop for running batches of iterations, each batch has its own random number
-							// generator.
-							for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-								sample68(i$var66, threadID$i$var66, RNG$1);
-					}
-				);
-
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, length$xMeasured, 1,
+				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+							sample68(i$var66, threadID$i$var66, RNG$1);
+				}
+			);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample68)
-				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-				parallelFor(RNG$, 0, length$xMeasured, 1,
-					(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
-						
-							// Inner loop for running batches of iterations, each batch has its own random number
-							// generator.
-							for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
-								sample68(i$var66, threadID$i$var66, RNG$1);
-					}
-				);
-
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, length$xMeasured, 1,
+				(int forStart$i$var66, int forEnd$i$var66, int threadID$i$var66, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int i$var66 = forStart$i$var66; i$var66 < forEnd$i$var66; i$var66 += 1)
+							sample68(i$var66, threadID$i$var66, RNG$1);
+				}
+			);
 			
 			// Constraints moved from conditionals in inner loops/scopes/etc.
 			if(!fixedFlag$sample52)
@@ -1497,12 +1349,10 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 		if(!fixedProbFlag$sample52)
 			logProbability$var52 = Double.NaN;
 		logProbability$var67 = Double.NaN;
-		if(!fixedProbFlag$sample68)
-			logProbability$z = Double.NaN;
+		logProbability$z = Double.NaN;
 		logProbability$var71 = Double.NaN;
 		logProbability$x = 0.0;
-		if(!fixedProbFlag$sample72)
-			logProbability$var72 = Double.NaN;
+		logProbability$var72 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -1518,8 +1368,6 @@ class GaussianMixtureTest$MultiThreadCPU extends org.sandwood.runtime.internal.m
 			logProbabilityValue$sample34();
 		if(fixedFlag$sample52)
 			logProbabilityValue$sample52();
-		if(fixedFlag$sample68)
-			logProbabilityValue$sample68();
 		logProbabilityValue$sample72();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$SingleThreadCPU_model.java
@@ -13,12 +13,9 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	private boolean fixedFlag$sample17 = false;
 	private boolean fixedFlag$sample34 = false;
 	private boolean fixedFlag$sample52 = false;
-	private boolean fixedFlag$sample68 = false;
 	private boolean fixedProbFlag$sample17 = false;
 	private boolean fixedProbFlag$sample34 = false;
 	private boolean fixedProbFlag$sample52 = false;
-	private boolean fixedProbFlag$sample68 = false;
-	private boolean fixedProbFlag$sample72 = false;
 	private int k;
 	private int length$xMeasured;
 	private double logProbability$$evidence;
@@ -71,10 +68,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// Should the probability of sample 17 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample17 = (fixedFlag$sample17 && fixedProbFlag$sample17);
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample68 = (fixedFlag$sample17 && fixedProbFlag$sample68);
 	}
 
 	// Getter for fixedFlag$sample34.
@@ -93,10 +86,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// Should the probability of sample 34 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample34 = (fixedFlag$sample34 && fixedProbFlag$sample34);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample72 = (fixedFlag$sample34 && fixedProbFlag$sample72);
 	}
 
 	// Getter for fixedFlag$sample52.
@@ -115,32 +104,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// Should the probability of sample 52 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample52 = (fixedFlag$sample52 && fixedProbFlag$sample52);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample72 = (fixedFlag$sample52 && fixedProbFlag$sample72);
-	}
-
-	// Getter for fixedFlag$sample68.
-	@Override
-	public final boolean get$fixedFlag$sample68() {
-		return fixedFlag$sample68;
-	}
-
-	// Setter for fixedFlag$sample68.
-	@Override
-	public final void set$fixedFlag$sample68(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample68 including if probabilities
-		// need to be updated.
-		fixedFlag$sample68 = cv$value;
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedProbFlag$sample68);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample72 = (fixedFlag$sample68 && fixedProbFlag$sample72);
 	}
 
 	// Getter for k.
@@ -219,9 +182,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		
 		// Unset the fixed probability flag for sample 34 as it depends on mu.
 		fixedProbFlag$sample34 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on mu.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for phi.
@@ -240,9 +200,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		
 		// Unset the fixed probability flag for sample 17 as it depends on phi.
 		fixedProbFlag$sample17 = false;
-		
-		// Unset the fixed probability flag for sample 68 as it depends on phi.
-		fixedProbFlag$sample68 = false;
 	}
 
 	// Getter for sigma.
@@ -261,9 +218,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		
 		// Unset the fixed probability flag for sample 52 as it depends on sigma.
 		fixedProbFlag$sample52 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on sigma.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for x.
@@ -627,226 +581,149 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	// Calculate the probability of the samples represented by sample68 using sampled
 	// values.
 	private final void logProbabilityValue$sample68() {
-		// Determine if we need to calculate the values for sample task 68 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample68) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = z[((i$var66 - 0) / 1)];
 				{
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = z[((i$var66 - 0) / 1)];
 					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < k))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < k))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var67[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample68[((i$var66 - 0) / 1)] = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var67[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedFlag$sample17);
+			// Store the sample task probability
+			logProbability$sample68[((i$var66 - 0) / 1)] = cv$sampleProbability;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample68[((i$var66 - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var67[((i$var66 - 0) / 1)] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$z = (logProbability$z + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample72 using sampled
 	// values.
 	private final void logProbabilityValue$sample72() {
-		// Determine if we need to calculate the values for sample task 72 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample72) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = x[i$var66];
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = x[i$var66];
 					{
-						{
-							double var69 = mu[z[((i$var66 - 0) / 1)]];
-							double var70 = sigma[z[((i$var66 - 0) / 1)]];
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var69) / Math.sqrt(var70))) - (0.5 * Math.log(var70))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var69 = mu[z[((i$var66 - 0) / 1)]];
+						double var70 = sigma[z[((i$var66 - 0) / 1)]];
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var69) / Math.sqrt(var70))) - (0.5 * Math.log(var70))));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var71[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample72[((i$var66 - 0) / 1)] = cv$sampleProbability;
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$x = (logProbability$x + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample72 = ((fixedFlag$sample34 && fixedFlag$sample52) && fixedFlag$sample68);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var71[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample72[((i$var66 - 0) / 1)] = cv$sampleProbability;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample72[((i$var66 - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var71[((i$var66 - 0) / 1)] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$x = (logProbability$x + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$x = (logProbability$x + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -1336,12 +1213,9 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			x = new double[length$xMeasured];
 		}
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample68) {
-			// Constructor for z
-			{
-				z = new int[((((length$xMeasured - 1) - 0) / 1) + 1)];
-			}
+		// Constructor for z
+		{
+			z = new int[((((length$xMeasured - 1) - 0) / 1) + 1)];
 		}
 		
 		// Constructor for logProbability$var67
@@ -1382,8 +1256,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 			x[i$var66] = ((Math.sqrt(sigma[z[((i$var66 - 0) / 1)]]) * DistributionSampling.sampleGaussian(RNG$)) + mu[z[((i$var66 - 0) / 1)]]);
 		}
 	}
@@ -1403,10 +1276,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			if(!fixedFlag$sample52)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -1424,8 +1295,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 			x[i$var66] = ((Math.sqrt(sigma[z[((i$var66 - 0) / 1)]]) * DistributionSampling.sampleGaussian(RNG$)) + mu[z[((i$var66 - 0) / 1)]]);
 		}
 	}
@@ -1444,10 +1314,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			if(!fixedFlag$sample52)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -1465,10 +1333,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			if(!fixedFlag$sample52)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -1486,17 +1352,13 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				if(!fixedFlag$sample52)
 					sample52(var51);
 			}
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				if(!fixedFlag$sample68)
-					sample68(i$var66);
-			}
+			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+				sample68(i$var66);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			for(int i$var66 = (length$xMeasured - ((((length$xMeasured - 1) - 0) % 1) + 1)); i$var66 >= ((0 - 1) + 1); i$var66 -= 1) {
-				if(!fixedFlag$sample68)
-					sample68(i$var66);
-			}
+			for(int i$var66 = (length$xMeasured - ((((length$xMeasured - 1) - 0) % 1) + 1)); i$var66 >= ((0 - 1) + 1); i$var66 -= 1)
+				sample68(i$var66);
 			for(int var51 = (k - ((((k - 1) - 0) % 1) + 1)); var51 >= ((0 - 1) + 1); var51 -= 1) {
 				if(!fixedFlag$sample52)
 					sample52(var51);
@@ -1546,17 +1408,13 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var67[((i$var66 - 0) / 1)] = Double.NaN;
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample68[((i$var66 - 0) / 1)] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample68[((i$var66 - 0) / 1)] = Double.NaN;
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var71[((i$var66 - 0) / 1)] = Double.NaN;
 		logProbability$x = 0.0;
-		if(!fixedProbFlag$sample72) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample72[((i$var66 - 0) / 1)] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample72[((i$var66 - 0) / 1)] = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -1572,8 +1430,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			logProbabilityValue$sample34();
 		if(fixedFlag$sample52)
 			logProbabilityValue$sample52();
-		if(fixedFlag$sample68)
-			logProbabilityValue$sample68();
 		logProbabilityValue$sample72();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$SingleThreadCPU_modelNoComments.java
@@ -11,12 +11,9 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	private boolean fixedFlag$sample17 = false;
 	private boolean fixedFlag$sample34 = false;
 	private boolean fixedFlag$sample52 = false;
-	private boolean fixedFlag$sample68 = false;
 	private boolean fixedProbFlag$sample17 = false;
 	private boolean fixedProbFlag$sample34 = false;
 	private boolean fixedProbFlag$sample52 = false;
-	private boolean fixedProbFlag$sample68 = false;
-	private boolean fixedProbFlag$sample72 = false;
 	private int k;
 	private int length$xMeasured;
 	private double logProbability$$evidence;
@@ -61,7 +58,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	public final void set$fixedFlag$sample17(boolean cv$value) {
 		fixedFlag$sample17 = cv$value;
 		fixedProbFlag$sample17 = (fixedFlag$sample17 && fixedProbFlag$sample17);
-		fixedProbFlag$sample68 = (fixedFlag$sample17 && fixedProbFlag$sample68);
 	}
 
 	@Override
@@ -73,7 +69,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	public final void set$fixedFlag$sample34(boolean cv$value) {
 		fixedFlag$sample34 = cv$value;
 		fixedProbFlag$sample34 = (fixedFlag$sample34 && fixedProbFlag$sample34);
-		fixedProbFlag$sample72 = (fixedFlag$sample34 && fixedProbFlag$sample72);
 	}
 
 	@Override
@@ -85,19 +80,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	public final void set$fixedFlag$sample52(boolean cv$value) {
 		fixedFlag$sample52 = cv$value;
 		fixedProbFlag$sample52 = (fixedFlag$sample52 && fixedProbFlag$sample52);
-		fixedProbFlag$sample72 = (fixedFlag$sample52 && fixedProbFlag$sample72);
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample68() {
-		return fixedFlag$sample68;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample68(boolean cv$value) {
-		fixedFlag$sample68 = cv$value;
-		fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedProbFlag$sample68);
-		fixedProbFlag$sample72 = (fixedFlag$sample68 && fixedProbFlag$sample72);
 	}
 
 	@Override
@@ -159,7 +141,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	public final void set$mu(double[] cv$value) {
 		mu = cv$value;
 		fixedProbFlag$sample34 = false;
-		fixedProbFlag$sample72 = false;
 	}
 
 	@Override
@@ -171,7 +152,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	public final void set$phi(double[] cv$value) {
 		phi = cv$value;
 		fixedProbFlag$sample17 = false;
-		fixedProbFlag$sample68 = false;
 	}
 
 	@Override
@@ -183,7 +163,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	public final void set$sigma(double[] cv$value) {
 		sigma = cv$value;
 		fixedProbFlag$sample52 = false;
-		fixedProbFlag$sample72 = false;
 	}
 
 	@Override
@@ -381,121 +360,84 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	}
 
 	private final void logProbabilityValue$sample68() {
-		if(!fixedProbFlag$sample68) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				int cv$sampleValue = z[((i$var66 - 0) / 1)];
 				{
-					int cv$sampleValue = z[((i$var66 - 0) / 1)];
 					{
-						{
-							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < k))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < k))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var67[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
-				logProbability$sample68[((i$var66 - 0) / 1)] = cv$sampleProbability;
 			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedFlag$sample17);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample68[((i$var66 - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var67[((i$var66 - 0) / 1)] = cv$rvAccumulator;
-			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var67[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
+			logProbability$sample68[((i$var66 - 0) / 1)] = cv$sampleProbability;
 		}
+		logProbability$z = (logProbability$z + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample72() {
-		if(!fixedProbFlag$sample72) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				double cv$sampleValue = x[i$var66];
 				{
-					double cv$sampleValue = x[i$var66];
 					{
-						{
-							double var69 = mu[z[((i$var66 - 0) / 1)]];
-							double var70 = sigma[z[((i$var66 - 0) / 1)]];
-							double cv$weightedProbability = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var69) / Math.sqrt(var70))) - (0.5 * Math.log(var70))));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var69 = mu[z[((i$var66 - 0) / 1)]];
+						double var70 = sigma[z[((i$var66 - 0) / 1)]];
+						double cv$weightedProbability = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var69) / Math.sqrt(var70))) - (0.5 * Math.log(var70))));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var71[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
-				logProbability$sample72[((i$var66 - 0) / 1)] = cv$sampleProbability;
 			}
-			logProbability$x = (logProbability$x + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample72 = ((fixedFlag$sample34 && fixedFlag$sample52) && fixedFlag$sample68);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample72[((i$var66 - 0) / 1)];
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var71[((i$var66 - 0) / 1)] = cv$rvAccumulator;
-			}
-			logProbability$x = (logProbability$x + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var71[((i$var66 - 0) / 1)] = cv$sampleAccumulator;
+			logProbability$sample72[((i$var66 - 0) / 1)] = cv$sampleProbability;
 		}
+		logProbability$x = (logProbability$x + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void sample17() {
@@ -788,10 +730,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		{
 			x = new double[length$xMeasured];
 		}
-		if(!fixedFlag$sample68) {
-			{
-				z = new int[((((length$xMeasured - 1) - 0) / 1) + 1)];
-			}
+		{
+			z = new int[((((length$xMeasured - 1) - 0) / 1) + 1)];
 		}
 		{
 			logProbability$var67 = new double[((((length$xMeasured - 1) - 0) / 1) + 1)];
@@ -821,8 +761,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 			x[i$var66] = ((Math.sqrt(sigma[z[((i$var66 - 0) / 1)]]) * DistributionSampling.sampleGaussian(RNG$)) + mu[z[((i$var66 - 0) / 1)]]);
 		}
 	}
@@ -839,10 +778,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			if(!fixedFlag$sample52)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 	}
 
 	@Override
@@ -858,8 +795,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 			x[i$var66] = ((Math.sqrt(sigma[z[((i$var66 - 0) / 1)]]) * DistributionSampling.sampleGaussian(RNG$)) + mu[z[((i$var66 - 0) / 1)]]);
 		}
 	}
@@ -876,10 +812,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			if(!fixedFlag$sample52)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 	}
 
 	@Override
@@ -894,10 +828,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			if(!fixedFlag$sample52)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 	}
 
 	@Override
@@ -913,15 +845,11 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				if(!fixedFlag$sample52)
 					sample52(var51);
 			}
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				if(!fixedFlag$sample68)
-					sample68(i$var66);
-			}
+			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+				sample68(i$var66);
 		} else {
-			for(int i$var66 = (length$xMeasured - ((((length$xMeasured - 1) - 0) % 1) + 1)); i$var66 >= ((0 - 1) + 1); i$var66 -= 1) {
-				if(!fixedFlag$sample68)
-					sample68(i$var66);
-			}
+			for(int i$var66 = (length$xMeasured - ((((length$xMeasured - 1) - 0) % 1) + 1)); i$var66 >= ((0 - 1) + 1); i$var66 -= 1)
+				sample68(i$var66);
 			for(int var51 = (k - ((((k - 1) - 0) % 1) + 1)); var51 >= ((0 - 1) + 1); var51 -= 1) {
 				if(!fixedFlag$sample52)
 					sample52(var51);
@@ -960,17 +888,13 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var67[((i$var66 - 0) / 1)] = Double.NaN;
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample68[((i$var66 - 0) / 1)] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample68[((i$var66 - 0) / 1)] = Double.NaN;
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var71[((i$var66 - 0) / 1)] = Double.NaN;
 		logProbability$x = 0.0;
-		if(!fixedProbFlag$sample72) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample72[((i$var66 - 0) / 1)] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample72[((i$var66 - 0) / 1)] = Double.NaN;
 	}
 
 	@Override
@@ -982,8 +906,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			logProbabilityValue$sample34();
 		if(fixedFlag$sample52)
 			logProbabilityValue$sample52();
-		if(fixedFlag$sample68)
-			logProbabilityValue$sample68();
 		logProbabilityValue$sample72();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$SingleThreadCPU_modelSingle.java
@@ -13,12 +13,9 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	private boolean fixedFlag$sample17 = false;
 	private boolean fixedFlag$sample34 = false;
 	private boolean fixedFlag$sample52 = false;
-	private boolean fixedFlag$sample68 = false;
 	private boolean fixedProbFlag$sample17 = false;
 	private boolean fixedProbFlag$sample34 = false;
 	private boolean fixedProbFlag$sample52 = false;
-	private boolean fixedProbFlag$sample68 = false;
-	private boolean fixedProbFlag$sample72 = false;
 	private int k;
 	private int length$xMeasured;
 	private double logProbability$$evidence;
@@ -70,10 +67,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// Should the probability of sample 17 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample17 = (fixedFlag$sample17 && fixedProbFlag$sample17);
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample68 = (fixedFlag$sample17 && fixedProbFlag$sample68);
 	}
 
 	// Getter for fixedFlag$sample34.
@@ -92,10 +85,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// Should the probability of sample 34 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample34 = (fixedFlag$sample34 && fixedProbFlag$sample34);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample72 = (fixedFlag$sample34 && fixedProbFlag$sample72);
 	}
 
 	// Getter for fixedFlag$sample52.
@@ -114,32 +103,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// Should the probability of sample 52 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample52 = (fixedFlag$sample52 && fixedProbFlag$sample52);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample72 = (fixedFlag$sample52 && fixedProbFlag$sample72);
-	}
-
-	// Getter for fixedFlag$sample68.
-	@Override
-	public final boolean get$fixedFlag$sample68() {
-		return fixedFlag$sample68;
-	}
-
-	// Setter for fixedFlag$sample68.
-	@Override
-	public final void set$fixedFlag$sample68(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample68 including if probabilities
-		// need to be updated.
-		fixedFlag$sample68 = cv$value;
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedProbFlag$sample68);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample72 = (fixedFlag$sample68 && fixedProbFlag$sample72);
 	}
 
 	// Getter for k.
@@ -218,9 +181,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		
 		// Unset the fixed probability flag for sample 34 as it depends on mu.
 		fixedProbFlag$sample34 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on mu.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for phi.
@@ -239,9 +199,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		
 		// Unset the fixed probability flag for sample 17 as it depends on phi.
 		fixedProbFlag$sample17 = false;
-		
-		// Unset the fixed probability flag for sample 68 as it depends on phi.
-		fixedProbFlag$sample68 = false;
 	}
 
 	// Getter for sigma.
@@ -260,9 +217,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		
 		// Unset the fixed probability flag for sample 52 as it depends on sigma.
 		fixedProbFlag$sample52 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on sigma.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for x.
@@ -636,226 +590,154 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	// Calculate the probability of the samples represented by sample68 using sampled
 	// values.
 	private final void logProbabilityValue$sample68() {
-		// Determine if we need to calculate the values for sample task 68 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample68) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = z[((i$var66 - 0) / 1)];
 				{
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = z[((i$var66 - 0) / 1)];
 					{
-						{
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < k))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < k))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var67 = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$z = cv$accumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedFlag$sample17);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$z;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var67 = cv$rvAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var67 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$z = cv$accumulator;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample72 using sampled
 	// values.
 	private final void logProbabilityValue$sample72() {
-		// Determine if we need to calculate the values for sample task 72 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample72) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = x[i$var66];
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = x[i$var66];
 					{
-						{
-							double var69 = mu[z[((i$var66 - 0) / 1)]];
-							double var70 = sigma[z[((i$var66 - 0) / 1)]];
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var69) / Math.sqrt(var70))) - (0.5 * Math.log(var70))));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var69 = mu[z[((i$var66 - 0) / 1)]];
+						double var70 = sigma[z[((i$var66 - 0) / 1)]];
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var69) / Math.sqrt(var70))) - (0.5 * Math.log(var70))));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var71 = cv$sampleAccumulator;
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$var72 = cv$accumulator;
-			
-			// Update the variable probability
-			logProbability$x = (logProbability$x + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample72 = ((fixedFlag$sample34 && fixedFlag$sample52) && fixedFlag$sample68);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			double cv$sampleValue = logProbability$var72;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var71 = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$x = (logProbability$x + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var71 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$var72 = cv$accumulator;
+		
+		// Update the variable probability
+		logProbability$x = (logProbability$x + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -1345,12 +1227,9 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			x = new double[length$xMeasured];
 		}
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample68) {
-			// Constructor for z
-			{
-				z = new int[((((length$xMeasured - 1) - 0) / 1) + 1)];
-			}
+		// Constructor for z
+		{
+			z = new int[((((length$xMeasured - 1) - 0) / 1) + 1)];
 		}
 		
 		// Allocate scratch space
@@ -1371,8 +1250,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 			x[i$var66] = ((Math.sqrt(sigma[z[((i$var66 - 0) / 1)]]) * DistributionSampling.sampleGaussian(RNG$)) + mu[z[((i$var66 - 0) / 1)]]);
 		}
 	}
@@ -1392,10 +1270,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			if(!fixedFlag$sample52)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -1413,8 +1289,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 			x[i$var66] = ((Math.sqrt(sigma[z[((i$var66 - 0) / 1)]]) * DistributionSampling.sampleGaussian(RNG$)) + mu[z[((i$var66 - 0) / 1)]]);
 		}
 	}
@@ -1433,10 +1308,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			if(!fixedFlag$sample52)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -1454,10 +1327,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			if(!fixedFlag$sample52)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[((i$var66 - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, phi, k);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -1475,17 +1346,13 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				if(!fixedFlag$sample52)
 					sample52(var51);
 			}
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				if(!fixedFlag$sample68)
-					sample68(i$var66);
-			}
+			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+				sample68(i$var66);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			for(int i$var66 = (length$xMeasured - ((((length$xMeasured - 1) - 0) % 1) + 1)); i$var66 >= ((0 - 1) + 1); i$var66 -= 1) {
-				if(!fixedFlag$sample68)
-					sample68(i$var66);
-			}
+			for(int i$var66 = (length$xMeasured - ((((length$xMeasured - 1) - 0) % 1) + 1)); i$var66 >= ((0 - 1) + 1); i$var66 -= 1)
+				sample68(i$var66);
 			for(int var51 = (k - ((((k - 1) - 0) % 1) + 1)); var51 >= ((0 - 1) + 1); var51 -= 1) {
 				if(!fixedFlag$sample52)
 					sample52(var51);
@@ -1533,12 +1400,10 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		if(!fixedProbFlag$sample52)
 			logProbability$var52 = Double.NaN;
 		logProbability$var67 = Double.NaN;
-		if(!fixedProbFlag$sample68)
-			logProbability$z = Double.NaN;
+		logProbability$z = Double.NaN;
 		logProbability$var71 = Double.NaN;
 		logProbability$x = 0.0;
-		if(!fixedProbFlag$sample72)
-			logProbability$var72 = Double.NaN;
+		logProbability$var72 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -1554,8 +1419,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			logProbabilityValue$sample34();
 		if(fixedFlag$sample52)
 			logProbabilityValue$sample52();
-		if(fixedFlag$sample68)
-			logProbabilityValue$sample68();
 		logProbabilityValue$sample72();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$SingleThreadCPU_optimisedModel.java
@@ -13,12 +13,9 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	private boolean fixedFlag$sample17 = false;
 	private boolean fixedFlag$sample34 = false;
 	private boolean fixedFlag$sample52 = false;
-	private boolean fixedFlag$sample68 = false;
 	private boolean fixedProbFlag$sample17 = false;
 	private boolean fixedProbFlag$sample34 = false;
 	private boolean fixedProbFlag$sample52 = false;
-	private boolean fixedProbFlag$sample68 = false;
-	private boolean fixedProbFlag$sample72 = false;
 	private int length$xMeasured;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -72,12 +69,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// 
 		// Substituted "fixedFlag$sample17" with its value "cv$value".
 		fixedProbFlag$sample17 = (cv$value && fixedProbFlag$sample17);
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample17" with its value "cv$value".
-		fixedProbFlag$sample68 = (cv$value && fixedProbFlag$sample68);
 	}
 
 	// Getter for fixedFlag$sample34.
@@ -98,12 +89,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// 
 		// Substituted "fixedFlag$sample34" with its value "cv$value".
 		fixedProbFlag$sample34 = (cv$value && fixedProbFlag$sample34);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample34" with its value "cv$value".
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
 	}
 
 	// Getter for fixedFlag$sample52.
@@ -124,38 +109,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// 
 		// Substituted "fixedFlag$sample52" with its value "cv$value".
 		fixedProbFlag$sample52 = (cv$value && fixedProbFlag$sample52);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample52" with its value "cv$value".
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
-	}
-
-	// Getter for fixedFlag$sample68.
-	@Override
-	public final boolean get$fixedFlag$sample68() {
-		return fixedFlag$sample68;
-	}
-
-	// Setter for fixedFlag$sample68.
-	@Override
-	public final void set$fixedFlag$sample68(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample68 including if probabilities
-		// need to be updated.
-		fixedFlag$sample68 = cv$value;
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample68" with its value "cv$value".
-		fixedProbFlag$sample68 = (cv$value && fixedProbFlag$sample68);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample68" with its value "cv$value".
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
 	}
 
 	// Getter for k.
@@ -234,9 +187,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		
 		// Unset the fixed probability flag for sample 34 as it depends on mu.
 		fixedProbFlag$sample34 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on mu.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for phi.
@@ -255,9 +205,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		
 		// Unset the fixed probability flag for sample 17 as it depends on phi.
 		fixedProbFlag$sample17 = false;
-		
-		// Unset the fixed probability flag for sample 68 as it depends on phi.
-		fixedProbFlag$sample68 = false;
 	}
 
 	// Getter for sigma.
@@ -276,9 +223,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		
 		// Unset the fixed probability flag for sample 52 as it depends on sigma.
 		fixedProbFlag$sample52 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on sigma.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for x.
@@ -580,178 +524,115 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	// Calculate the probability of the samples represented by sample68 using sampled
 	// values.
 	private final void logProbabilityValue$sample68() {
-		// Determine if we need to calculate the values for sample task 68 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample68) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// The sample value to calculate the probability of generating
-				int cv$sampleValue = z[i$var66];
-				
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < 5))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var67[i$var66] = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample68[i$var66] = cv$distributionAccumulator;
-			}
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			// The sample value to calculate the probability of generating
+			int cv$sampleValue = z[i$var66];
 			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < 5))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY);
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
 			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var67[i$var66] = cv$distributionAccumulator;
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedFlag$sample17);
+			// Store the sample task probability
+			logProbability$sample68[i$var66] = cv$distributionAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// Variable declaration of cv$rvAccumulator moved.
-				double cv$rvAccumulator = logProbability$sample68[i$var66];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var67[i$var66] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$z = (logProbability$z + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample72 using sampled
 	// values.
 	private final void logProbabilityValue$sample72() {
-		// Determine if we need to calculate the values for sample task 72 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample72) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double var70 = sigma[z[i$var66]];
-				
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = (DistributionSampling.logProbabilityGaussian(((x[i$var66] - mu[z[i$var66]]) / Math.sqrt(var70))) - (Math.log(var70) * 0.5));
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var71[i$var66] = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample72[i$var66] = cv$distributionAccumulator;
-			}
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			double var70 = sigma[z[i$var66]];
 			
-			// Update the variable probability
-			logProbability$x = (logProbability$x + cv$accumulator);
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = (DistributionSampling.logProbabilityGaussian(((x[i$var66] - mu[z[i$var66]]) / Math.sqrt(var70))) - (Math.log(var70) * 0.5));
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample72 = ((fixedFlag$sample34 && fixedFlag$sample52) && fixedFlag$sample68);
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var71[i$var66] = cv$distributionAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample72[i$var66] = cv$distributionAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// Variable declaration of cv$rvAccumulator moved.
-				double cv$rvAccumulator = logProbability$sample72[i$var66];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var71[i$var66] = cv$rvAccumulator;
-			}
-			
-			// Update the variable probability
-			logProbability$x = (logProbability$x + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$x = (logProbability$x + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -1052,10 +933,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// Constructor for x
 		x = new double[length$xMeasured];
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample68)
-			// Constructor for z
-			z = new int[length$xMeasured];
+		// Constructor for z
+		z = new int[length$xMeasured];
 		
 		// Constructor for logProbability$var67
 		logProbability$var67 = new double[length$xMeasured];
@@ -1091,8 +970,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 			x[i$var66] = ((Math.sqrt(sigma[z[i$var66]]) * DistributionSampling.sampleGaussian(RNG$)) + mu[z[i$var66]]);
 		}
 	}
@@ -1116,12 +994,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			for(int var51 = 0; var51 < 5; var51 += 1)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -1143,8 +1017,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 			x[i$var66] = ((Math.sqrt(sigma[z[i$var66]]) * DistributionSampling.sampleGaussian(RNG$)) + mu[z[i$var66]]);
 		}
 	}
@@ -1167,12 +1040,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			for(int var51 = 0; var51 < 5; var51 += 1)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -1194,12 +1063,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			for(int var51 = 0; var51 < 5; var51 += 1)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -1221,20 +1086,13 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				for(int var51 = 0; var51 < 5; var51 += 1)
 					sample52(var51);
 			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample68) {
-				for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-					sample68(i$var66);
-			}
+			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+				sample68(i$var66);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample68) {
-				for(int i$var66 = (length$xMeasured - 1); i$var66 >= 0; i$var66 -= 1)
-					sample68(i$var66);
-			}
+			for(int i$var66 = (length$xMeasured - 1); i$var66 >= 0; i$var66 -= 1)
+				sample68(i$var66);
 			
 			// Constraints moved from conditionals in inner loops/scopes/etc.
 			if(!fixedFlag$sample52) {
@@ -1287,17 +1145,13 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var67[i$var66] = Double.NaN;
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample68[i$var66] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample68[i$var66] = Double.NaN;
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var71[i$var66] = Double.NaN;
 		logProbability$x = 0.0;
-		if(!fixedProbFlag$sample72) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample72[i$var66] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample72[i$var66] = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -1313,8 +1167,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			logProbabilityValue$sample34();
 		if(fixedFlag$sample52)
 			logProbabilityValue$sample52();
-		if(fixedFlag$sample68)
-			logProbabilityValue$sample68();
 		logProbabilityValue$sample72();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$SingleThreadCPU_optimisedModelNoComments.java
@@ -11,12 +11,9 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	private boolean fixedFlag$sample17 = false;
 	private boolean fixedFlag$sample34 = false;
 	private boolean fixedFlag$sample52 = false;
-	private boolean fixedFlag$sample68 = false;
 	private boolean fixedProbFlag$sample17 = false;
 	private boolean fixedProbFlag$sample34 = false;
 	private boolean fixedProbFlag$sample52 = false;
-	private boolean fixedProbFlag$sample68 = false;
-	private boolean fixedProbFlag$sample72 = false;
 	private int length$xMeasured;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -60,7 +57,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	public final void set$fixedFlag$sample17(boolean cv$value) {
 		fixedFlag$sample17 = cv$value;
 		fixedProbFlag$sample17 = (cv$value && fixedProbFlag$sample17);
-		fixedProbFlag$sample68 = (cv$value && fixedProbFlag$sample68);
 	}
 
 	@Override
@@ -72,7 +68,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	public final void set$fixedFlag$sample34(boolean cv$value) {
 		fixedFlag$sample34 = cv$value;
 		fixedProbFlag$sample34 = (cv$value && fixedProbFlag$sample34);
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
 	}
 
 	@Override
@@ -84,19 +79,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	public final void set$fixedFlag$sample52(boolean cv$value) {
 		fixedFlag$sample52 = cv$value;
 		fixedProbFlag$sample52 = (cv$value && fixedProbFlag$sample52);
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample68() {
-		return fixedFlag$sample68;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample68(boolean cv$value) {
-		fixedFlag$sample68 = cv$value;
-		fixedProbFlag$sample68 = (cv$value && fixedProbFlag$sample68);
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
 	}
 
 	@Override
@@ -158,7 +140,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	public final void set$mu(double[] cv$value) {
 		mu = cv$value;
 		fixedProbFlag$sample34 = false;
-		fixedProbFlag$sample72 = false;
 	}
 
 	@Override
@@ -170,7 +151,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	public final void set$phi(double[] cv$value) {
 		phi = cv$value;
 		fixedProbFlag$sample17 = false;
-		fixedProbFlag$sample68 = false;
 	}
 
 	@Override
@@ -182,7 +162,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	public final void set$sigma(double[] cv$value) {
 		sigma = cv$value;
 		fixedProbFlag$sample52 = false;
-		fixedProbFlag$sample72 = false;
 	}
 
 	@Override
@@ -270,59 +249,30 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	}
 
 	private final void logProbabilityValue$sample68() {
-		if(!fixedProbFlag$sample68) {
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				int cv$sampleValue = z[i$var66];
-				double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < 5))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY);
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				logProbability$var67[i$var66] = cv$distributionAccumulator;
-				logProbability$sample68[i$var66] = cv$distributionAccumulator;
-			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedFlag$sample17);
-		} else {
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$rvAccumulator = logProbability$sample68[i$var66];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var67[i$var66] = cv$rvAccumulator;
-			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample68)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			int cv$sampleValue = z[i$var66];
+			double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < 5))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY);
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+			logProbability$var67[i$var66] = cv$distributionAccumulator;
+			logProbability$sample68[i$var66] = cv$distributionAccumulator;
 		}
+		logProbability$z = (logProbability$z + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample72() {
-		if(!fixedProbFlag$sample72) {
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double var70 = sigma[z[i$var66]];
-				double cv$distributionAccumulator = (DistributionSampling.logProbabilityGaussian(((x[i$var66] - mu[z[i$var66]]) / Math.sqrt(var70))) - (Math.log(var70) * 0.5));
-				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-				logProbability$var71[i$var66] = cv$distributionAccumulator;
-				logProbability$sample72[i$var66] = cv$distributionAccumulator;
-			}
-			logProbability$x = (logProbability$x + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample72 = ((fixedFlag$sample34 && fixedFlag$sample52) && fixedFlag$sample68);
-		} else {
-			double cv$accumulator = 0.0;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double cv$rvAccumulator = logProbability$sample72[i$var66];
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var71[i$var66] = cv$rvAccumulator;
-			}
-			logProbability$x = (logProbability$x + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			double var70 = sigma[z[i$var66]];
+			double cv$distributionAccumulator = (DistributionSampling.logProbabilityGaussian(((x[i$var66] - mu[z[i$var66]]) / Math.sqrt(var70))) - (Math.log(var70) * 0.5));
+			cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+			logProbability$var71[i$var66] = cv$distributionAccumulator;
+			logProbability$sample72[i$var66] = cv$distributionAccumulator;
 		}
+		logProbability$x = (logProbability$x + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void sample17() {
@@ -426,8 +376,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		if(!fixedFlag$sample52)
 			sigma = new double[5];
 		x = new double[length$xMeasured];
-		if(!fixedFlag$sample68)
-			z = new int[length$xMeasured];
+		z = new int[length$xMeasured];
 		logProbability$var67 = new double[length$xMeasured];
 		logProbability$sample68 = new double[length$xMeasured];
 		logProbability$var71 = new double[length$xMeasured];
@@ -448,8 +397,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 			x[i$var66] = ((Math.sqrt(sigma[z[i$var66]]) * DistributionSampling.sampleGaussian(RNG$)) + mu[z[i$var66]]);
 		}
 	}
@@ -466,10 +414,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			for(int var51 = 0; var51 < 5; var51 += 1)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		if(!fixedFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 	}
 
 	@Override
@@ -485,8 +431,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 			x[i$var66] = ((Math.sqrt(sigma[z[i$var66]]) * DistributionSampling.sampleGaussian(RNG$)) + mu[z[i$var66]]);
 		}
 	}
@@ -503,10 +448,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			for(int var51 = 0; var51 < 5; var51 += 1)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		if(!fixedFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 	}
 
 	@Override
@@ -521,10 +464,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			for(int var51 = 0; var51 < 5; var51 += 1)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		if(!fixedFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 	}
 
 	@Override
@@ -540,15 +481,11 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				for(int var51 = 0; var51 < 5; var51 += 1)
 					sample52(var51);
 			}
-			if(!fixedFlag$sample68) {
-				for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-					sample68(i$var66);
-			}
+			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+				sample68(i$var66);
 		} else {
-			if(!fixedFlag$sample68) {
-				for(int i$var66 = (length$xMeasured - 1); i$var66 >= 0; i$var66 -= 1)
-					sample68(i$var66);
-			}
+			for(int i$var66 = (length$xMeasured - 1); i$var66 >= 0; i$var66 -= 1)
+				sample68(i$var66);
 			if(!fixedFlag$sample52) {
 				for(int var51 = 4; var51 >= 0; var51 -= 1)
 					sample52(var51);
@@ -586,17 +523,13 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var67[i$var66] = Double.NaN;
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample68[i$var66] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample68[i$var66] = Double.NaN;
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
 			logProbability$var71[i$var66] = Double.NaN;
 		logProbability$x = 0.0;
-		if(!fixedProbFlag$sample72) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				logProbability$sample72[i$var66] = Double.NaN;
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			logProbability$sample72[i$var66] = Double.NaN;
 	}
 
 	@Override
@@ -608,8 +541,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			logProbabilityValue$sample34();
 		if(fixedFlag$sample52)
 			logProbabilityValue$sample52();
-		if(fixedFlag$sample68)
-			logProbabilityValue$sample68();
 		logProbabilityValue$sample72();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest$SingleThreadCPU_optimisedModelSingle.java
@@ -13,12 +13,9 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	private boolean fixedFlag$sample17 = false;
 	private boolean fixedFlag$sample34 = false;
 	private boolean fixedFlag$sample52 = false;
-	private boolean fixedFlag$sample68 = false;
 	private boolean fixedProbFlag$sample17 = false;
 	private boolean fixedProbFlag$sample34 = false;
 	private boolean fixedProbFlag$sample52 = false;
-	private boolean fixedProbFlag$sample68 = false;
-	private boolean fixedProbFlag$sample72 = false;
 	private int length$xMeasured;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -71,12 +68,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// 
 		// Substituted "fixedFlag$sample17" with its value "cv$value".
 		fixedProbFlag$sample17 = (cv$value && fixedProbFlag$sample17);
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample17" with its value "cv$value".
-		fixedProbFlag$sample68 = (cv$value && fixedProbFlag$sample68);
 	}
 
 	// Getter for fixedFlag$sample34.
@@ -97,12 +88,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// 
 		// Substituted "fixedFlag$sample34" with its value "cv$value".
 		fixedProbFlag$sample34 = (cv$value && fixedProbFlag$sample34);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample34" with its value "cv$value".
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
 	}
 
 	// Getter for fixedFlag$sample52.
@@ -123,38 +108,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// 
 		// Substituted "fixedFlag$sample52" with its value "cv$value".
 		fixedProbFlag$sample52 = (cv$value && fixedProbFlag$sample52);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample52" with its value "cv$value".
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
-	}
-
-	// Getter for fixedFlag$sample68.
-	@Override
-	public final boolean get$fixedFlag$sample68() {
-		return fixedFlag$sample68;
-	}
-
-	// Setter for fixedFlag$sample68.
-	@Override
-	public final void set$fixedFlag$sample68(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample68 including if probabilities
-		// need to be updated.
-		fixedFlag$sample68 = cv$value;
-		
-		// Should the probability of sample 68 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample68" with its value "cv$value".
-		fixedProbFlag$sample68 = (cv$value && fixedProbFlag$sample68);
-		
-		// Should the probability of sample 72 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample68" with its value "cv$value".
-		fixedProbFlag$sample72 = (cv$value && fixedProbFlag$sample72);
 	}
 
 	// Getter for k.
@@ -233,9 +186,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		
 		// Unset the fixed probability flag for sample 34 as it depends on mu.
 		fixedProbFlag$sample34 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on mu.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for phi.
@@ -254,9 +204,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		
 		// Unset the fixed probability flag for sample 17 as it depends on phi.
 		fixedProbFlag$sample17 = false;
-		
-		// Unset the fixed probability flag for sample 68 as it depends on phi.
-		fixedProbFlag$sample68 = false;
 	}
 
 	// Getter for sigma.
@@ -275,9 +222,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		
 		// Unset the fixed probability flag for sample 52 as it depends on sigma.
 		fixedProbFlag$sample52 = false;
-		
-		// Unset the fixed probability flag for sample 72 as it depends on sigma.
-		fixedProbFlag$sample72 = false;
 	}
 
 	// Getter for x.
@@ -601,197 +545,124 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 	// Calculate the probability of the samples represented by sample68 using sampled
 	// values.
 	private final void logProbabilityValue$sample68() {
-		// Determine if we need to calculate the values for sample task 68 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample68) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			// The sample value to calculate the probability of generating
+			int cv$sampleValue = z[i$var66];
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				// The sample value to calculate the probability of generating
-				int cv$sampleValue = z[i$var66];
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < 5))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-			}
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var67 = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$z = cv$sampleAccumulator;
-			}
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < 5))?Math.log(phi[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var67 = cv$sampleAccumulator;
 			
-			// Add probability to model
+			// Store the random variable instance probability
 			// 
 			// Add the probability of this instance of the random variable to the probability
 			// of all instances of the random variable.
 			// 
 			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample68 = (fixedFlag$sample68 && fixedFlag$sample17);
+			logProbability$z = cv$sampleAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if((0 < length$xMeasured))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$var67 = logProbability$z;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$z);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample68)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$z);
-		}
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample72 using sampled
 	// values.
 	private final void logProbabilityValue$sample72() {
-		// Determine if we need to calculate the values for sample task 72 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample72) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
+			double var70 = sigma[z[i$var66]];
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-				double var70 = sigma[z[i$var66]];
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				cv$sampleAccumulator = ((cv$sampleAccumulator + DistributionSampling.logProbabilityGaussian(((x[i$var66] - mu[z[i$var66]]) / Math.sqrt(var70)))) - (Math.log(var70) * 0.5));
-			}
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var71 = cv$sampleAccumulator;
-				
-				// Store the random variable instance probability
-				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$var72 = cv$sampleAccumulator;
-			}
-			
-			// Update the variable probability
+			// Add the probability of this sample task to the sample task accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Scale the probability relative to the observed distribution space.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$x = (logProbability$x + cv$sampleAccumulator);
-			
-			// Add probability to model
+			// Add the probability of this distribution configuration to the accumulator.
 			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// An accumulator for the distributed probability space covered.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
 			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample72 = ((fixedFlag$sample34 && fixedFlag$sample52) && fixedFlag$sample68);
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			cv$sampleAccumulator = ((cv$sampleAccumulator + DistributionSampling.logProbabilityGaussian(((x[i$var66] - mu[z[i$var66]]) / Math.sqrt(var70)))) - (Math.log(var70) * 0.5));
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if((0 < length$xMeasured))
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-			if(cv$sampleReached)
-				logProbability$var71 = logProbability$var72;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var71 = cv$sampleAccumulator;
 			
-			// Update the variable probability
+			// Store the random variable instance probability
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$x = (logProbability$x + logProbability$var72);
-			
-			// Add probability to model
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var72);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var72);
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$var72 = cv$sampleAccumulator;
 		}
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$x = (logProbability$x + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -1092,10 +963,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		// Constructor for x
 		x = new double[length$xMeasured];
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample68)
-			// Constructor for z
-			z = new int[length$xMeasured];
+		// Constructor for z
+		z = new int[length$xMeasured];
 		
 		// Allocate scratch space
 		allocateScratch();
@@ -1119,8 +988,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 			x[i$var66] = ((Math.sqrt(sigma[z[i$var66]]) * DistributionSampling.sampleGaussian(RNG$)) + mu[z[i$var66]]);
 		}
 	}
@@ -1144,12 +1012,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			for(int var51 = 0; var51 < 5; var51 += 1)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -1171,8 +1035,7 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
 		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1) {
-			if(!fixedFlag$sample68)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 			x[i$var66] = ((Math.sqrt(sigma[z[i$var66]]) * DistributionSampling.sampleGaussian(RNG$)) + mu[z[i$var66]]);
 		}
 	}
@@ -1195,12 +1058,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			for(int var51 = 0; var51 < 5; var51 += 1)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -1222,12 +1081,8 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			for(int var51 = 0; var51 < 5; var51 += 1)
 				sigma[var51] = DistributionSampling.sampleInverseGamma(RNG$, 1.0, 1.0);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample68) {
-			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-				z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
-		}
+		for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+			z[i$var66] = DistributionSampling.sampleCategorical(RNG$, phi, 5);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -1249,20 +1104,13 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 				for(int var51 = 0; var51 < 5; var51 += 1)
 					sample52(var51);
 			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample68) {
-				for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
-					sample68(i$var66);
-			}
+			for(int i$var66 = 0; i$var66 < length$xMeasured; i$var66 += 1)
+				sample68(i$var66);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample68) {
-				for(int i$var66 = (length$xMeasured - 1); i$var66 >= 0; i$var66 -= 1)
-					sample68(i$var66);
-			}
+			for(int i$var66 = (length$xMeasured - 1); i$var66 >= 0; i$var66 -= 1)
+				sample68(i$var66);
 			
 			// Constraints moved from conditionals in inner loops/scopes/etc.
 			if(!fixedFlag$sample52) {
@@ -1313,12 +1161,10 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 		if(!fixedProbFlag$sample52)
 			logProbability$var52 = Double.NaN;
 		logProbability$var67 = Double.NaN;
-		if(!fixedProbFlag$sample68)
-			logProbability$z = Double.NaN;
+		logProbability$z = Double.NaN;
 		logProbability$var71 = Double.NaN;
 		logProbability$x = 0.0;
-		if(!fixedProbFlag$sample72)
-			logProbability$var72 = Double.NaN;
+		logProbability$var72 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -1334,8 +1180,6 @@ class GaussianMixtureTest$SingleThreadCPU extends org.sandwood.runtime.internal.
 			logProbabilityValue$sample34();
 		if(fixedFlag$sample52)
 			logProbabilityValue$sample52();
-		if(fixedFlag$sample68)
-			logProbabilityValue$sample68();
 		logProbabilityValue$sample72();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class GaussianMixtureTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -165,17 +166,12 @@ public class GaussianMixtureTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample68(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample68())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -303,7 +299,6 @@ public class GaussianMixtureTest extends Model {
         newCore.set$fixedFlag$sample17(oldCore.get$fixedFlag$sample17());
         newCore.set$fixedFlag$sample34(oldCore.get$fixedFlag$sample34());
         newCore.set$fixedFlag$sample52(oldCore.get$fixedFlag$sample52());
-        newCore.set$fixedFlag$sample68(oldCore.get$fixedFlag$sample68());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class GaussianMixtureTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -165,17 +166,12 @@ public class GaussianMixtureTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample68(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample68())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -303,7 +299,6 @@ public class GaussianMixtureTest extends Model {
         newCore.set$fixedFlag$sample17(oldCore.get$fixedFlag$sample17());
         newCore.set$fixedFlag$sample34(oldCore.get$fixedFlag$sample34());
         newCore.set$fixedFlag$sample52(oldCore.get$fixedFlag$sample52());
-        newCore.set$fixedFlag$sample68(oldCore.get$fixedFlag$sample68());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class GaussianMixtureTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -165,17 +166,12 @@ public class GaussianMixtureTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample68(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample68())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -303,7 +299,6 @@ public class GaussianMixtureTest extends Model {
         newCore.set$fixedFlag$sample17(oldCore.get$fixedFlag$sample17());
         newCore.set$fixedFlag$sample34(oldCore.get$fixedFlag$sample34());
         newCore.set$fixedFlag$sample52(oldCore.get$fixedFlag$sample52());
-        newCore.set$fixedFlag$sample68(oldCore.get$fixedFlag$sample68());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class GaussianMixtureTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -165,17 +166,12 @@ public class GaussianMixtureTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample68(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample68())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -303,7 +299,6 @@ public class GaussianMixtureTest extends Model {
         newCore.set$fixedFlag$sample17(oldCore.get$fixedFlag$sample17());
         newCore.set$fixedFlag$sample34(oldCore.get$fixedFlag$sample34());
         newCore.set$fixedFlag$sample52(oldCore.get$fixedFlag$sample52());
-        newCore.set$fixedFlag$sample68(oldCore.get$fixedFlag$sample68());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class GaussianMixtureTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -165,17 +166,12 @@ public class GaussianMixtureTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample68(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample68())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -303,7 +299,6 @@ public class GaussianMixtureTest extends Model {
         newCore.set$fixedFlag$sample17(oldCore.get$fixedFlag$sample17());
         newCore.set$fixedFlag$sample34(oldCore.get$fixedFlag$sample34());
         newCore.set$fixedFlag$sample52(oldCore.get$fixedFlag$sample52());
-        newCore.set$fixedFlag$sample68(oldCore.get$fixedFlag$sample68());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/GaussianMixtureTest/GaussianMixtureTest_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class GaussianMixtureTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -165,17 +166,12 @@ public class GaussianMixtureTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample68(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample68())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -303,7 +299,6 @@ public class GaussianMixtureTest extends Model {
         newCore.set$fixedFlag$sample17(oldCore.get$fixedFlag$sample17());
         newCore.set$fixedFlag$sample34(oldCore.get$fixedFlag$sample34());
         newCore.set$fixedFlag$sample52(oldCore.get$fixedFlag$sample52());
-        newCore.set$fixedFlag$sample68(oldCore.get$fixedFlag$sample68());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM/HMM_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM/HMM_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMM extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM/HMM_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM/HMM_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMM extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM/HMM_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM/HMM_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMM extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM/HMM_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM/HMM_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMM extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM/HMM_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM/HMM_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMM extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM/HMM_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM/HMM_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMM extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics/HMMMetrics_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics/HMMMetrics_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -206,7 +207,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -305,7 +306,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics/HMMMetrics_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics/HMMMetrics_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -206,7 +207,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -305,7 +306,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics/HMMMetrics_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics/HMMMetrics_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -206,7 +207,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -305,7 +306,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics/HMMMetrics_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics/HMMMetrics_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -206,7 +207,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -305,7 +306,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics/HMMMetrics_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics/HMMMetrics_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -206,7 +207,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -305,7 +306,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics/HMMMetrics_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics/HMMMetrics_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -206,7 +207,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -305,7 +306,7 @@ public class HMMMetrics extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$CoreInterface_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$CoreInterface_model.java
@@ -26,6 +26,12 @@ interface HMMMetrics2$CoreInterface extends org.sandwood.runtime.internal.model.
 	// Setter for fixedFlag$sample123.
 	public void set$fixedFlag$sample123(boolean cv$value);
 
+	// Getter for fixedFlag$sample157.
+	public boolean get$fixedFlag$sample157();
+
+	// Setter for fixedFlag$sample157.
+	public void set$fixedFlag$sample157(boolean cv$value);
+
 	// Getter for fixedFlag$sample19.
 	public boolean get$fixedFlag$sample19();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$CoreInterface_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$CoreInterface_modelNoComments.java
@@ -9,6 +9,8 @@ interface HMMMetrics2$CoreInterface extends org.sandwood.runtime.internal.model.
 	public void set$fixedFlag$sample104(boolean cv$value);
 	public boolean get$fixedFlag$sample123();
 	public void set$fixedFlag$sample123(boolean cv$value);
+	public boolean get$fixedFlag$sample157();
+	public void set$fixedFlag$sample157(boolean cv$value);
 	public boolean get$fixedFlag$sample19();
 	public void set$fixedFlag$sample19(boolean cv$value);
 	public boolean get$fixedFlag$sample32();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$CoreInterface_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$CoreInterface_modelSingle.java
@@ -26,6 +26,12 @@ interface HMMMetrics2$CoreInterface extends org.sandwood.runtime.internal.model.
 	// Setter for fixedFlag$sample123.
 	public void set$fixedFlag$sample123(boolean cv$value);
 
+	// Getter for fixedFlag$sample157.
+	public boolean get$fixedFlag$sample157();
+
+	// Setter for fixedFlag$sample157.
+	public void set$fixedFlag$sample157(boolean cv$value);
+
 	// Getter for fixedFlag$sample19.
 	public boolean get$fixedFlag$sample19();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$CoreInterface_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$CoreInterface_optimisedModel.java
@@ -26,6 +26,12 @@ interface HMMMetrics2$CoreInterface extends org.sandwood.runtime.internal.model.
 	// Setter for fixedFlag$sample123.
 	public void set$fixedFlag$sample123(boolean cv$value);
 
+	// Getter for fixedFlag$sample157.
+	public boolean get$fixedFlag$sample157();
+
+	// Setter for fixedFlag$sample157.
+	public void set$fixedFlag$sample157(boolean cv$value);
+
 	// Getter for fixedFlag$sample19.
 	public boolean get$fixedFlag$sample19();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$CoreInterface_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$CoreInterface_optimisedModelNoComments.java
@@ -9,6 +9,8 @@ interface HMMMetrics2$CoreInterface extends org.sandwood.runtime.internal.model.
 	public void set$fixedFlag$sample104(boolean cv$value);
 	public boolean get$fixedFlag$sample123();
 	public void set$fixedFlag$sample123(boolean cv$value);
+	public boolean get$fixedFlag$sample157();
+	public void set$fixedFlag$sample157(boolean cv$value);
 	public boolean get$fixedFlag$sample19();
 	public void set$fixedFlag$sample19(boolean cv$value);
 	public boolean get$fixedFlag$sample32();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$CoreInterface_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$CoreInterface_optimisedModelSingle.java
@@ -26,6 +26,12 @@ interface HMMMetrics2$CoreInterface extends org.sandwood.runtime.internal.model.
 	// Setter for fixedFlag$sample123.
 	public void set$fixedFlag$sample123(boolean cv$value);
 
+	// Getter for fixedFlag$sample157.
+	public boolean get$fixedFlag$sample157();
+
+	// Setter for fixedFlag$sample157.
+	public void set$fixedFlag$sample157(boolean cv$value);
+
 	// Getter for fixedFlag$sample19.
 	public boolean get$fixedFlag$sample19();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_model.java
@@ -17,6 +17,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 	private double[][][] distribution$sample123;
 	private boolean fixedFlag$sample104 = false;
 	private boolean fixedFlag$sample123 = false;
+	private boolean fixedFlag$sample157 = false;
 	private boolean fixedFlag$sample19 = false;
 	private boolean fixedFlag$sample32 = false;
 	private boolean fixedFlag$sample52 = false;
@@ -163,6 +164,18 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 		// Should the probability of sample 157 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample157 = (fixedFlag$sample123 && fixedProbFlag$sample157);
+	}
+
+	// Getter for fixedFlag$sample157.
+	@Override
+	public final boolean get$fixedFlag$sample157() {
+		return fixedFlag$sample157;
+	}
+
+	// Setter for fixedFlag$sample157.
+	@Override
+	public final void set$fixedFlag$sample157(boolean cv$value) {
+		fixedFlag$sample157 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample19.
@@ -9891,7 +9904,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 									for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
 										if(metric_valid_1d[timeStep$var136]) {
-											var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
+											if(!fixedFlag$sample157)
+												var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 										}
 									}
@@ -10201,7 +10215,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 									for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
 										if(metric_valid_1d[timeStep$var136]) {
-											var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
+											if(!fixedFlag$sample157)
+												var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 										}
 									}
@@ -10693,29 +10708,35 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propogateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample157 = false;
+		
+		// Propagating values back from observations into the models intermediate variables.
 		{
-			// Deep copy between arrays
-			boolean[][] cv$source1 = metric_valid;
-			boolean[][] cv$target1 = metric_valid_g;
-			int cv$length1 = cv$target1.length;
-			for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
-				boolean[] cv$source2 = cv$source1[cv$index1];
-				boolean[] cv$target2 = cv$target1[cv$index1];
-				int cv$length2 = cv$target2.length;
-				for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
-					cv$target2[cv$index2] = cv$source2[cv$index2];
+			{
+				// Deep copy between arrays
+				boolean[][] cv$source1 = metric_valid;
+				boolean[][] cv$target1 = metric_valid_g;
+				int cv$length1 = cv$target1.length;
+				for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
+					boolean[] cv$source2 = cv$source1[cv$index1];
+					boolean[] cv$target2 = cv$target1[cv$index1];
+					int cv$length2 = cv$target2.length;
+					for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
+						cv$target2[cv$index2] = cv$source2[cv$index2];
+				}
 			}
-		}
-		for(int sample = (noSamples - ((((noSamples - 1) - 0) % 1) + 1)); sample >= ((0 - 1) + 1); sample -= 1) {
-			for(int timeStep$var136 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); timeStep$var136 >= ((0 - 1) + 1); timeStep$var136 -= 1) {
-				metric_g[sample][timeStep$var136] = metric[sample][timeStep$var136];
-				if(metric_valid_g[sample][timeStep$var136]) {
-					{
-						// Looking for a path between Put 158 and consumer double 154.
+			for(int sample = (noSamples - ((((noSamples - 1) - 0) % 1) + 1)); sample >= ((0 - 1) + 1); sample -= 1) {
+				for(int timeStep$var136 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); timeStep$var136 >= ((0 - 1) + 1); timeStep$var136 -= 1) {
+					metric_g[sample][timeStep$var136] = metric[sample][timeStep$var136];
+					if(metric_valid_g[sample][timeStep$var136]) {
 						{
-							for(int index$timeStep$2_1 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); index$timeStep$2_1 >= ((0 - 1) + 1); index$timeStep$2_1 -= 1) {
-								if((timeStep$var136 == index$timeStep$2_1))
-									var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = metric_g[sample][timeStep$var136];
+							// Looking for a path between Put 158 and consumer double 154.
+							{
+								for(int index$timeStep$2_1 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); index$timeStep$2_1 >= ((0 - 1) + 1); index$timeStep$2_1 -= 1) {
+									if((timeStep$var136 == index$timeStep$2_1))
+										var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = metric_g[sample][timeStep$var136];
+								}
 							}
 						}
 					}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_modelNoComments.java
@@ -15,6 +15,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 	private double[][][] distribution$sample123;
 	private boolean fixedFlag$sample104 = false;
 	private boolean fixedFlag$sample123 = false;
+	private boolean fixedFlag$sample157 = false;
 	private boolean fixedFlag$sample19 = false;
 	private boolean fixedFlag$sample32 = false;
 	private boolean fixedFlag$sample52 = false;
@@ -126,6 +127,16 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 		fixedProbFlag$sample123 = (fixedFlag$sample123 && fixedProbFlag$sample123);
 		fixedProbFlag$sample145 = (fixedFlag$sample123 && fixedProbFlag$sample145);
 		fixedProbFlag$sample157 = (fixedFlag$sample123 && fixedProbFlag$sample157);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample157() {
+		return fixedFlag$sample157;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample157(boolean cv$value) {
+		fixedFlag$sample157 = cv$value;
 	}
 
 	@Override
@@ -6903,7 +6914,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 								for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
 										if(metric_valid_1d[timeStep$var136]) {
-											var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
+											if(!fixedFlag$sample157)
+												var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 										}
 									}
@@ -7128,7 +7140,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 								for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
 										if(metric_valid_1d[timeStep$var136]) {
-											var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
+											if(!fixedFlag$sample157)
+												var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 										}
 									}
@@ -7468,27 +7481,30 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 
 	@Override
 	public final void propogateObservedValues() {
+		fixedFlag$sample157 = false;
 		{
-			boolean[][] cv$source1 = metric_valid;
-			boolean[][] cv$target1 = metric_valid_g;
-			int cv$length1 = cv$target1.length;
-			for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
-				boolean[] cv$source2 = cv$source1[cv$index1];
-				boolean[] cv$target2 = cv$target1[cv$index1];
-				int cv$length2 = cv$target2.length;
-				for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
-					cv$target2[cv$index2] = cv$source2[cv$index2];
+			{
+				boolean[][] cv$source1 = metric_valid;
+				boolean[][] cv$target1 = metric_valid_g;
+				int cv$length1 = cv$target1.length;
+				for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
+					boolean[] cv$source2 = cv$source1[cv$index1];
+					boolean[] cv$target2 = cv$target1[cv$index1];
+					int cv$length2 = cv$target2.length;
+					for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
+						cv$target2[cv$index2] = cv$source2[cv$index2];
+				}
 			}
-		}
-		for(int sample = (noSamples - ((((noSamples - 1) - 0) % 1) + 1)); sample >= ((0 - 1) + 1); sample -= 1) {
-			for(int timeStep$var136 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); timeStep$var136 >= ((0 - 1) + 1); timeStep$var136 -= 1) {
-				metric_g[sample][timeStep$var136] = metric[sample][timeStep$var136];
-				if(metric_valid_g[sample][timeStep$var136]) {
-					{
+			for(int sample = (noSamples - ((((noSamples - 1) - 0) % 1) + 1)); sample >= ((0 - 1) + 1); sample -= 1) {
+				for(int timeStep$var136 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); timeStep$var136 >= ((0 - 1) + 1); timeStep$var136 -= 1) {
+					metric_g[sample][timeStep$var136] = metric[sample][timeStep$var136];
+					if(metric_valid_g[sample][timeStep$var136]) {
 						{
-							for(int index$timeStep$2_1 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); index$timeStep$2_1 >= ((0 - 1) + 1); index$timeStep$2_1 -= 1) {
-								if((timeStep$var136 == index$timeStep$2_1))
-									var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = metric_g[sample][timeStep$var136];
+							{
+								for(int index$timeStep$2_1 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); index$timeStep$2_1 >= ((0 - 1) + 1); index$timeStep$2_1 -= 1) {
+									if((timeStep$var136 == index$timeStep$2_1))
+										var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = metric_g[sample][timeStep$var136];
+								}
 							}
 						}
 					}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_modelSingle.java
@@ -17,6 +17,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 	private double[][][] distribution$sample123;
 	private boolean fixedFlag$sample104 = false;
 	private boolean fixedFlag$sample123 = false;
+	private boolean fixedFlag$sample157 = false;
 	private boolean fixedFlag$sample19 = false;
 	private boolean fixedFlag$sample32 = false;
 	private boolean fixedFlag$sample52 = false;
@@ -162,6 +163,18 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 		// Should the probability of sample 157 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample157 = (fixedFlag$sample123 && fixedProbFlag$sample157);
+	}
+
+	// Getter for fixedFlag$sample157.
+	@Override
+	public final boolean get$fixedFlag$sample157() {
+		return fixedFlag$sample157;
+	}
+
+	// Setter for fixedFlag$sample157.
+	@Override
+	public final void set$fixedFlag$sample157(boolean cv$value) {
+		fixedFlag$sample157 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample19.
@@ -9870,7 +9883,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 									for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
 										if(metric_valid_1d[timeStep$var136]) {
-											var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
+											if(!fixedFlag$sample157)
+												var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 										}
 									}
@@ -10180,7 +10194,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 									for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
 										if(metric_valid_1d[timeStep$var136]) {
-											var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
+											if(!fixedFlag$sample157)
+												var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 										}
 									}
@@ -10647,29 +10662,35 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propogateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample157 = false;
+		
+		// Propagating values back from observations into the models intermediate variables.
 		{
-			// Deep copy between arrays
-			boolean[][] cv$source1 = metric_valid;
-			boolean[][] cv$target1 = metric_valid_g;
-			int cv$length1 = cv$target1.length;
-			for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
-				boolean[] cv$source2 = cv$source1[cv$index1];
-				boolean[] cv$target2 = cv$target1[cv$index1];
-				int cv$length2 = cv$target2.length;
-				for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
-					cv$target2[cv$index2] = cv$source2[cv$index2];
+			{
+				// Deep copy between arrays
+				boolean[][] cv$source1 = metric_valid;
+				boolean[][] cv$target1 = metric_valid_g;
+				int cv$length1 = cv$target1.length;
+				for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
+					boolean[] cv$source2 = cv$source1[cv$index1];
+					boolean[] cv$target2 = cv$target1[cv$index1];
+					int cv$length2 = cv$target2.length;
+					for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
+						cv$target2[cv$index2] = cv$source2[cv$index2];
+				}
 			}
-		}
-		for(int sample = (noSamples - ((((noSamples - 1) - 0) % 1) + 1)); sample >= ((0 - 1) + 1); sample -= 1) {
-			for(int timeStep$var136 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); timeStep$var136 >= ((0 - 1) + 1); timeStep$var136 -= 1) {
-				metric_g[sample][timeStep$var136] = metric[sample][timeStep$var136];
-				if(metric_valid_g[sample][timeStep$var136]) {
-					{
-						// Looking for a path between Put 158 and consumer double 154.
+			for(int sample = (noSamples - ((((noSamples - 1) - 0) % 1) + 1)); sample >= ((0 - 1) + 1); sample -= 1) {
+				for(int timeStep$var136 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); timeStep$var136 >= ((0 - 1) + 1); timeStep$var136 -= 1) {
+					metric_g[sample][timeStep$var136] = metric[sample][timeStep$var136];
+					if(metric_valid_g[sample][timeStep$var136]) {
 						{
-							for(int index$timeStep$2_1 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); index$timeStep$2_1 >= ((0 - 1) + 1); index$timeStep$2_1 -= 1) {
-								if((timeStep$var136 == index$timeStep$2_1))
-									var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = metric_g[sample][timeStep$var136];
+							// Looking for a path between Put 158 and consumer double 154.
+							{
+								for(int index$timeStep$2_1 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); index$timeStep$2_1 >= ((0 - 1) + 1); index$timeStep$2_1 -= 1) {
+									if((timeStep$var136 == index$timeStep$2_1))
+										var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = metric_g[sample][timeStep$var136];
+								}
 							}
 						}
 					}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_optimisedModel.java
@@ -17,6 +17,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 	private double[][][] distribution$sample123;
 	private boolean fixedFlag$sample104 = false;
 	private boolean fixedFlag$sample123 = false;
+	private boolean fixedFlag$sample157 = false;
 	private boolean fixedFlag$sample19 = false;
 	private boolean fixedFlag$sample32 = false;
 	private boolean fixedFlag$sample52 = false;
@@ -177,6 +178,18 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 		// 
 		// Substituted "fixedFlag$sample123" with its value "cv$value".
 		fixedProbFlag$sample157 = (cv$value && fixedProbFlag$sample157);
+	}
+
+	// Getter for fixedFlag$sample157.
+	@Override
+	public final boolean get$fixedFlag$sample157() {
+		return fixedFlag$sample157;
+	}
+
+	// Setter for fixedFlag$sample157.
+	@Override
+	public final void set$fixedFlag$sample157(boolean cv$value) {
+		fixedFlag$sample157 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample19.
@@ -5209,7 +5222,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 									for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
 										if(metric_valid_1d[timeStep$var136]) {
-											var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
+											if(!fixedFlag$sample157)
+												var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 										}
 									}
@@ -5479,7 +5493,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 									for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
 										if(metric_valid_1d[timeStep$var136]) {
-											var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
+											if(!fixedFlag$sample157)
+												var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 										}
 									}
@@ -5990,7 +6005,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propogateObservedValues() {
-		// Propagating values back from observations into the models intermediate variables.
+		// Reset any fixed flags on observed values
+		fixedFlag$sample157 = false;
 		int cv$length1 = metric_valid_g.length;
 		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
 			boolean[] cv$source2 = metric_valid[cv$index1];

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_optimisedModelNoComments.java
@@ -15,6 +15,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 	private double[][][] distribution$sample123;
 	private boolean fixedFlag$sample104 = false;
 	private boolean fixedFlag$sample123 = false;
+	private boolean fixedFlag$sample157 = false;
 	private boolean fixedFlag$sample19 = false;
 	private boolean fixedFlag$sample32 = false;
 	private boolean fixedFlag$sample52 = false;
@@ -126,6 +127,16 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 		fixedProbFlag$sample123 = (cv$value && fixedProbFlag$sample123);
 		fixedProbFlag$sample145 = (cv$value && fixedProbFlag$sample145);
 		fixedProbFlag$sample157 = (cv$value && fixedProbFlag$sample157);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample157() {
+		return fixedFlag$sample157;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample157(boolean cv$value) {
+		fixedFlag$sample157 = cv$value;
 	}
 
 	@Override
@@ -2092,7 +2103,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 								for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
 										if(metric_valid_1d[timeStep$var136]) {
-											var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
+											if(!fixedFlag$sample157)
+												var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 										}
 									}
@@ -2251,7 +2263,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 								for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
 										if(metric_valid_1d[timeStep$var136]) {
-											var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
+											if(!fixedFlag$sample157)
+												var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 										}
 									}
@@ -2587,6 +2600,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 
 	@Override
 	public final void propogateObservedValues() {
+		fixedFlag$sample157 = false;
 		int cv$length1 = metric_valid_g.length;
 		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
 			boolean[] cv$source2 = metric_valid[cv$index1];

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$MultiThreadCPU_optimisedModelSingle.java
@@ -17,6 +17,7 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 	private double[][][] distribution$sample123;
 	private boolean fixedFlag$sample104 = false;
 	private boolean fixedFlag$sample123 = false;
+	private boolean fixedFlag$sample157 = false;
 	private boolean fixedFlag$sample19 = false;
 	private boolean fixedFlag$sample32 = false;
 	private boolean fixedFlag$sample52 = false;
@@ -176,6 +177,18 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 		// 
 		// Substituted "fixedFlag$sample123" with its value "cv$value".
 		fixedProbFlag$sample157 = (cv$value && fixedProbFlag$sample157);
+	}
+
+	// Getter for fixedFlag$sample157.
+	@Override
+	public final boolean get$fixedFlag$sample157() {
+		return fixedFlag$sample157;
+	}
+
+	// Setter for fixedFlag$sample157.
+	@Override
+	public final void set$fixedFlag$sample157(boolean cv$value) {
+		fixedFlag$sample157 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample19.
@@ -5402,7 +5415,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 									for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
 										if(metric_valid_1d[timeStep$var136]) {
-											var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
+											if(!fixedFlag$sample157)
+												var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 										}
 									}
@@ -5672,7 +5686,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 									for(int timeStep$var136 = forStart$timeStep$var136; timeStep$var136 < forEnd$timeStep$var136; timeStep$var136 += 1) {
 										metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$2, metric_valid_bias[st[sample][timeStep$var136]]);
 										if(metric_valid_1d[timeStep$var136]) {
-											var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
+											if(!fixedFlag$sample157)
+												var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$2)) + metric_mean[st[sample][timeStep$var136]]);
 											metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 										}
 									}
@@ -6158,7 +6173,8 @@ class HMMMetrics2$MultiThreadCPU extends org.sandwood.runtime.internal.model.Cor
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propogateObservedValues() {
-		// Propagating values back from observations into the models intermediate variables.
+		// Reset any fixed flags on observed values
+		fixedFlag$sample157 = false;
 		int cv$length1 = metric_valid_g.length;
 		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
 			boolean[] cv$source2 = metric_valid[cv$index1];

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_model.java
@@ -16,6 +16,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 	private double[][][] distribution$sample123;
 	private boolean fixedFlag$sample104 = false;
 	private boolean fixedFlag$sample123 = false;
+	private boolean fixedFlag$sample157 = false;
 	private boolean fixedFlag$sample19 = false;
 	private boolean fixedFlag$sample32 = false;
 	private boolean fixedFlag$sample52 = false;
@@ -162,6 +163,18 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// Should the probability of sample 157 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample157 = (fixedFlag$sample123 && fixedProbFlag$sample157);
+	}
+
+	// Getter for fixedFlag$sample157.
+	@Override
+	public final boolean get$fixedFlag$sample157() {
+		return fixedFlag$sample157;
+	}
+
+	// Setter for fixedFlag$sample157.
+	@Override
+	public final void set$fixedFlag$sample157(boolean cv$value) {
+		fixedFlag$sample157 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample19.
@@ -9778,7 +9791,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
 				if(metric_valid_1d[timeStep$var136]) {
-					var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
+					if(!fixedFlag$sample157)
+						var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 				}
 			}
@@ -9987,7 +10001,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
 				if(metric_valid_1d[timeStep$var136]) {
-					var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
+					if(!fixedFlag$sample157)
+						var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 				}
 			}
@@ -10287,29 +10302,35 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propogateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample157 = false;
+		
+		// Propagating values back from observations into the models intermediate variables.
 		{
-			// Deep copy between arrays
-			boolean[][] cv$source1 = metric_valid;
-			boolean[][] cv$target1 = metric_valid_g;
-			int cv$length1 = cv$target1.length;
-			for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
-				boolean[] cv$source2 = cv$source1[cv$index1];
-				boolean[] cv$target2 = cv$target1[cv$index1];
-				int cv$length2 = cv$target2.length;
-				for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
-					cv$target2[cv$index2] = cv$source2[cv$index2];
+			{
+				// Deep copy between arrays
+				boolean[][] cv$source1 = metric_valid;
+				boolean[][] cv$target1 = metric_valid_g;
+				int cv$length1 = cv$target1.length;
+				for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
+					boolean[] cv$source2 = cv$source1[cv$index1];
+					boolean[] cv$target2 = cv$target1[cv$index1];
+					int cv$length2 = cv$target2.length;
+					for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
+						cv$target2[cv$index2] = cv$source2[cv$index2];
+				}
 			}
-		}
-		for(int sample = (noSamples - ((((noSamples - 1) - 0) % 1) + 1)); sample >= ((0 - 1) + 1); sample -= 1) {
-			for(int timeStep$var136 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); timeStep$var136 >= ((0 - 1) + 1); timeStep$var136 -= 1) {
-				metric_g[sample][timeStep$var136] = metric[sample][timeStep$var136];
-				if(metric_valid_g[sample][timeStep$var136]) {
-					{
-						// Looking for a path between Put 158 and consumer double 154.
+			for(int sample = (noSamples - ((((noSamples - 1) - 0) % 1) + 1)); sample >= ((0 - 1) + 1); sample -= 1) {
+				for(int timeStep$var136 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); timeStep$var136 >= ((0 - 1) + 1); timeStep$var136 -= 1) {
+					metric_g[sample][timeStep$var136] = metric[sample][timeStep$var136];
+					if(metric_valid_g[sample][timeStep$var136]) {
 						{
-							for(int index$timeStep$2_1 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); index$timeStep$2_1 >= ((0 - 1) + 1); index$timeStep$2_1 -= 1) {
-								if((timeStep$var136 == index$timeStep$2_1))
-									var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = metric_g[sample][timeStep$var136];
+							// Looking for a path between Put 158 and consumer double 154.
+							{
+								for(int index$timeStep$2_1 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); index$timeStep$2_1 >= ((0 - 1) + 1); index$timeStep$2_1 -= 1) {
+									if((timeStep$var136 == index$timeStep$2_1))
+										var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = metric_g[sample][timeStep$var136];
+								}
 							}
 						}
 					}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_modelNoComments.java
@@ -14,6 +14,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 	private double[][][] distribution$sample123;
 	private boolean fixedFlag$sample104 = false;
 	private boolean fixedFlag$sample123 = false;
+	private boolean fixedFlag$sample157 = false;
 	private boolean fixedFlag$sample19 = false;
 	private boolean fixedFlag$sample32 = false;
 	private boolean fixedFlag$sample52 = false;
@@ -125,6 +126,16 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 		fixedProbFlag$sample123 = (fixedFlag$sample123 && fixedProbFlag$sample123);
 		fixedProbFlag$sample145 = (fixedFlag$sample123 && fixedProbFlag$sample145);
 		fixedProbFlag$sample157 = (fixedFlag$sample123 && fixedProbFlag$sample157);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample157() {
+		return fixedFlag$sample157;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample157(boolean cv$value) {
+		fixedFlag$sample157 = cv$value;
 	}
 
 	@Override
@@ -6850,7 +6861,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
 				if(metric_valid_1d[timeStep$var136]) {
-					var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
+					if(!fixedFlag$sample157)
+						var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 				}
 			}
@@ -7029,7 +7041,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
 				if(metric_valid_1d[timeStep$var136]) {
-					var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
+					if(!fixedFlag$sample157)
+						var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 				}
 			}
@@ -7281,27 +7294,30 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 
 	@Override
 	public final void propogateObservedValues() {
+		fixedFlag$sample157 = false;
 		{
-			boolean[][] cv$source1 = metric_valid;
-			boolean[][] cv$target1 = metric_valid_g;
-			int cv$length1 = cv$target1.length;
-			for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
-				boolean[] cv$source2 = cv$source1[cv$index1];
-				boolean[] cv$target2 = cv$target1[cv$index1];
-				int cv$length2 = cv$target2.length;
-				for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
-					cv$target2[cv$index2] = cv$source2[cv$index2];
+			{
+				boolean[][] cv$source1 = metric_valid;
+				boolean[][] cv$target1 = metric_valid_g;
+				int cv$length1 = cv$target1.length;
+				for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
+					boolean[] cv$source2 = cv$source1[cv$index1];
+					boolean[] cv$target2 = cv$target1[cv$index1];
+					int cv$length2 = cv$target2.length;
+					for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
+						cv$target2[cv$index2] = cv$source2[cv$index2];
+				}
 			}
-		}
-		for(int sample = (noSamples - ((((noSamples - 1) - 0) % 1) + 1)); sample >= ((0 - 1) + 1); sample -= 1) {
-			for(int timeStep$var136 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); timeStep$var136 >= ((0 - 1) + 1); timeStep$var136 -= 1) {
-				metric_g[sample][timeStep$var136] = metric[sample][timeStep$var136];
-				if(metric_valid_g[sample][timeStep$var136]) {
-					{
+			for(int sample = (noSamples - ((((noSamples - 1) - 0) % 1) + 1)); sample >= ((0 - 1) + 1); sample -= 1) {
+				for(int timeStep$var136 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); timeStep$var136 >= ((0 - 1) + 1); timeStep$var136 -= 1) {
+					metric_g[sample][timeStep$var136] = metric[sample][timeStep$var136];
+					if(metric_valid_g[sample][timeStep$var136]) {
 						{
-							for(int index$timeStep$2_1 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); index$timeStep$2_1 >= ((0 - 1) + 1); index$timeStep$2_1 -= 1) {
-								if((timeStep$var136 == index$timeStep$2_1))
-									var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = metric_g[sample][timeStep$var136];
+							{
+								for(int index$timeStep$2_1 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); index$timeStep$2_1 >= ((0 - 1) + 1); index$timeStep$2_1 -= 1) {
+									if((timeStep$var136 == index$timeStep$2_1))
+										var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = metric_g[sample][timeStep$var136];
+								}
 							}
 						}
 					}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_modelSingle.java
@@ -16,6 +16,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 	private double[][][] distribution$sample123;
 	private boolean fixedFlag$sample104 = false;
 	private boolean fixedFlag$sample123 = false;
+	private boolean fixedFlag$sample157 = false;
 	private boolean fixedFlag$sample19 = false;
 	private boolean fixedFlag$sample32 = false;
 	private boolean fixedFlag$sample52 = false;
@@ -161,6 +162,18 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// Should the probability of sample 157 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample157 = (fixedFlag$sample123 && fixedProbFlag$sample157);
+	}
+
+	// Getter for fixedFlag$sample157.
+	@Override
+	public final boolean get$fixedFlag$sample157() {
+		return fixedFlag$sample157;
+	}
+
+	// Setter for fixedFlag$sample157.
+	@Override
+	public final void set$fixedFlag$sample157(boolean cv$value) {
+		fixedFlag$sample157 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample19.
@@ -9757,7 +9770,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
 				if(metric_valid_1d[timeStep$var136]) {
-					var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
+					if(!fixedFlag$sample157)
+						var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 				}
 			}
@@ -9966,7 +9980,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
 				if(metric_valid_1d[timeStep$var136]) {
-					var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
+					if(!fixedFlag$sample157)
+						var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)];
 				}
 			}
@@ -10241,29 +10256,35 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propogateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample157 = false;
+		
+		// Propagating values back from observations into the models intermediate variables.
 		{
-			// Deep copy between arrays
-			boolean[][] cv$source1 = metric_valid;
-			boolean[][] cv$target1 = metric_valid_g;
-			int cv$length1 = cv$target1.length;
-			for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
-				boolean[] cv$source2 = cv$source1[cv$index1];
-				boolean[] cv$target2 = cv$target1[cv$index1];
-				int cv$length2 = cv$target2.length;
-				for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
-					cv$target2[cv$index2] = cv$source2[cv$index2];
+			{
+				// Deep copy between arrays
+				boolean[][] cv$source1 = metric_valid;
+				boolean[][] cv$target1 = metric_valid_g;
+				int cv$length1 = cv$target1.length;
+				for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
+					boolean[] cv$source2 = cv$source1[cv$index1];
+					boolean[] cv$target2 = cv$target1[cv$index1];
+					int cv$length2 = cv$target2.length;
+					for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
+						cv$target2[cv$index2] = cv$source2[cv$index2];
+				}
 			}
-		}
-		for(int sample = (noSamples - ((((noSamples - 1) - 0) % 1) + 1)); sample >= ((0 - 1) + 1); sample -= 1) {
-			for(int timeStep$var136 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); timeStep$var136 >= ((0 - 1) + 1); timeStep$var136 -= 1) {
-				metric_g[sample][timeStep$var136] = metric[sample][timeStep$var136];
-				if(metric_valid_g[sample][timeStep$var136]) {
-					{
-						// Looking for a path between Put 158 and consumer double 154.
+			for(int sample = (noSamples - ((((noSamples - 1) - 0) % 1) + 1)); sample >= ((0 - 1) + 1); sample -= 1) {
+				for(int timeStep$var136 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); timeStep$var136 >= ((0 - 1) + 1); timeStep$var136 -= 1) {
+					metric_g[sample][timeStep$var136] = metric[sample][timeStep$var136];
+					if(metric_valid_g[sample][timeStep$var136]) {
 						{
-							for(int index$timeStep$2_1 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); index$timeStep$2_1 >= ((0 - 1) + 1); index$timeStep$2_1 -= 1) {
-								if((timeStep$var136 == index$timeStep$2_1))
-									var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = metric_g[sample][timeStep$var136];
+							// Looking for a path between Put 158 and consumer double 154.
+							{
+								for(int index$timeStep$2_1 = (length$metric[sample] - ((((length$metric[sample] - 1) - 0) % 1) + 1)); index$timeStep$2_1 >= ((0 - 1) + 1); index$timeStep$2_1 -= 1) {
+									if((timeStep$var136 == index$timeStep$2_1))
+										var151[((sample - 0) / 1)][((timeStep$var136 - 0) / 1)] = metric_g[sample][timeStep$var136];
+								}
 							}
 						}
 					}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_optimisedModel.java
@@ -16,6 +16,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 	private double[][][] distribution$sample123;
 	private boolean fixedFlag$sample104 = false;
 	private boolean fixedFlag$sample123 = false;
+	private boolean fixedFlag$sample157 = false;
 	private boolean fixedFlag$sample19 = false;
 	private boolean fixedFlag$sample32 = false;
 	private boolean fixedFlag$sample52 = false;
@@ -176,6 +177,18 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// 
 		// Substituted "fixedFlag$sample123" with its value "cv$value".
 		fixedProbFlag$sample157 = (cv$value && fixedProbFlag$sample157);
+	}
+
+	// Getter for fixedFlag$sample157.
+	@Override
+	public final boolean get$fixedFlag$sample157() {
+		return fixedFlag$sample157;
+	}
+
+	// Setter for fixedFlag$sample157.
+	@Override
+	public final void set$fixedFlag$sample157(boolean cv$value) {
+		fixedFlag$sample157 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample19.
@@ -5109,7 +5122,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
 				if(metric_valid_1d[timeStep$var136]) {
-					var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
+					if(!fixedFlag$sample157)
+						var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 				}
 			}
@@ -5286,7 +5300,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
 				if(metric_valid_1d[timeStep$var136]) {
-					var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
+					if(!fixedFlag$sample157)
+						var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 				}
 			}
@@ -5621,7 +5636,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propogateObservedValues() {
-		// Propagating values back from observations into the models intermediate variables.
+		// Reset any fixed flags on observed values
+		fixedFlag$sample157 = false;
 		int cv$length1 = metric_valid_g.length;
 		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
 			boolean[] cv$source2 = metric_valid[cv$index1];

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_optimisedModelNoComments.java
@@ -14,6 +14,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 	private double[][][] distribution$sample123;
 	private boolean fixedFlag$sample104 = false;
 	private boolean fixedFlag$sample123 = false;
+	private boolean fixedFlag$sample157 = false;
 	private boolean fixedFlag$sample19 = false;
 	private boolean fixedFlag$sample32 = false;
 	private boolean fixedFlag$sample52 = false;
@@ -125,6 +126,16 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 		fixedProbFlag$sample123 = (cv$value && fixedProbFlag$sample123);
 		fixedProbFlag$sample145 = (cv$value && fixedProbFlag$sample145);
 		fixedProbFlag$sample157 = (cv$value && fixedProbFlag$sample157);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample157() {
+		return fixedFlag$sample157;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample157(boolean cv$value) {
+		fixedFlag$sample157 = cv$value;
 	}
 
 	@Override
@@ -2032,7 +2043,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
 				if(metric_valid_1d[timeStep$var136]) {
-					var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
+					if(!fixedFlag$sample157)
+						var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 				}
 			}
@@ -2145,7 +2157,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
 				if(metric_valid_1d[timeStep$var136]) {
-					var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
+					if(!fixedFlag$sample157)
+						var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 				}
 			}
@@ -2393,6 +2406,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 
 	@Override
 	public final void propogateObservedValues() {
+		fixedFlag$sample157 = false;
 		int cv$length1 = metric_valid_g.length;
 		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
 			boolean[] cv$source2 = metric_valid[cv$index1];

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2$SingleThreadCPU_optimisedModelSingle.java
@@ -16,6 +16,7 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 	private double[][][] distribution$sample123;
 	private boolean fixedFlag$sample104 = false;
 	private boolean fixedFlag$sample123 = false;
+	private boolean fixedFlag$sample157 = false;
 	private boolean fixedFlag$sample19 = false;
 	private boolean fixedFlag$sample32 = false;
 	private boolean fixedFlag$sample52 = false;
@@ -175,6 +176,18 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// 
 		// Substituted "fixedFlag$sample123" with its value "cv$value".
 		fixedProbFlag$sample157 = (cv$value && fixedProbFlag$sample157);
+	}
+
+	// Getter for fixedFlag$sample157.
+	@Override
+	public final boolean get$fixedFlag$sample157() {
+		return fixedFlag$sample157;
+	}
+
+	// Setter for fixedFlag$sample157.
+	@Override
+	public final void set$fixedFlag$sample157(boolean cv$value) {
+		fixedFlag$sample157 = cv$value;
 	}
 
 	// Getter for fixedFlag$sample19.
@@ -5302,7 +5315,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
 				if(metric_valid_1d[timeStep$var136]) {
-					var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
+					if(!fixedFlag$sample157)
+						var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 				}
 			}
@@ -5479,7 +5493,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 			for(int timeStep$var136 = 0; timeStep$var136 < length$metric[sample]; timeStep$var136 += 1) {
 				metric_valid_1d[timeStep$var136] = DistributionSampling.sampleBernoulli(RNG$, metric_valid_bias[st[sample][timeStep$var136]]);
 				if(metric_valid_1d[timeStep$var136]) {
-					var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
+					if(!fixedFlag$sample157)
+						var151[sample][timeStep$var136] = ((Math.sqrt(metric_var[st[sample][timeStep$var136]]) * DistributionSampling.sampleGaussian(RNG$)) + metric_mean[st[sample][timeStep$var136]]);
 					metric_1d[timeStep$var136] = var151[sample][timeStep$var136];
 				}
 			}
@@ -5789,7 +5804,8 @@ class HMMMetrics2$SingleThreadCPU extends org.sandwood.runtime.internal.model.Co
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propogateObservedValues() {
-		// Propagating values back from observations into the models intermediate variables.
+		// Reset any fixed flags on observed values
+		fixedFlag$sample157 = false;
 		int cv$length1 = metric_valid_g.length;
 		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
 			boolean[] cv$source2 = metric_valid[cv$index1];

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -112,7 +113,7 @@ public class HMMMetrics2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -216,7 +217,7 @@ public class HMMMetrics2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -112,7 +113,7 @@ public class HMMMetrics2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -216,7 +217,7 @@ public class HMMMetrics2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -112,7 +113,7 @@ public class HMMMetrics2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -216,7 +217,7 @@ public class HMMMetrics2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -112,7 +113,7 @@ public class HMMMetrics2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -216,7 +217,7 @@ public class HMMMetrics2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -112,7 +113,7 @@ public class HMMMetrics2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -216,7 +217,7 @@ public class HMMMetrics2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics2/HMMMetrics2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -112,7 +113,7 @@ public class HMMMetrics2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -216,7 +217,7 @@ public class HMMMetrics2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -229,7 +230,7 @@ public class HMMMetrics4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -265,7 +266,7 @@ public class HMMMetrics4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -229,7 +230,7 @@ public class HMMMetrics4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -265,7 +266,7 @@ public class HMMMetrics4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -229,7 +230,7 @@ public class HMMMetrics4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -265,7 +266,7 @@ public class HMMMetrics4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -229,7 +230,7 @@ public class HMMMetrics4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -265,7 +266,7 @@ public class HMMMetrics4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -229,7 +230,7 @@ public class HMMMetrics4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -265,7 +266,7 @@ public class HMMMetrics4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMMetrics4/HMMMetrics4_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -229,7 +230,7 @@ public class HMMMetrics4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -265,7 +266,7 @@ public class HMMMetrics4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTest/HMMTest_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTest/HMMTest_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTest/HMMTest_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTest/HMMTest_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTest/HMMTest_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTest/HMMTest_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTest/HMMTest_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTest/HMMTest_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTest/HMMTest_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTest/HMMTest_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTest/HMMTest_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTest/HMMTest_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestFromStan extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestFromStan extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestFromStan extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestFromStan extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestFromStan extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestFromStan/HMMTestFromStan_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestFromStan extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1/HMMTestPart1_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1/HMMTestPart1_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1/HMMTestPart1_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1/HMMTestPart1_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1/HMMTestPart1_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1/HMMTestPart1_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1/HMMTestPart1_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1/HMMTestPart1_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1/HMMTestPart1_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1/HMMTestPart1_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1/HMMTestPart1_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1/HMMTestPart1_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1b/HMMTestPart1b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1b/HMMTestPart1b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1b/HMMTestPart1b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1b/HMMTestPart1b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1b/HMMTestPart1b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1b/HMMTestPart1b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1b/HMMTestPart1b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1b/HMMTestPart1b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1b/HMMTestPart1b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1b/HMMTestPart1b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1b/HMMTestPart1b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart1b/HMMTestPart1b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart1b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2/HMMTestPart2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2/HMMTestPart2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2/HMMTestPart2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2/HMMTestPart2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2/HMMTestPart2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2/HMMTestPart2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2/HMMTestPart2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2/HMMTestPart2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2/HMMTestPart2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2/HMMTestPart2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2/HMMTestPart2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2/HMMTestPart2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2b/HMMTestPart2b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2b/HMMTestPart2b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2b/HMMTestPart2b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2b/HMMTestPart2b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2b/HMMTestPart2b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2b/HMMTestPart2b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2b/HMMTestPart2b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2b/HMMTestPart2b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2b/HMMTestPart2b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2b/HMMTestPart2b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2b/HMMTestPart2b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart2b/HMMTestPart2b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart2b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3/HMMTestPart3_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3b/HMMTestPart3b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3c/HMMTestPart3c_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3c extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3d/HMMTestPart3d_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3d/HMMTestPart3d_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3d/HMMTestPart3d_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3d/HMMTestPart3d_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3d/HMMTestPart3d_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3d/HMMTestPart3d_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3d/HMMTestPart3d_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3d/HMMTestPart3d_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3d/HMMTestPart3d_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3d/HMMTestPart3d_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3d/HMMTestPart3d_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart3d/HMMTestPart3d_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart3d extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4/HMMTestPart4_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4/HMMTestPart4_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class HMMTestPart4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4/HMMTestPart4_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4/HMMTestPart4_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class HMMTestPart4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4/HMMTestPart4_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4/HMMTestPart4_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class HMMTestPart4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4/HMMTestPart4_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4/HMMTestPart4_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class HMMTestPart4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4/HMMTestPart4_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4/HMMTestPart4_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class HMMTestPart4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4/HMMTestPart4_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4/HMMTestPart4_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class HMMTestPart4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4b/HMMTestPart4b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4b/HMMTestPart4b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class HMMTestPart4b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4b/HMMTestPart4b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4b/HMMTestPart4b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class HMMTestPart4b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4b/HMMTestPart4b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4b/HMMTestPart4b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class HMMTestPart4b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4b/HMMTestPart4b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4b/HMMTestPart4b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class HMMTestPart4b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4b/HMMTestPart4b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4b/HMMTestPart4b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class HMMTestPart4b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4b/HMMTestPart4b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart4b/HMMTestPart4b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -73,7 +74,7 @@ public class HMMTestPart4b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5/HMMTestPart5_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart5b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart5b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart5b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart5b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart5b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart5b/HMMTestPart5b_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart5b extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart6/HMMTestPart6_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart7/HMMTestPart7_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart7/HMMTestPart7_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart7/HMMTestPart7_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart7/HMMTestPart7_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart7/HMMTestPart7_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart7/HMMTestPart7_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart7/HMMTestPart7_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart7/HMMTestPart7_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart7/HMMTestPart7_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart7/HMMTestPart7_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart7/HMMTestPart7_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart7/HMMTestPart7_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart7 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart8/HMMTestPart8_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart8/HMMTestPart8_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart8/HMMTestPart8_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart8/HMMTestPart8_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart8/HMMTestPart8_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart8/HMMTestPart8_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart8/HMMTestPart8_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart8/HMMTestPart8_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart8/HMMTestPart8_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart8/HMMTestPart8_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart8/HMMTestPart8_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMMTestPart8/HMMTestPart8_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMMTestPart8 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2/HMM_Mk2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2/HMM_Mk2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class HMM_Mk2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2/HMM_Mk2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2/HMM_Mk2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class HMM_Mk2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2/HMM_Mk2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2/HMM_Mk2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class HMM_Mk2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2/HMM_Mk2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2/HMM_Mk2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class HMM_Mk2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2/HMM_Mk2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2/HMM_Mk2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class HMM_Mk2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2/HMM_Mk2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2/HMM_Mk2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class HMM_Mk2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2Dist/HMM_Mk2Dist_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2Dist/HMM_Mk2Dist_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class HMM_Mk2Dist extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2Dist/HMM_Mk2Dist_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2Dist/HMM_Mk2Dist_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class HMM_Mk2Dist extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2Dist/HMM_Mk2Dist_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2Dist/HMM_Mk2Dist_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class HMM_Mk2Dist extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2Dist/HMM_Mk2Dist_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2Dist/HMM_Mk2Dist_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class HMM_Mk2Dist extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2Dist/HMM_Mk2Dist_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2Dist/HMM_Mk2Dist_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class HMM_Mk2Dist extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2Dist/HMM_Mk2Dist_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Mk2Dist/HMM_Mk2Dist_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class HMM_Mk2Dist extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Paper/HMM_Paper_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Paper/HMM_Paper_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMM_Paper extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Paper/HMM_Paper_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Paper/HMM_Paper_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMM_Paper extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Paper/HMM_Paper_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Paper/HMM_Paper_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMM_Paper extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Paper/HMM_Paper_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Paper/HMM_Paper_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMM_Paper extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Paper/HMM_Paper_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Paper/HMM_Paper_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMM_Paper extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Paper/HMM_Paper_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/HMM_Paper/HMM_Paper_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class HMM_Paper extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/InjectionAttackTest/InjectionAttackTest_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/InjectionAttackTest/InjectionAttackTest_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class InjectionAttackTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/InjectionAttackTest/InjectionAttackTest_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/InjectionAttackTest/InjectionAttackTest_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class InjectionAttackTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/InjectionAttackTest/InjectionAttackTest_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/InjectionAttackTest/InjectionAttackTest_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class InjectionAttackTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/InjectionAttackTest/InjectionAttackTest_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/InjectionAttackTest/InjectionAttackTest_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class InjectionAttackTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/InjectionAttackTest/InjectionAttackTest_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/InjectionAttackTest/InjectionAttackTest_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class InjectionAttackTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/InjectionAttackTest/InjectionAttackTest_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/InjectionAttackTest/InjectionAttackTest_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class InjectionAttackTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$CoreInterface_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$CoreInterface_model.java
@@ -26,12 +26,6 @@ interface LDATest$CoreInterface extends org.sandwood.runtime.internal.model.Core
 	// Setter for fixedFlag$sample58.
 	public void set$fixedFlag$sample58(boolean cv$value);
 
-	// Getter for fixedFlag$sample90.
-	public boolean get$fixedFlag$sample90();
-
-	// Setter for fixedFlag$sample90.
-	public void set$fixedFlag$sample90(boolean cv$value);
-
 	// Getter for length$documents.
 	public int[] get$length$documents();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$CoreInterface_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$CoreInterface_modelNoComments.java
@@ -9,8 +9,6 @@ interface LDATest$CoreInterface extends org.sandwood.runtime.internal.model.Core
 	public void set$fixedFlag$sample42(boolean cv$value);
 	public boolean get$fixedFlag$sample58();
 	public void set$fixedFlag$sample58(boolean cv$value);
-	public boolean get$fixedFlag$sample90();
-	public void set$fixedFlag$sample90(boolean cv$value);
 	public int[] get$length$documents();
 	public void set$length$documents(int[] cv$value);
 	public double get$logProbability$phi();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$CoreInterface_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$CoreInterface_modelSingle.java
@@ -26,12 +26,6 @@ interface LDATest$CoreInterface extends org.sandwood.runtime.internal.model.Core
 	// Setter for fixedFlag$sample58.
 	public void set$fixedFlag$sample58(boolean cv$value);
 
-	// Getter for fixedFlag$sample90.
-	public boolean get$fixedFlag$sample90();
-
-	// Setter for fixedFlag$sample90.
-	public void set$fixedFlag$sample90(boolean cv$value);
-
 	// Getter for length$documents.
 	public int[] get$length$documents();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$CoreInterface_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$CoreInterface_optimisedModel.java
@@ -26,12 +26,6 @@ interface LDATest$CoreInterface extends org.sandwood.runtime.internal.model.Core
 	// Setter for fixedFlag$sample58.
 	public void set$fixedFlag$sample58(boolean cv$value);
 
-	// Getter for fixedFlag$sample90.
-	public boolean get$fixedFlag$sample90();
-
-	// Setter for fixedFlag$sample90.
-	public void set$fixedFlag$sample90(boolean cv$value);
-
 	// Getter for length$documents.
 	public int[] get$length$documents();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$CoreInterface_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$CoreInterface_optimisedModelNoComments.java
@@ -9,8 +9,6 @@ interface LDATest$CoreInterface extends org.sandwood.runtime.internal.model.Core
 	public void set$fixedFlag$sample42(boolean cv$value);
 	public boolean get$fixedFlag$sample58();
 	public void set$fixedFlag$sample58(boolean cv$value);
-	public boolean get$fixedFlag$sample90();
-	public void set$fixedFlag$sample90(boolean cv$value);
 	public int[] get$length$documents();
 	public void set$length$documents(int[] cv$value);
 	public double get$logProbability$phi();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$CoreInterface_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$CoreInterface_optimisedModelSingle.java
@@ -26,12 +26,6 @@ interface LDATest$CoreInterface extends org.sandwood.runtime.internal.model.Core
 	// Setter for fixedFlag$sample58.
 	public void set$fixedFlag$sample58(boolean cv$value);
 
-	// Getter for fixedFlag$sample90.
-	public boolean get$fixedFlag$sample90();
-
-	// Setter for fixedFlag$sample90.
-	public void set$fixedFlag$sample90(boolean cv$value);
-
 	// Getter for length$documents.
 	public int[] get$length$documents();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$MultiThreadCPU_model.java
@@ -16,11 +16,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	private int[][] documents;
 	private boolean fixedFlag$sample42 = false;
 	private boolean fixedFlag$sample58 = false;
-	private boolean fixedFlag$sample90 = false;
 	private boolean fixedProbFlag$sample42 = false;
 	private boolean fixedProbFlag$sample58 = false;
-	private boolean fixedProbFlag$sample90 = false;
-	private boolean fixedProbFlag$sample93 = false;
 	private int[] length$documents;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -89,10 +86,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		// Should the probability of sample 42 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample42 = (fixedFlag$sample42 && fixedProbFlag$sample42);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedProbFlag$sample93);
 	}
 
 	// Getter for fixedFlag$sample58.
@@ -111,32 +104,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		// Should the probability of sample 58 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample58 = (fixedFlag$sample58 && fixedProbFlag$sample58);
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample90 = (fixedFlag$sample58 && fixedProbFlag$sample90);
-	}
-
-	// Getter for fixedFlag$sample90.
-	@Override
-	public final boolean get$fixedFlag$sample90() {
-		return fixedFlag$sample90;
-	}
-
-	// Setter for fixedFlag$sample90.
-	@Override
-	public final void set$fixedFlag$sample90(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample90 including if probabilities
-		// need to be updated.
-		fixedFlag$sample90 = cv$value;
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedProbFlag$sample90);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample93 = (fixedFlag$sample90 && fixedProbFlag$sample93);
 	}
 
 	// Getter for length$documents.
@@ -216,9 +183,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		
 		// Unset the fixed probability flag for sample 42 as it depends on phi.
 		fixedProbFlag$sample42 = false;
-		
-		// Unset the fixed probability flag for sample 93 as it depends on phi.
-		fixedProbFlag$sample93 = false;
 	}
 
 	// Getter for theta.
@@ -237,9 +201,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		
 		// Unset the fixed probability flag for sample 58 as it depends on theta.
 		fixedProbFlag$sample58 = false;
-		
-		// Unset the fixed probability flag for sample 90 as it depends on theta.
-		fixedProbFlag$sample90 = false;
 	}
 
 	// Getter for vocabSize.
@@ -502,235 +463,154 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	// Calculate the probability of the samples represented by sample90 using sampled
 	// values.
 	private final void logProbabilityValue$sample90() {
-		// Determine if we need to calculate the values for sample task 90 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample90) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// Accumulator for sample probabilities for a specific instance of the random variable.
-					double cv$sampleAccumulator = 0.0;
-					
-					// An accumulator for log probabilities.
-					double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					
-					// An accumulator for the distributed probability space covered.
-					double cv$probabilityReached = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				double cv$sampleAccumulator = 0.0;
+				
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					// The sample value to calculate the probability of generating
+					int cv$sampleValue = z[((i$var71 - 0) / 1)][((j - 0) / 1)];
 					{
-						// The sample value to calculate the probability of generating
-						int cv$sampleValue = z[((i$var71 - 0) / 1)][((j - 0) / 1)];
 						{
-							{
-								double[] var86 = theta[i$var71];
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(var86[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							double[] var86 = theta[i$var71];
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(var86[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
 						}
 					}
-					if((cv$probabilityReached == 0.0))
-						// Return negative infinity if no distribution probability space is reached.
-						cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					else
-						// Scale the probability relative to the observed distribution space.
-						cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-					double cv$sampleProbability = cv$distributionAccumulator;
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-					
-					// Add the probability of this instance of the random variable to the probability
-					// of all instances of the random variable.
-					cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-					logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
-					
-					// Store the sample task probability
-					logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+				logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
+				
+				// Store the sample task probability
+				logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 			}
-			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedFlag$sample58);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$rvAccumulator = 0.0;
-					double cv$sampleValue = logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)];
-					cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$rvAccumulator;
-				}
-			}
-			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$z = (logProbability$z + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample93 using sampled
 	// values.
 	private final void logProbabilityValue$sample93() {
-		// Determine if we need to calculate the values for sample task 93 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample93) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// Accumulator for sample probabilities for a specific instance of the random variable.
-					double cv$sampleAccumulator = 0.0;
-					
-					// An accumulator for log probabilities.
-					double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					
-					// An accumulator for the distributed probability space covered.
-					double cv$probabilityReached = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				double cv$sampleAccumulator = 0.0;
+				
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					// The sample value to calculate the probability of generating
+					int cv$sampleValue = w[i$var71][j];
 					{
-						// The sample value to calculate the probability of generating
-						int cv$sampleValue = w[i$var71][j];
 						{
-							{
-								double[] var89 = phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]];
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(var89[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							double[] var89 = phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]];
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(var89[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
 						}
 					}
-					if((cv$probabilityReached == 0.0))
-						// Return negative infinity if no distribution probability space is reached.
-						cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					else
-						// Scale the probability relative to the observed distribution space.
-						cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-					double cv$sampleProbability = cv$distributionAccumulator;
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-					
-					// Add the probability of this instance of the random variable to the probability
-					// of all instances of the random variable.
-					cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-					logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
-					
-					// Store the sample task probability
-					logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+				logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
+				
+				// Store the sample task probability
+				logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 			}
-			
-			// Update the variable probability
-			logProbability$w = (logProbability$w + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedFlag$sample90);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$rvAccumulator = 0.0;
-					double cv$sampleValue = logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)];
-					cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$rvAccumulator;
-				}
-			}
-			
-			// Update the variable probability
-			logProbability$w = (logProbability$w + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$w = (logProbability$w + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -1115,14 +995,11 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 				w[i$var71] = new int[length$documents[i$var71]];
 		}
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample90) {
-			// Constructor for z
-			{
-				z = new int[((((length$documents.length - 1) - 0) / 1) + 1)][];
-				for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
-					z[((i$var71 - 0) / 1)] = new int[((((length$documents[i$var71] - 1) - 0) / 1) + 1)];
-			}
+		// Constructor for z
+		{
+			z = new int[((((length$documents.length - 1) - 0) / 1) + 1)][];
+			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
+				z[((i$var71 - 0) / 1)] = new int[((((length$documents[i$var71] - 1) - 0) / 1) + 1)];
 		}
 		
 		// Constructor for logProbability$var87
@@ -1206,8 +1083,7 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
 									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 										t[j] = DistributionSampling.sampleCategorical(RNG$2, phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]], vocabSize);
 									}
 							}
@@ -1266,10 +1142,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 								
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
-									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-									}
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 							}
 						);
 					}
@@ -1327,8 +1201,7 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
 									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 										t[j] = DistributionSampling.sampleCategorical(RNG$2, phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]], vocabSize);
 									}
 							}
@@ -1386,10 +1259,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 								
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
-									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-									}
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 							}
 						);
 					}
@@ -1446,10 +1317,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 								
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
-									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-									}
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 							}
 						);
 					}
@@ -1504,10 +1373,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 									
 										// Inner loop for running batches of iterations, each batch has its own random number
 										// generator.
-										for(int j = forStart$j; j < forEnd$j; j += 1) {
-											if(!fixedFlag$sample90)
-												sample90(i$var71, j, threadID$j, RNG$2);
-										}
+										for(int j = forStart$j; j < forEnd$j; j += 1)
+											sample90(i$var71, j, threadID$j, RNG$2);
 								}
 							);
 						}
@@ -1532,10 +1399,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 									
 										// Inner loop for running batches of iterations, each batch has its own random number
 										// generator.
-										for(int j = forStart$j; j < forEnd$j; j += 1) {
-											if(!fixedFlag$sample90)
-												sample90(i$var71, j, threadID$j, RNG$2);
-										}
+										for(int j = forStart$j; j < forEnd$j; j += 1)
+											sample90(i$var71, j, threadID$j, RNG$2);
 								}
 							);
 						}
@@ -1623,22 +1488,18 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 				logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			for(int j = 0; j < length$documents[i$var71]; j += 1)
 				logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 		logProbability$w = 0.0;
-		if(!fixedProbFlag$sample93) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 	}
 
@@ -1653,8 +1514,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			logProbabilityValue$sample42();
 		if(fixedFlag$sample58)
 			logProbabilityValue$sample58();
-		if(fixedFlag$sample90)
-			logProbabilityValue$sample90();
 		logProbabilityValue$sample93();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$MultiThreadCPU_modelNoComments.java
@@ -14,11 +14,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	private int[][] documents;
 	private boolean fixedFlag$sample42 = false;
 	private boolean fixedFlag$sample58 = false;
-	private boolean fixedFlag$sample90 = false;
 	private boolean fixedProbFlag$sample42 = false;
 	private boolean fixedProbFlag$sample58 = false;
-	private boolean fixedProbFlag$sample90 = false;
-	private boolean fixedProbFlag$sample93 = false;
 	private int[] length$documents;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -75,7 +72,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	public final void set$fixedFlag$sample42(boolean cv$value) {
 		fixedFlag$sample42 = cv$value;
 		fixedProbFlag$sample42 = (fixedFlag$sample42 && fixedProbFlag$sample42);
-		fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedProbFlag$sample93);
 	}
 
 	@Override
@@ -87,19 +83,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	public final void set$fixedFlag$sample58(boolean cv$value) {
 		fixedFlag$sample58 = cv$value;
 		fixedProbFlag$sample58 = (fixedFlag$sample58 && fixedProbFlag$sample58);
-		fixedProbFlag$sample90 = (fixedFlag$sample58 && fixedProbFlag$sample90);
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample90() {
-		return fixedFlag$sample90;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample90(boolean cv$value) {
-		fixedFlag$sample90 = cv$value;
-		fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedProbFlag$sample90);
-		fixedProbFlag$sample93 = (fixedFlag$sample90 && fixedProbFlag$sample93);
 	}
 
 	@Override
@@ -161,7 +144,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	public final void set$phi(double[][] cv$value) {
 		phi = cv$value;
 		fixedProbFlag$sample42 = false;
-		fixedProbFlag$sample93 = false;
 	}
 
 	@Override
@@ -173,7 +155,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	public final void set$theta(double[][] cv$value) {
 		theta = cv$value;
 		fixedProbFlag$sample58 = false;
-		fixedProbFlag$sample90 = false;
 	}
 
 	@Override
@@ -318,129 +299,88 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	}
 
 	private final void logProbabilityValue$sample90() {
-		if(!fixedProbFlag$sample90) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$sampleAccumulator = 0.0;
-					double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				double cv$sampleAccumulator = 0.0;
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				double cv$probabilityReached = 0.0;
+				{
+					int cv$sampleValue = z[((i$var71 - 0) / 1)][((j - 0) / 1)];
 					{
-						int cv$sampleValue = z[((i$var71 - 0) / 1)][((j - 0) / 1)];
 						{
-							{
-								double[] var86 = theta[i$var71];
-								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(var86[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							double[] var86 = theta[i$var71];
+							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(var86[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
 						}
 					}
-					if((cv$probabilityReached == 0.0))
-						cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					else
-						cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-					double cv$sampleProbability = cv$distributionAccumulator;
-					cv$sampleReached = true;
-					cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-					cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-					logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
-					logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 				}
+				if((cv$probabilityReached == 0.0))
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				cv$sampleReached = true;
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+				logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
+				logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedFlag$sample58);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$rvAccumulator = 0.0;
-					double cv$sampleValue = logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)];
-					cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-					cv$sampleReached = true;
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$rvAccumulator;
-				}
-			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		logProbability$z = (logProbability$z + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample93() {
-		if(!fixedProbFlag$sample93) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$sampleAccumulator = 0.0;
-					double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				double cv$sampleAccumulator = 0.0;
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				double cv$probabilityReached = 0.0;
+				{
+					int cv$sampleValue = w[i$var71][j];
 					{
-						int cv$sampleValue = w[i$var71][j];
 						{
-							{
-								double[] var89 = phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]];
-								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(var89[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							double[] var89 = phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]];
+							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(var89[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
 						}
 					}
-					if((cv$probabilityReached == 0.0))
-						cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					else
-						cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-					double cv$sampleProbability = cv$distributionAccumulator;
-					cv$sampleReached = true;
-					cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-					cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-					logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
-					logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 				}
+				if((cv$probabilityReached == 0.0))
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				cv$sampleReached = true;
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+				logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
+				logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 			}
-			logProbability$w = (logProbability$w + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedFlag$sample90);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$rvAccumulator = 0.0;
-					double cv$sampleValue = logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)];
-					cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-					cv$sampleReached = true;
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$rvAccumulator;
-				}
-			}
-			logProbability$w = (logProbability$w + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		logProbability$w = (logProbability$w + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void sample42(int var41, int threadID$cv$var41, Rng RNG$) {
@@ -668,12 +608,10 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
 				w[i$var71] = new int[length$documents[i$var71]];
 		}
-		if(!fixedFlag$sample90) {
-			{
-				z = new int[((((length$documents.length - 1) - 0) / 1) + 1)][];
-				for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
-					z[((i$var71 - 0) / 1)] = new int[((((length$documents[i$var71] - 1) - 0) / 1) + 1)];
-			}
+		{
+			z = new int[((((length$documents.length - 1) - 0) / 1) + 1)][];
+			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
+				z[((i$var71 - 0) / 1)] = new int[((((length$documents[i$var71] - 1) - 0) / 1) + 1)];
 		}
 		{
 			logProbability$var87 = new double[((((length$documents.length - 1) - 0) / 1) + 1)][];
@@ -727,8 +665,7 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
 							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
 								for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 										t[j] = DistributionSampling.sampleCategorical(RNG$2, phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]], vocabSize);
 									}
 							}
@@ -765,10 +702,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 						int threadID$i$var71 = threadID$index$i$var71;
 						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
 							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-								for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-									}
+								for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 							}
 						);
 					}
@@ -805,8 +740,7 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
 							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
 								for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 										t[j] = DistributionSampling.sampleCategorical(RNG$2, phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]], vocabSize);
 									}
 							}
@@ -843,10 +777,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 						int threadID$i$var71 = threadID$index$i$var71;
 						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
 							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-								for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-									}
+								for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 							}
 						);
 					}
@@ -881,10 +813,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 						int threadID$i$var71 = threadID$index$i$var71;
 						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
 							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-								for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-									}
+								for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 							}
 						);
 					}
@@ -918,10 +848,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 							int threadID$i$var71 = threadID$index$i$var71;
 							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
 								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-									for(int j = forStart$j; j < forEnd$j; j += 1) {
-											if(!fixedFlag$sample90)
-												sample90(i$var71, j, threadID$j, RNG$2);
-										}
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+											sample90(i$var71, j, threadID$j, RNG$2);
 								}
 							);
 						}
@@ -935,10 +863,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 							int threadID$i$var71 = threadID$index$i$var71;
 							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
 								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-									for(int j = forStart$j; j < forEnd$j; j += 1) {
-											if(!fixedFlag$sample90)
-												sample90(i$var71, j, threadID$j, RNG$2);
-										}
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+											sample90(i$var71, j, threadID$j, RNG$2);
 								}
 							);
 						}
@@ -996,22 +922,18 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 				logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			for(int j = 0; j < length$documents[i$var71]; j += 1)
 				logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 		logProbability$w = 0.0;
-		if(!fixedProbFlag$sample93) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 	}
 
@@ -1022,8 +944,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			logProbabilityValue$sample42();
 		if(fixedFlag$sample58)
 			logProbabilityValue$sample58();
-		if(fixedFlag$sample90)
-			logProbabilityValue$sample90();
 		logProbabilityValue$sample93();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$MultiThreadCPU_modelSingle.java
@@ -16,11 +16,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	private int[][] documents;
 	private boolean fixedFlag$sample42 = false;
 	private boolean fixedFlag$sample58 = false;
-	private boolean fixedFlag$sample90 = false;
 	private boolean fixedProbFlag$sample42 = false;
 	private boolean fixedProbFlag$sample58 = false;
-	private boolean fixedProbFlag$sample90 = false;
-	private boolean fixedProbFlag$sample93 = false;
 	private int[] length$documents;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -88,10 +85,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		// Should the probability of sample 42 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample42 = (fixedFlag$sample42 && fixedProbFlag$sample42);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedProbFlag$sample93);
 	}
 
 	// Getter for fixedFlag$sample58.
@@ -110,32 +103,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		// Should the probability of sample 58 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample58 = (fixedFlag$sample58 && fixedProbFlag$sample58);
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample90 = (fixedFlag$sample58 && fixedProbFlag$sample90);
-	}
-
-	// Getter for fixedFlag$sample90.
-	@Override
-	public final boolean get$fixedFlag$sample90() {
-		return fixedFlag$sample90;
-	}
-
-	// Setter for fixedFlag$sample90.
-	@Override
-	public final void set$fixedFlag$sample90(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample90 including if probabilities
-		// need to be updated.
-		fixedFlag$sample90 = cv$value;
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedProbFlag$sample90);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample93 = (fixedFlag$sample90 && fixedProbFlag$sample93);
 	}
 
 	// Getter for length$documents.
@@ -215,9 +182,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		
 		// Unset the fixed probability flag for sample 42 as it depends on phi.
 		fixedProbFlag$sample42 = false;
-		
-		// Unset the fixed probability flag for sample 93 as it depends on phi.
-		fixedProbFlag$sample93 = false;
 	}
 
 	// Getter for theta.
@@ -236,9 +200,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		
 		// Unset the fixed probability flag for sample 58 as it depends on theta.
 		fixedProbFlag$sample58 = false;
-		
-		// Unset the fixed probability flag for sample 90 as it depends on theta.
-		fixedProbFlag$sample90 = false;
 	}
 
 	// Getter for vocabSize.
@@ -511,235 +472,159 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	// Calculate the probability of the samples represented by sample90 using sampled
 	// values.
 	private final void logProbabilityValue$sample90() {
-		// Determine if we need to calculate the values for sample task 90 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample90) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// An accumulator for log probabilities.
-					double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					
-					// An accumulator for the distributed probability space covered.
-					double cv$probabilityReached = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					// The sample value to calculate the probability of generating
+					int cv$sampleValue = z[((i$var71 - 0) / 1)][((j - 0) / 1)];
 					{
-						// The sample value to calculate the probability of generating
-						int cv$sampleValue = z[((i$var71 - 0) / 1)][((j - 0) / 1)];
 						{
-							{
-								double[] var86 = theta[i$var71];
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(var86[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							double[] var86 = theta[i$var71];
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(var86[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
 						}
 					}
-					if((cv$probabilityReached == 0.0))
-						// Return negative infinity if no distribution probability space is reached.
-						cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					else
-						// Scale the probability relative to the observed distribution space.
-						cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-					double cv$sampleProbability = cv$distributionAccumulator;
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var87 = cv$sampleAccumulator;
-			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$z = cv$accumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedFlag$sample58);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-			}
-			double cv$sampleValue = logProbability$z;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var87 = cv$rvAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var87 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$z = cv$accumulator;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample93 using sampled
 	// values.
 	private final void logProbabilityValue$sample93() {
-		// Determine if we need to calculate the values for sample task 93 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample93) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// An accumulator for log probabilities.
-					double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					
-					// An accumulator for the distributed probability space covered.
-					double cv$probabilityReached = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					// The sample value to calculate the probability of generating
+					int cv$sampleValue = w[i$var71][j];
 					{
-						// The sample value to calculate the probability of generating
-						int cv$sampleValue = w[i$var71][j];
 						{
-							{
-								double[] var89 = phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]];
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(var89[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							double[] var89 = phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]];
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(var89[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
 						}
 					}
-					if((cv$probabilityReached == 0.0))
-						// Return negative infinity if no distribution probability space is reached.
-						cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					else
-						// Scale the probability relative to the observed distribution space.
-						cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-					double cv$sampleProbability = cv$distributionAccumulator;
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var90 = cv$sampleAccumulator;
-			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$var91 = cv$accumulator;
-			
-			// Update the variable probability
-			logProbability$w = (logProbability$w + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedFlag$sample90);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-			}
-			double cv$sampleValue = logProbability$var91;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var90 = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$w = (logProbability$w + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var90 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$var91 = cv$accumulator;
+		
+		// Update the variable probability
+		logProbability$w = (logProbability$w + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -1124,14 +1009,11 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 				w[i$var71] = new int[length$documents[i$var71]];
 		}
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample90) {
-			// Constructor for z
-			{
-				z = new int[((((length$documents.length - 1) - 0) / 1) + 1)][];
-				for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
-					z[((i$var71 - 0) / 1)] = new int[((((length$documents[i$var71] - 1) - 0) / 1) + 1)];
-			}
+		// Constructor for z
+		{
+			z = new int[((((length$documents.length - 1) - 0) / 1) + 1)][];
+			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
+				z[((i$var71 - 0) / 1)] = new int[((((length$documents[i$var71] - 1) - 0) / 1) + 1)];
 		}
 		
 		// Allocate scratch space
@@ -1187,8 +1069,7 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
 									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 										t[j] = DistributionSampling.sampleCategorical(RNG$2, phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]], vocabSize);
 									}
 							}
@@ -1247,10 +1128,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 								
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
-									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-									}
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 							}
 						);
 					}
@@ -1308,8 +1187,7 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
 									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 										t[j] = DistributionSampling.sampleCategorical(RNG$2, phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]], vocabSize);
 									}
 							}
@@ -1367,10 +1245,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 								
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
-									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-									}
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 							}
 						);
 					}
@@ -1427,10 +1303,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 								
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
-									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-									}
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 							}
 						);
 					}
@@ -1485,10 +1359,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 									
 										// Inner loop for running batches of iterations, each batch has its own random number
 										// generator.
-										for(int j = forStart$j; j < forEnd$j; j += 1) {
-											if(!fixedFlag$sample90)
-												sample90(i$var71, j, threadID$j, RNG$2);
-										}
+										for(int j = forStart$j; j < forEnd$j; j += 1)
+											sample90(i$var71, j, threadID$j, RNG$2);
 								}
 							);
 						}
@@ -1513,10 +1385,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 									
 										// Inner loop for running batches of iterations, each batch has its own random number
 										// generator.
-										for(int j = forStart$j; j < forEnd$j; j += 1) {
-											if(!fixedFlag$sample90)
-												sample90(i$var71, j, threadID$j, RNG$2);
-										}
+										for(int j = forStart$j; j < forEnd$j; j += 1)
+											sample90(i$var71, j, threadID$j, RNG$2);
 								}
 							);
 						}
@@ -1600,12 +1470,10 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		if(!fixedProbFlag$sample58)
 			logProbability$var57 = Double.NaN;
 		logProbability$var87 = Double.NaN;
-		if(!fixedProbFlag$sample90)
-			logProbability$z = Double.NaN;
+		logProbability$z = Double.NaN;
 		logProbability$var90 = Double.NaN;
 		logProbability$w = 0.0;
-		if(!fixedProbFlag$sample93)
-			logProbability$var91 = Double.NaN;
+		logProbability$var91 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -1619,8 +1487,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			logProbabilityValue$sample42();
 		if(fixedFlag$sample58)
 			logProbabilityValue$sample58();
-		if(fixedFlag$sample90)
-			logProbabilityValue$sample90();
 		logProbabilityValue$sample93();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$MultiThreadCPU_optimisedModel.java
@@ -16,11 +16,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	private int[][] documents;
 	private boolean fixedFlag$sample42 = false;
 	private boolean fixedFlag$sample58 = false;
-	private boolean fixedFlag$sample90 = false;
 	private boolean fixedProbFlag$sample42 = false;
 	private boolean fixedProbFlag$sample58 = false;
-	private boolean fixedProbFlag$sample90 = false;
-	private boolean fixedProbFlag$sample93 = false;
 	private int[] length$documents;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -91,12 +88,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		// 
 		// Substituted "fixedFlag$sample42" with its value "cv$value".
 		fixedProbFlag$sample42 = (cv$value && fixedProbFlag$sample42);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample42" with its value "cv$value".
-		fixedProbFlag$sample93 = (cv$value && fixedProbFlag$sample93);
 	}
 
 	// Getter for fixedFlag$sample58.
@@ -117,38 +108,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		// 
 		// Substituted "fixedFlag$sample58" with its value "cv$value".
 		fixedProbFlag$sample58 = (cv$value && fixedProbFlag$sample58);
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample58" with its value "cv$value".
-		fixedProbFlag$sample90 = (cv$value && fixedProbFlag$sample90);
-	}
-
-	// Getter for fixedFlag$sample90.
-	@Override
-	public final boolean get$fixedFlag$sample90() {
-		return fixedFlag$sample90;
-	}
-
-	// Setter for fixedFlag$sample90.
-	@Override
-	public final void set$fixedFlag$sample90(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample90 including if probabilities
-		// need to be updated.
-		fixedFlag$sample90 = cv$value;
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample90" with its value "cv$value".
-		fixedProbFlag$sample90 = (cv$value && fixedProbFlag$sample90);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample90" with its value "cv$value".
-		fixedProbFlag$sample93 = (cv$value && fixedProbFlag$sample93);
 	}
 
 	// Getter for length$documents.
@@ -228,9 +187,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		
 		// Unset the fixed probability flag for sample 42 as it depends on phi.
 		fixedProbFlag$sample42 = false;
-		
-		// Unset the fixed probability flag for sample 93 as it depends on phi.
-		fixedProbFlag$sample93 = false;
 	}
 
 	// Getter for theta.
@@ -249,9 +205,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		
 		// Unset the fixed probability flag for sample 58 as it depends on theta.
 		fixedProbFlag$sample58 = false;
-		
-		// Unset the fixed probability flag for sample 90 as it depends on theta.
-		fixedProbFlag$sample90 = false;
 	}
 
 	// Getter for vocabSize.
@@ -456,183 +409,116 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	// Calculate the probability of the samples represented by sample90 using sampled
 	// values.
 	private final void logProbabilityValue$sample90() {
-		// Determine if we need to calculate the values for sample task 90 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample90) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = z[i$var71][j];
-					
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// An accumulator for log probabilities.
-					// 
-					// Store the value of the function call, so the function call is only made once.
-					// 
-					// Scale the probability relative to the observed distribution space.
-					// 
-					// Add the probability of this distribution configuration to the accumulator.
-					// 
-					// An accumulator for the distributed probability space covered.
-					// 
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// An accumulator for log probabilities.
-					// 
-					// Store the value of the function call, so the function call is only made once.
-					double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(theta[i$var71][cv$sampleValue]):Double.NEGATIVE_INFINITY);
-					
-					// Add the probability of this instance of the random variable to the probability
-					// of all instances of the random variable.
-					// 
-					// Add the probability of this sample task to the sample task accumulator.
-					// 
-					// Accumulator for sample probabilities for a specific instance of the random variable.
-					cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					// 
-					// Accumulator for sample probabilities for a specific instance of the random variable.
-					logProbability$var87[i$var71][j] = cv$distributionAccumulator;
-					
-					// Store the sample task probability
-					logProbability$sample90[i$var71][j] = cv$distributionAccumulator;
-				}
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = z[i$var71][j];
+				
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(theta[i$var71][cv$sampleValue]):Double.NEGATIVE_INFINITY);
+				
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				logProbability$var87[i$var71][j] = cv$distributionAccumulator;
+				
+				// Store the sample task probability
+				logProbability$sample90[i$var71][j] = cv$distributionAccumulator;
 			}
-			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedFlag$sample58);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// Variable declaration of cv$rvAccumulator moved.
-					double cv$rvAccumulator = logProbability$sample90[i$var71][j];
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var87[i$var71][j] = cv$rvAccumulator;
-				}
-			}
-			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$z = (logProbability$z + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample93 using sampled
 	// values.
 	private final void logProbabilityValue$sample93() {
-		// Determine if we need to calculate the values for sample task 93 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample93) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = w[i$var71][j];
-					
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// An accumulator for log probabilities.
-					// 
-					// Store the value of the function call, so the function call is only made once.
-					// 
-					// Scale the probability relative to the observed distribution space.
-					// 
-					// Add the probability of this distribution configuration to the accumulator.
-					// 
-					// An accumulator for the distributed probability space covered.
-					// 
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// An accumulator for log probabilities.
-					// 
-					// Store the value of the function call, so the function call is only made once.
-					double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(phi[z[i$var71][j]][cv$sampleValue]):Double.NEGATIVE_INFINITY);
-					
-					// Add the probability of this instance of the random variable to the probability
-					// of all instances of the random variable.
-					// 
-					// Add the probability of this sample task to the sample task accumulator.
-					// 
-					// Accumulator for sample probabilities for a specific instance of the random variable.
-					cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					// 
-					// Accumulator for sample probabilities for a specific instance of the random variable.
-					logProbability$var90[i$var71][j] = cv$distributionAccumulator;
-					
-					// Store the sample task probability
-					logProbability$sample93[i$var71][j] = cv$distributionAccumulator;
-				}
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = w[i$var71][j];
+				
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(phi[z[i$var71][j]][cv$sampleValue]):Double.NEGATIVE_INFINITY);
+				
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				logProbability$var90[i$var71][j] = cv$distributionAccumulator;
+				
+				// Store the sample task probability
+				logProbability$sample93[i$var71][j] = cv$distributionAccumulator;
 			}
-			
-			// Update the variable probability
-			logProbability$w = (logProbability$w + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedFlag$sample90);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// Variable declaration of cv$rvAccumulator moved.
-					double cv$rvAccumulator = logProbability$sample93[i$var71][j];
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var90[i$var71][j] = cv$rvAccumulator;
-				}
-			}
-			
-			// Update the variable probability
-			logProbability$w = (logProbability$w + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$w = (logProbability$w + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -884,13 +770,10 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
 			w[i$var71] = new int[length$documents[i$var71]];
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample90) {
-			// Constructor for z
-			z = new int[length$documents.length][];
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
-				z[i$var71] = new int[length$documents[i$var71]];
-		}
+		// Constructor for z
+		z = new int[length$documents.length][];
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
+			z[i$var71] = new int[length$documents[i$var71]];
 		
 		// Constructor for logProbability$var87
 		logProbability$var87 = new double[length$documents.length][];
@@ -965,8 +848,7 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
 									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 										t[j] = DistributionSampling.sampleCategorical(RNG$2, phi[z[i$var71][j]], vocabSize);
 									}
 							}
@@ -1009,32 +891,29 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			);
 
 		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample90)
-			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-			parallelFor(RNG$, 0, length$documents.length, 1,
-				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-					
-						// Inner loop for running batches of iterations, each batch has its own random number
-						// generator.
-						for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-							int i$var71 = index$i$var71;
-							int threadID$i$var71 = threadID$index$i$var71;
-							
-							//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-									
-										// Inner loop for running batches of iterations, each batch has its own random number
-										// generator.
-										for(int j = forStart$j; j < forEnd$j; j += 1)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-								}
-							);
-						}
-				}
-			);
-
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, length$documents.length, 1,
+			(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+						int i$var71 = index$i$var71;
+						int threadID$i$var71 = threadID$index$i$var71;
+						
+						//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+								
+									// Inner loop for running batches of iterations, each batch has its own random number
+									// generator.
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+							}
+						);
+					}
+			}
+		);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -1087,8 +966,7 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
 									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 										t[j] = DistributionSampling.sampleCategorical(RNG$2, phi[z[i$var71][j]], vocabSize);
 									}
 							}
@@ -1130,32 +1008,29 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			);
 
 		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample90)
-			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-			parallelFor(RNG$, 0, length$documents.length, 1,
-				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-					
-						// Inner loop for running batches of iterations, each batch has its own random number
-						// generator.
-						for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-							int i$var71 = index$i$var71;
-							int threadID$i$var71 = threadID$index$i$var71;
-							
-							//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-									
-										// Inner loop for running batches of iterations, each batch has its own random number
-										// generator.
-										for(int j = forStart$j; j < forEnd$j; j += 1)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-								}
-							);
-						}
-				}
-			);
-
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, length$documents.length, 1,
+			(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+						int i$var71 = index$i$var71;
+						int threadID$i$var71 = threadID$index$i$var71;
+						
+						//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+								
+									// Inner loop for running batches of iterations, each batch has its own random number
+									// generator.
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+							}
+						);
+					}
+			}
+		);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -1191,32 +1066,29 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			);
 
 		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample90)
-			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-			parallelFor(RNG$, 0, length$documents.length, 1,
-				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-					
-						// Inner loop for running batches of iterations, each batch has its own random number
-						// generator.
-						for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-							int i$var71 = index$i$var71;
-							int threadID$i$var71 = threadID$index$i$var71;
-							
-							//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-									
-										// Inner loop for running batches of iterations, each batch has its own random number
-										// generator.
-										for(int j = forStart$j; j < forEnd$j; j += 1)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-								}
-							);
-						}
-				}
-			);
-
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, length$documents.length, 1,
+			(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+						int i$var71 = index$i$var71;
+						int threadID$i$var71 = threadID$index$i$var71;
+						
+						//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+								
+									// Inner loop for running batches of iterations, each batch has its own random number
+									// generator.
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+							}
+						);
+					}
+			}
+		);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -1252,61 +1124,55 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 				);
 
 			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample90)
-				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-				parallelFor(RNG$, 0, length$documents.length, 1,
-					(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-						
-							// Inner loop for running batches of iterations, each batch has its own random number
-							// generator.
-							for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-								int i$var71 = index$i$var71;
-								int threadID$i$var71 = threadID$index$i$var71;
-								
-								//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-								parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-									(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-										
-											// Inner loop for running batches of iterations, each batch has its own random number
-											// generator.
-											for(int j = forStart$j; j < forEnd$j; j += 1)
-												sample90(i$var71, j, threadID$j, RNG$2);
-									}
-								);
-							}
-					}
-				);
-
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, length$documents.length, 1,
+				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+							int i$var71 = index$i$var71;
+							int threadID$i$var71 = threadID$index$i$var71;
+							
+							//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+									
+										// Inner loop for running batches of iterations, each batch has its own random number
+										// generator.
+										for(int j = forStart$j; j < forEnd$j; j += 1)
+											sample90(i$var71, j, threadID$j, RNG$2);
+								}
+							);
+						}
+				}
+			);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample90)
-				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-				parallelFor(RNG$, 0, length$documents.length, 1,
-					(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-						
-							// Inner loop for running batches of iterations, each batch has its own random number
-							// generator.
-							for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-								int i$var71 = index$i$var71;
-								int threadID$i$var71 = threadID$index$i$var71;
-								
-								//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-								parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-									(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-										
-											// Inner loop for running batches of iterations, each batch has its own random number
-											// generator.
-											for(int j = forStart$j; j < forEnd$j; j += 1)
-												sample90(i$var71, j, threadID$j, RNG$2);
-									}
-								);
-							}
-					}
-				);
-
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, length$documents.length, 1,
+				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+							int i$var71 = index$i$var71;
+							int threadID$i$var71 = threadID$index$i$var71;
+							
+							//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+									
+										// Inner loop for running batches of iterations, each batch has its own random number
+										// generator.
+										for(int j = forStart$j; j < forEnd$j; j += 1)
+											sample90(i$var71, j, threadID$j, RNG$2);
+								}
+							);
+						}
+				}
+			);
 			
 			// Constraints moved from conditionals in inner loops/scopes/etc.
 			if(!fixedFlag$sample58)
@@ -1391,22 +1257,18 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 				logProbability$var87[i$var71][j] = Double.NaN;
 		}
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample90[i$var71][j] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample90[i$var71][j] = Double.NaN;
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			for(int j = 0; j < length$documents[i$var71]; j += 1)
 				logProbability$var90[i$var71][j] = Double.NaN;
 		}
 		logProbability$w = 0.0;
-		if(!fixedProbFlag$sample93) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample93[i$var71][j] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample93[i$var71][j] = Double.NaN;
 		}
 	}
 
@@ -1421,8 +1283,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			logProbabilityValue$sample42();
 		if(fixedFlag$sample58)
 			logProbabilityValue$sample58();
-		if(fixedFlag$sample90)
-			logProbabilityValue$sample90();
 		logProbabilityValue$sample93();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$MultiThreadCPU_optimisedModelNoComments.java
@@ -14,11 +14,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	private int[][] documents;
 	private boolean fixedFlag$sample42 = false;
 	private boolean fixedFlag$sample58 = false;
-	private boolean fixedFlag$sample90 = false;
 	private boolean fixedProbFlag$sample42 = false;
 	private boolean fixedProbFlag$sample58 = false;
-	private boolean fixedProbFlag$sample90 = false;
-	private boolean fixedProbFlag$sample93 = false;
 	private int[] length$documents;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -75,7 +72,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	public final void set$fixedFlag$sample42(boolean cv$value) {
 		fixedFlag$sample42 = cv$value;
 		fixedProbFlag$sample42 = (cv$value && fixedProbFlag$sample42);
-		fixedProbFlag$sample93 = (cv$value && fixedProbFlag$sample93);
 	}
 
 	@Override
@@ -87,19 +83,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	public final void set$fixedFlag$sample58(boolean cv$value) {
 		fixedFlag$sample58 = cv$value;
 		fixedProbFlag$sample58 = (cv$value && fixedProbFlag$sample58);
-		fixedProbFlag$sample90 = (cv$value && fixedProbFlag$sample90);
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample90() {
-		return fixedFlag$sample90;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample90(boolean cv$value) {
-		fixedFlag$sample90 = cv$value;
-		fixedProbFlag$sample90 = (cv$value && fixedProbFlag$sample90);
-		fixedProbFlag$sample93 = (cv$value && fixedProbFlag$sample93);
 	}
 
 	@Override
@@ -161,7 +144,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	public final void set$phi(double[][] cv$value) {
 		phi = cv$value;
 		fixedProbFlag$sample42 = false;
-		fixedProbFlag$sample93 = false;
 	}
 
 	@Override
@@ -173,7 +155,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	public final void set$theta(double[][] cv$value) {
 		theta = cv$value;
 		fixedProbFlag$sample58 = false;
-		fixedProbFlag$sample90 = false;
 	}
 
 	@Override
@@ -244,67 +225,34 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	}
 
 	private final void logProbabilityValue$sample90() {
-		if(!fixedProbFlag$sample90) {
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					int cv$sampleValue = z[i$var71][j];
-					double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(theta[i$var71][cv$sampleValue]):Double.NEGATIVE_INFINITY);
-					cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-					logProbability$var87[i$var71][j] = cv$distributionAccumulator;
-					logProbability$sample90[i$var71][j] = cv$distributionAccumulator;
-				}
+		double cv$accumulator = 0.0;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				int cv$sampleValue = z[i$var71][j];
+				double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(theta[i$var71][cv$sampleValue]):Double.NEGATIVE_INFINITY);
+				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+				logProbability$var87[i$var71][j] = cv$distributionAccumulator;
+				logProbability$sample90[i$var71][j] = cv$distributionAccumulator;
 			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedFlag$sample58);
-		} else {
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$rvAccumulator = logProbability$sample90[i$var71][j];
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var87[i$var71][j] = cv$rvAccumulator;
-				}
-			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		logProbability$z = (logProbability$z + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample93() {
-		if(!fixedProbFlag$sample93) {
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					int cv$sampleValue = w[i$var71][j];
-					double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(phi[z[i$var71][j]][cv$sampleValue]):Double.NEGATIVE_INFINITY);
-					cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-					logProbability$var90[i$var71][j] = cv$distributionAccumulator;
-					logProbability$sample93[i$var71][j] = cv$distributionAccumulator;
-				}
+		double cv$accumulator = 0.0;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				int cv$sampleValue = w[i$var71][j];
+				double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(phi[z[i$var71][j]][cv$sampleValue]):Double.NEGATIVE_INFINITY);
+				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+				logProbability$var90[i$var71][j] = cv$distributionAccumulator;
+				logProbability$sample93[i$var71][j] = cv$distributionAccumulator;
 			}
-			logProbability$w = (logProbability$w + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedFlag$sample90);
-		} else {
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$rvAccumulator = logProbability$sample93[i$var71][j];
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var90[i$var71][j] = cv$rvAccumulator;
-				}
-			}
-			logProbability$w = (logProbability$w + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		logProbability$w = (logProbability$w + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void sample42(int var41, int threadID$cv$var41, Rng RNG$) {
@@ -400,11 +348,9 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		w = new int[length$documents.length][];
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
 			w[i$var71] = new int[length$documents[i$var71]];
-		if(!fixedFlag$sample90) {
-			z = new int[length$documents.length][];
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
-				z[i$var71] = new int[length$documents[i$var71]];
-		}
+		z = new int[length$documents.length][];
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
+			z[i$var71] = new int[length$documents[i$var71]];
 		logProbability$var87 = new double[length$documents.length][];
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
 			logProbability$var87[i$var71] = new double[length$documents[i$var71]];
@@ -447,8 +393,7 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
 							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
 								for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 										t[j] = DistributionSampling.sampleCategorical(RNG$2, phi[z[i$var71][j]], vocabSize);
 									}
 							}
@@ -476,22 +421,20 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 				}
 			);
 
-		if(!fixedFlag$sample90)
-			parallelFor(RNG$, 0, length$documents.length, 1,
-				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-					for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-							int i$var71 = index$i$var71;
-							int threadID$i$var71 = threadID$index$i$var71;
-							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-									for(int j = forStart$j; j < forEnd$j; j += 1)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-								}
-							);
-						}
-				}
-			);
-
+		parallelFor(RNG$, 0, length$documents.length, 1,
+			(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+						int i$var71 = index$i$var71;
+						int threadID$i$var71 = threadID$index$i$var71;
+						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+								for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+							}
+						);
+					}
+			}
+		);
 	}
 
 	@Override
@@ -521,8 +464,7 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
 							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
 								for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 										t[j] = DistributionSampling.sampleCategorical(RNG$2, phi[z[i$var71][j]], vocabSize);
 									}
 							}
@@ -550,22 +492,20 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 				}
 			);
 
-		if(!fixedFlag$sample90)
-			parallelFor(RNG$, 0, length$documents.length, 1,
-				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-					for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-							int i$var71 = index$i$var71;
-							int threadID$i$var71 = threadID$index$i$var71;
-							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-									for(int j = forStart$j; j < forEnd$j; j += 1)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-								}
-							);
-						}
-				}
-			);
-
+		parallelFor(RNG$, 0, length$documents.length, 1,
+			(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+						int i$var71 = index$i$var71;
+						int threadID$i$var71 = threadID$index$i$var71;
+						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+								for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+							}
+						);
+					}
+			}
+		);
 	}
 
 	@Override
@@ -586,22 +526,20 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 				}
 			);
 
-		if(!fixedFlag$sample90)
-			parallelFor(RNG$, 0, length$documents.length, 1,
-				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-					for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-							int i$var71 = index$i$var71;
-							int threadID$i$var71 = threadID$index$i$var71;
-							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-									for(int j = forStart$j; j < forEnd$j; j += 1)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-								}
-							);
-						}
-				}
-			);
-
+		parallelFor(RNG$, 0, length$documents.length, 1,
+			(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+						int i$var71 = index$i$var71;
+						int threadID$i$var71 = threadID$index$i$var71;
+						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+								for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+							}
+						);
+					}
+			}
+		);
 	}
 
 	@Override
@@ -623,39 +561,35 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 					}
 				);
 
-			if(!fixedFlag$sample90)
-				parallelFor(RNG$, 0, length$documents.length, 1,
-					(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-						for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-								int i$var71 = index$i$var71;
-								int threadID$i$var71 = threadID$index$i$var71;
-								parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-									(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-										for(int j = forStart$j; j < forEnd$j; j += 1)
-												sample90(i$var71, j, threadID$j, RNG$2);
-									}
-								);
-							}
-					}
-				);
-
+			parallelFor(RNG$, 0, length$documents.length, 1,
+				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+							int i$var71 = index$i$var71;
+							int threadID$i$var71 = threadID$index$i$var71;
+							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+											sample90(i$var71, j, threadID$j, RNG$2);
+								}
+							);
+						}
+				}
+			);
 		} else {
-			if(!fixedFlag$sample90)
-				parallelFor(RNG$, 0, length$documents.length, 1,
-					(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-						for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-								int i$var71 = index$i$var71;
-								int threadID$i$var71 = threadID$index$i$var71;
-								parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-									(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-										for(int j = forStart$j; j < forEnd$j; j += 1)
-												sample90(i$var71, j, threadID$j, RNG$2);
-									}
-								);
-							}
-					}
-				);
-
+			parallelFor(RNG$, 0, length$documents.length, 1,
+				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+							int i$var71 = index$i$var71;
+							int threadID$i$var71 = threadID$index$i$var71;
+							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+											sample90(i$var71, j, threadID$j, RNG$2);
+								}
+							);
+						}
+				}
+			);
 			if(!fixedFlag$sample58)
 				parallelFor(RNG$, 0, length$documents.length, 1,
 					(int forStart$var56, int forEnd$var56, int threadID$var56, org.sandwood.random.internal.Rng RNG$1) -> { 
@@ -708,22 +642,18 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 				logProbability$var87[i$var71][j] = Double.NaN;
 		}
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample90[i$var71][j] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample90[i$var71][j] = Double.NaN;
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			for(int j = 0; j < length$documents[i$var71]; j += 1)
 				logProbability$var90[i$var71][j] = Double.NaN;
 		}
 		logProbability$w = 0.0;
-		if(!fixedProbFlag$sample93) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample93[i$var71][j] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample93[i$var71][j] = Double.NaN;
 		}
 	}
 
@@ -734,8 +664,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			logProbabilityValue$sample42();
 		if(fixedFlag$sample58)
 			logProbabilityValue$sample58();
-		if(fixedFlag$sample90)
-			logProbabilityValue$sample90();
 		logProbabilityValue$sample93();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$MultiThreadCPU_optimisedModelSingle.java
@@ -16,11 +16,8 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	private int[][] documents;
 	private boolean fixedFlag$sample42 = false;
 	private boolean fixedFlag$sample58 = false;
-	private boolean fixedFlag$sample90 = false;
 	private boolean fixedProbFlag$sample42 = false;
 	private boolean fixedProbFlag$sample58 = false;
-	private boolean fixedProbFlag$sample90 = false;
-	private boolean fixedProbFlag$sample93 = false;
 	private int[] length$documents;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -90,12 +87,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		// 
 		// Substituted "fixedFlag$sample42" with its value "cv$value".
 		fixedProbFlag$sample42 = (cv$value && fixedProbFlag$sample42);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample42" with its value "cv$value".
-		fixedProbFlag$sample93 = (cv$value && fixedProbFlag$sample93);
 	}
 
 	// Getter for fixedFlag$sample58.
@@ -116,38 +107,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		// 
 		// Substituted "fixedFlag$sample58" with its value "cv$value".
 		fixedProbFlag$sample58 = (cv$value && fixedProbFlag$sample58);
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample58" with its value "cv$value".
-		fixedProbFlag$sample90 = (cv$value && fixedProbFlag$sample90);
-	}
-
-	// Getter for fixedFlag$sample90.
-	@Override
-	public final boolean get$fixedFlag$sample90() {
-		return fixedFlag$sample90;
-	}
-
-	// Setter for fixedFlag$sample90.
-	@Override
-	public final void set$fixedFlag$sample90(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample90 including if probabilities
-		// need to be updated.
-		fixedFlag$sample90 = cv$value;
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample90" with its value "cv$value".
-		fixedProbFlag$sample90 = (cv$value && fixedProbFlag$sample90);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample90" with its value "cv$value".
-		fixedProbFlag$sample93 = (cv$value && fixedProbFlag$sample93);
 	}
 
 	// Getter for length$documents.
@@ -227,9 +186,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		
 		// Unset the fixed probability flag for sample 42 as it depends on phi.
 		fixedProbFlag$sample42 = false;
-		
-		// Unset the fixed probability flag for sample 93 as it depends on phi.
-		fixedProbFlag$sample93 = false;
 	}
 
 	// Getter for theta.
@@ -248,9 +204,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		
 		// Unset the fixed probability flag for sample 58 as it depends on theta.
 		fixedProbFlag$sample58 = false;
-		
-		// Unset the fixed probability flag for sample 90 as it depends on theta.
-		fixedProbFlag$sample90 = false;
 	}
 
 	// Getter for vocabSize.
@@ -489,204 +442,127 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 	// Calculate the probability of the samples represented by sample90 using sampled
 	// values.
 	private final void logProbabilityValue$sample90() {
-		// Determine if we need to calculate the values for sample task 90 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample90) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = z[i$var71][j];
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					// 
-					// Scale the probability relative to the observed distribution space.
-					// 
-					// Add the probability of this distribution configuration to the accumulator.
-					// 
-					// An accumulator for the distributed probability space covered.
-					// 
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// An accumulator for log probabilities.
-					// 
-					// Store the value of the function call, so the function call is only made once.
-					cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(theta[i$var71][cv$sampleValue]):Double.NEGATIVE_INFINITY));
-				}
-			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var87 = cv$sampleAccumulator;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = z[i$var71][j];
 				
-				// Store the random variable instance probability
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
 				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
+				// Scale the probability relative to the observed distribution space.
 				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$z = cv$sampleAccumulator;
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(theta[i$var71][cv$sampleValue]):Double.NEGATIVE_INFINITY));
 			}
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var87 = cv$sampleAccumulator;
 			
-			// Add probability to model
+			// Store the random variable instance probability
 			// 
 			// Add the probability of this instance of the random variable to the probability
 			// of all instances of the random variable.
 			// 
 			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedFlag$sample58);
+			logProbability$z = cv$sampleAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				if((0 < length$documents[i$var71]))
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-			}
-			if(cv$sampleReached)
-				logProbability$var87 = logProbability$z;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$z);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$z);
-		}
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample93 using sampled
 	// values.
 	private final void logProbabilityValue$sample93() {
-		// Determine if we need to calculate the values for sample task 93 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample93) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = w[i$var71][j];
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					// 
-					// Scale the probability relative to the observed distribution space.
-					// 
-					// Add the probability of this distribution configuration to the accumulator.
-					// 
-					// An accumulator for the distributed probability space covered.
-					// 
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// An accumulator for log probabilities.
-					// 
-					// Store the value of the function call, so the function call is only made once.
-					cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(phi[z[i$var71][j]][cv$sampleValue]):Double.NEGATIVE_INFINITY));
-				}
-			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var90 = cv$sampleAccumulator;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = w[i$var71][j];
 				
-				// Store the random variable instance probability
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
 				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
+				// Scale the probability relative to the observed distribution space.
 				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$var91 = cv$sampleAccumulator;
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(phi[z[i$var71][j]][cv$sampleValue]):Double.NEGATIVE_INFINITY));
 			}
-			
-			// Update the variable probability
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$w = (logProbability$w + cv$sampleAccumulator);
-			
-			// Add probability to model
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedFlag$sample90);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				if((0 < length$documents[i$var71]))
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-			}
-			if(cv$sampleReached)
-				logProbability$var90 = logProbability$var91;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var90 = cv$sampleAccumulator;
 			
-			// Update the variable probability
+			// Store the random variable instance probability
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$w = (logProbability$w + logProbability$var91);
-			
-			// Add probability to model
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var91);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var91);
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$var91 = cv$sampleAccumulator;
 		}
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$w = (logProbability$w + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -938,13 +814,10 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
 			w[i$var71] = new int[length$documents[i$var71]];
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample90) {
-			// Constructor for z
-			z = new int[length$documents.length][];
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
-				z[i$var71] = new int[length$documents[i$var71]];
-		}
+		// Constructor for z
+		z = new int[length$documents.length][];
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
+			z[i$var71] = new int[length$documents[i$var71]];
 		
 		// Allocate scratch space
 		allocateScratch();
@@ -999,8 +872,7 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
 									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 										t[j] = DistributionSampling.sampleCategorical(RNG$2, phi[z[i$var71][j]], vocabSize);
 									}
 							}
@@ -1043,32 +915,29 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			);
 
 		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample90)
-			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-			parallelFor(RNG$, 0, length$documents.length, 1,
-				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-					
-						// Inner loop for running batches of iterations, each batch has its own random number
-						// generator.
-						for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-							int i$var71 = index$i$var71;
-							int threadID$i$var71 = threadID$index$i$var71;
-							
-							//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-									
-										// Inner loop for running batches of iterations, each batch has its own random number
-										// generator.
-										for(int j = forStart$j; j < forEnd$j; j += 1)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-								}
-							);
-						}
-				}
-			);
-
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, length$documents.length, 1,
+			(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+						int i$var71 = index$i$var71;
+						int threadID$i$var71 = threadID$index$i$var71;
+						
+						//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+								
+									// Inner loop for running batches of iterations, each batch has its own random number
+									// generator.
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+							}
+						);
+					}
+			}
+		);
 	}
 
 	// Method to execute the model code conventionally with priming of fixed intermediate
@@ -1121,8 +990,7 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 									// Inner loop for running batches of iterations, each batch has its own random number
 									// generator.
 									for(int j = forStart$j; j < forEnd$j; j += 1) {
-										if(!fixedFlag$sample90)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
 										t[j] = DistributionSampling.sampleCategorical(RNG$2, phi[z[i$var71][j]], vocabSize);
 									}
 							}
@@ -1164,32 +1032,29 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			);
 
 		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample90)
-			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-			parallelFor(RNG$, 0, length$documents.length, 1,
-				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-					
-						// Inner loop for running batches of iterations, each batch has its own random number
-						// generator.
-						for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-							int i$var71 = index$i$var71;
-							int threadID$i$var71 = threadID$index$i$var71;
-							
-							//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-									
-										// Inner loop for running batches of iterations, each batch has its own random number
-										// generator.
-										for(int j = forStart$j; j < forEnd$j; j += 1)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-								}
-							);
-						}
-				}
-			);
-
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, length$documents.length, 1,
+			(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+						int i$var71 = index$i$var71;
+						int threadID$i$var71 = threadID$index$i$var71;
+						
+						//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+								
+									// Inner loop for running batches of iterations, each batch has its own random number
+									// generator.
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+							}
+						);
+					}
+			}
+		);
 	}
 
 	// Method to execute the model code conventionally, excluding the elements that generate
@@ -1225,32 +1090,29 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			);
 
 		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample90)
-			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-			parallelFor(RNG$, 0, length$documents.length, 1,
-				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-					
-						// Inner loop for running batches of iterations, each batch has its own random number
-						// generator.
-						for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-							int i$var71 = index$i$var71;
-							int threadID$i$var71 = threadID$index$i$var71;
-							
-							//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-									
-										// Inner loop for running batches of iterations, each batch has its own random number
-										// generator.
-										for(int j = forStart$j; j < forEnd$j; j += 1)
-											z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
-								}
-							);
-						}
-				}
-			);
-
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, length$documents.length, 1,
+			(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+						int i$var71 = index$i$var71;
+						int threadID$i$var71 = threadID$index$i$var71;
+						
+						//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+						parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+							(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+								
+									// Inner loop for running batches of iterations, each batch has its own random number
+									// generator.
+									for(int j = forStart$j; j < forEnd$j; j += 1)
+										z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$2, theta[i$var71], noTopics);
+							}
+						);
+					}
+			}
+		);
 	}
 
 	// Method to execute one round of Gibbs sampling.
@@ -1286,61 +1148,55 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 				);
 
 			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample90)
-				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-				parallelFor(RNG$, 0, length$documents.length, 1,
-					(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-						
-							// Inner loop for running batches of iterations, each batch has its own random number
-							// generator.
-							for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-								int i$var71 = index$i$var71;
-								int threadID$i$var71 = threadID$index$i$var71;
-								
-								//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-								parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-									(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-										
-											// Inner loop for running batches of iterations, each batch has its own random number
-											// generator.
-											for(int j = forStart$j; j < forEnd$j; j += 1)
-												sample90(i$var71, j, threadID$j, RNG$2);
-									}
-								);
-							}
-					}
-				);
-
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, length$documents.length, 1,
+				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+							int i$var71 = index$i$var71;
+							int threadID$i$var71 = threadID$index$i$var71;
+							
+							//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+									
+										// Inner loop for running batches of iterations, each batch has its own random number
+										// generator.
+										for(int j = forStart$j; j < forEnd$j; j += 1)
+											sample90(i$var71, j, threadID$j, RNG$2);
+								}
+							);
+						}
+				}
+			);
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample90)
-				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-				parallelFor(RNG$, 0, length$documents.length, 1,
-					(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
-						
-							// Inner loop for running batches of iterations, each batch has its own random number
-							// generator.
-							for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
-								int i$var71 = index$i$var71;
-								int threadID$i$var71 = threadID$index$i$var71;
-								
-								//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-								parallelFor(RNG$1, 0, length$documents[i$var71], 1,
-									(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
-										
-											// Inner loop for running batches of iterations, each batch has its own random number
-											// generator.
-											for(int j = forStart$j; j < forEnd$j; j += 1)
-												sample90(i$var71, j, threadID$j, RNG$2);
-									}
-								);
-							}
-					}
-				);
-
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, length$documents.length, 1,
+				(int forStart$index$i$var71, int forEnd$index$i$var71, int threadID$index$i$var71, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int index$i$var71 = forStart$index$i$var71; index$i$var71 < forEnd$index$i$var71; index$i$var71 += 1) {
+							int i$var71 = index$i$var71;
+							int threadID$i$var71 = threadID$index$i$var71;
+							
+							//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+							parallelFor(RNG$1, 0, length$documents[i$var71], 1,
+								(int forStart$j, int forEnd$j, int threadID$j, org.sandwood.random.internal.Rng RNG$2) -> { 
+									
+										// Inner loop for running batches of iterations, each batch has its own random number
+										// generator.
+										for(int j = forStart$j; j < forEnd$j; j += 1)
+											sample90(i$var71, j, threadID$j, RNG$2);
+								}
+							);
+						}
+				}
+			);
 			
 			// Constraints moved from conditionals in inner loops/scopes/etc.
 			if(!fixedFlag$sample58)
@@ -1421,12 +1277,10 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 		if(!fixedProbFlag$sample58)
 			logProbability$var57 = Double.NaN;
 		logProbability$var87 = Double.NaN;
-		if(!fixedProbFlag$sample90)
-			logProbability$z = Double.NaN;
+		logProbability$z = Double.NaN;
 		logProbability$var90 = Double.NaN;
 		logProbability$w = 0.0;
-		if(!fixedProbFlag$sample93)
-			logProbability$var91 = Double.NaN;
+		logProbability$var91 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -1440,8 +1294,6 @@ class LDATest$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreMod
 			logProbabilityValue$sample42();
 		if(fixedFlag$sample58)
 			logProbabilityValue$sample58();
-		if(fixedFlag$sample90)
-			logProbabilityValue$sample90();
 		logProbabilityValue$sample93();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$SingleThreadCPU_model.java
@@ -15,11 +15,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	private int[][] documents;
 	private boolean fixedFlag$sample42 = false;
 	private boolean fixedFlag$sample58 = false;
-	private boolean fixedFlag$sample90 = false;
 	private boolean fixedProbFlag$sample42 = false;
 	private boolean fixedProbFlag$sample58 = false;
-	private boolean fixedProbFlag$sample90 = false;
-	private boolean fixedProbFlag$sample93 = false;
 	private int[] length$documents;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -88,10 +85,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		// Should the probability of sample 42 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample42 = (fixedFlag$sample42 && fixedProbFlag$sample42);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedProbFlag$sample93);
 	}
 
 	// Getter for fixedFlag$sample58.
@@ -110,32 +103,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		// Should the probability of sample 58 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample58 = (fixedFlag$sample58 && fixedProbFlag$sample58);
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample90 = (fixedFlag$sample58 && fixedProbFlag$sample90);
-	}
-
-	// Getter for fixedFlag$sample90.
-	@Override
-	public final boolean get$fixedFlag$sample90() {
-		return fixedFlag$sample90;
-	}
-
-	// Setter for fixedFlag$sample90.
-	@Override
-	public final void set$fixedFlag$sample90(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample90 including if probabilities
-		// need to be updated.
-		fixedFlag$sample90 = cv$value;
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedProbFlag$sample90);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample93 = (fixedFlag$sample90 && fixedProbFlag$sample93);
 	}
 
 	// Getter for length$documents.
@@ -215,9 +182,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		
 		// Unset the fixed probability flag for sample 42 as it depends on phi.
 		fixedProbFlag$sample42 = false;
-		
-		// Unset the fixed probability flag for sample 93 as it depends on phi.
-		fixedProbFlag$sample93 = false;
 	}
 
 	// Getter for theta.
@@ -236,9 +200,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		
 		// Unset the fixed probability flag for sample 58 as it depends on theta.
 		fixedProbFlag$sample58 = false;
-		
-		// Unset the fixed probability flag for sample 90 as it depends on theta.
-		fixedProbFlag$sample90 = false;
 	}
 
 	// Getter for vocabSize.
@@ -501,235 +462,154 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	// Calculate the probability of the samples represented by sample90 using sampled
 	// values.
 	private final void logProbabilityValue$sample90() {
-		// Determine if we need to calculate the values for sample task 90 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample90) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// Accumulator for sample probabilities for a specific instance of the random variable.
-					double cv$sampleAccumulator = 0.0;
-					
-					// An accumulator for log probabilities.
-					double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					
-					// An accumulator for the distributed probability space covered.
-					double cv$probabilityReached = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				double cv$sampleAccumulator = 0.0;
+				
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					// The sample value to calculate the probability of generating
+					int cv$sampleValue = z[((i$var71 - 0) / 1)][((j - 0) / 1)];
 					{
-						// The sample value to calculate the probability of generating
-						int cv$sampleValue = z[((i$var71 - 0) / 1)][((j - 0) / 1)];
 						{
-							{
-								double[] var86 = theta[i$var71];
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(var86[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							double[] var86 = theta[i$var71];
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(var86[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
 						}
 					}
-					if((cv$probabilityReached == 0.0))
-						// Return negative infinity if no distribution probability space is reached.
-						cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					else
-						// Scale the probability relative to the observed distribution space.
-						cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-					double cv$sampleProbability = cv$distributionAccumulator;
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-					
-					// Add the probability of this instance of the random variable to the probability
-					// of all instances of the random variable.
-					cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-					logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
-					
-					// Store the sample task probability
-					logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+				logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
+				
+				// Store the sample task probability
+				logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 			}
-			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedFlag$sample58);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$rvAccumulator = 0.0;
-					double cv$sampleValue = logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)];
-					cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$rvAccumulator;
-				}
-			}
-			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$z = (logProbability$z + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample93 using sampled
 	// values.
 	private final void logProbabilityValue$sample93() {
-		// Determine if we need to calculate the values for sample task 93 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample93) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// Accumulator for sample probabilities for a specific instance of the random variable.
-					double cv$sampleAccumulator = 0.0;
-					
-					// An accumulator for log probabilities.
-					double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					
-					// An accumulator for the distributed probability space covered.
-					double cv$probabilityReached = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				double cv$sampleAccumulator = 0.0;
+				
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					// The sample value to calculate the probability of generating
+					int cv$sampleValue = w[i$var71][j];
 					{
-						// The sample value to calculate the probability of generating
-						int cv$sampleValue = w[i$var71][j];
 						{
-							{
-								double[] var89 = phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]];
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(var89[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							double[] var89 = phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]];
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(var89[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
 						}
 					}
-					if((cv$probabilityReached == 0.0))
-						// Return negative infinity if no distribution probability space is reached.
-						cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					else
-						// Scale the probability relative to the observed distribution space.
-						cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-					double cv$sampleProbability = cv$distributionAccumulator;
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-					
-					// Add the probability of this instance of the random variable to the probability
-					// of all instances of the random variable.
-					cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-					logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
-					
-					// Store the sample task probability
-					logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+				logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
+				
+				// Store the sample task probability
+				logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 			}
-			
-			// Update the variable probability
-			logProbability$w = (logProbability$w + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedFlag$sample90);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$rvAccumulator = 0.0;
-					double cv$sampleValue = logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)];
-					cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$rvAccumulator;
-				}
-			}
-			
-			// Update the variable probability
-			logProbability$w = (logProbability$w + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$w = (logProbability$w + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -1084,14 +964,11 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				w[i$var71] = new int[length$documents[i$var71]];
 		}
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample90) {
-			// Constructor for z
-			{
-				z = new int[((((length$documents.length - 1) - 0) / 1) + 1)][];
-				for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
-					z[((i$var71 - 0) / 1)] = new int[((((length$documents[i$var71] - 1) - 0) / 1) + 1)];
-			}
+		// Constructor for z
+		{
+			z = new int[((((length$documents.length - 1) - 0) / 1) + 1)][];
+			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
+				z[((i$var71 - 0) / 1)] = new int[((((length$documents[i$var71] - 1) - 0) / 1) + 1)];
 		}
 		
 		// Constructor for logProbability$var87
@@ -1142,8 +1019,7 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			int[] t = w[i$var71];
 			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 				t[j] = DistributionSampling.sampleCategorical(RNG$, phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]], vocabSize);
 			}
 		}
@@ -1165,10 +1041,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, var57);
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -1189,8 +1063,7 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			int[] t = w[i$var71];
 			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 				t[j] = DistributionSampling.sampleCategorical(RNG$, phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]], vocabSize);
 			}
 		}
@@ -1211,10 +1084,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, var57);
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -1234,10 +1105,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, var57);
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -1255,19 +1124,15 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 					sample58(var56);
 			}
 			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					if(!fixedFlag$sample90)
-						sample90(i$var71, j);
-				}
+				for(int j = 0; j < length$documents[i$var71]; j += 1)
+					sample90(i$var71, j);
 			}
 		}
 		// Infer the samples in reverse chronological order.
 		else {
 			for(int i$var71 = (length$documents.length - ((((length$documents.length - 1) - 0) % 1) + 1)); i$var71 >= ((0 - 1) + 1); i$var71 -= 1) {
-				for(int j = (length$documents[i$var71] - ((((length$documents[i$var71] - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1) {
-					if(!fixedFlag$sample90)
-						sample90(i$var71, j);
-				}
+				for(int j = (length$documents[i$var71] - ((((length$documents[i$var71] - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1)
+					sample90(i$var71, j);
 			}
 			for(int var56 = (length$documents.length - ((((length$documents.length - 1) - 0) % 1) + 1)); var56 >= ((0 - 1) + 1); var56 -= 1) {
 				if(!fixedFlag$sample58)
@@ -1316,22 +1181,18 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			for(int j = 0; j < length$documents[i$var71]; j += 1)
 				logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 		logProbability$w = 0.0;
-		if(!fixedProbFlag$sample93) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 	}
 
@@ -1346,8 +1207,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			logProbabilityValue$sample42();
 		if(fixedFlag$sample58)
 			logProbabilityValue$sample58();
-		if(fixedFlag$sample90)
-			logProbabilityValue$sample90();
 		logProbabilityValue$sample93();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$SingleThreadCPU_modelNoComments.java
@@ -13,11 +13,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	private int[][] documents;
 	private boolean fixedFlag$sample42 = false;
 	private boolean fixedFlag$sample58 = false;
-	private boolean fixedFlag$sample90 = false;
 	private boolean fixedProbFlag$sample42 = false;
 	private boolean fixedProbFlag$sample58 = false;
-	private boolean fixedProbFlag$sample90 = false;
-	private boolean fixedProbFlag$sample93 = false;
 	private int[] length$documents;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -74,7 +71,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	public final void set$fixedFlag$sample42(boolean cv$value) {
 		fixedFlag$sample42 = cv$value;
 		fixedProbFlag$sample42 = (fixedFlag$sample42 && fixedProbFlag$sample42);
-		fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedProbFlag$sample93);
 	}
 
 	@Override
@@ -86,19 +82,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	public final void set$fixedFlag$sample58(boolean cv$value) {
 		fixedFlag$sample58 = cv$value;
 		fixedProbFlag$sample58 = (fixedFlag$sample58 && fixedProbFlag$sample58);
-		fixedProbFlag$sample90 = (fixedFlag$sample58 && fixedProbFlag$sample90);
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample90() {
-		return fixedFlag$sample90;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample90(boolean cv$value) {
-		fixedFlag$sample90 = cv$value;
-		fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedProbFlag$sample90);
-		fixedProbFlag$sample93 = (fixedFlag$sample90 && fixedProbFlag$sample93);
 	}
 
 	@Override
@@ -160,7 +143,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	public final void set$phi(double[][] cv$value) {
 		phi = cv$value;
 		fixedProbFlag$sample42 = false;
-		fixedProbFlag$sample93 = false;
 	}
 
 	@Override
@@ -172,7 +154,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	public final void set$theta(double[][] cv$value) {
 		theta = cv$value;
 		fixedProbFlag$sample58 = false;
-		fixedProbFlag$sample90 = false;
 	}
 
 	@Override
@@ -317,129 +298,88 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	}
 
 	private final void logProbabilityValue$sample90() {
-		if(!fixedProbFlag$sample90) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$sampleAccumulator = 0.0;
-					double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				double cv$sampleAccumulator = 0.0;
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				double cv$probabilityReached = 0.0;
+				{
+					int cv$sampleValue = z[((i$var71 - 0) / 1)][((j - 0) / 1)];
 					{
-						int cv$sampleValue = z[((i$var71 - 0) / 1)][((j - 0) / 1)];
 						{
-							{
-								double[] var86 = theta[i$var71];
-								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(var86[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							double[] var86 = theta[i$var71];
+							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(var86[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
 						}
 					}
-					if((cv$probabilityReached == 0.0))
-						cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					else
-						cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-					double cv$sampleProbability = cv$distributionAccumulator;
-					cv$sampleReached = true;
-					cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-					cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-					logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
-					logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 				}
+				if((cv$probabilityReached == 0.0))
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				cv$sampleReached = true;
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+				logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
+				logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedFlag$sample58);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$rvAccumulator = 0.0;
-					double cv$sampleValue = logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)];
-					cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-					cv$sampleReached = true;
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$rvAccumulator;
-				}
-			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		logProbability$z = (logProbability$z + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample93() {
-		if(!fixedProbFlag$sample93) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$sampleAccumulator = 0.0;
-					double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				double cv$sampleAccumulator = 0.0;
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				double cv$probabilityReached = 0.0;
+				{
+					int cv$sampleValue = w[i$var71][j];
 					{
-						int cv$sampleValue = w[i$var71][j];
 						{
-							{
-								double[] var89 = phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]];
-								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(var89[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							double[] var89 = phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]];
+							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(var89[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
 						}
 					}
-					if((cv$probabilityReached == 0.0))
-						cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					else
-						cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-					double cv$sampleProbability = cv$distributionAccumulator;
-					cv$sampleReached = true;
-					cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-					cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-					logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
-					logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 				}
+				if((cv$probabilityReached == 0.0))
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				cv$sampleReached = true;
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+				logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleAccumulator;
+				logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$sampleProbability;
 			}
-			logProbability$w = (logProbability$w + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedFlag$sample90);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$rvAccumulator = 0.0;
-					double cv$sampleValue = logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)];
-					cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-					cv$sampleReached = true;
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = cv$rvAccumulator;
-				}
-			}
-			logProbability$w = (logProbability$w + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		logProbability$w = (logProbability$w + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void sample42(int var41) {
@@ -652,12 +592,10 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
 				w[i$var71] = new int[length$documents[i$var71]];
 		}
-		if(!fixedFlag$sample90) {
-			{
-				z = new int[((((length$documents.length - 1) - 0) / 1) + 1)][];
-				for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
-					z[((i$var71 - 0) / 1)] = new int[((((length$documents[i$var71] - 1) - 0) / 1) + 1)];
-			}
+		{
+			z = new int[((((length$documents.length - 1) - 0) / 1) + 1)][];
+			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
+				z[((i$var71 - 0) / 1)] = new int[((((length$documents[i$var71] - 1) - 0) / 1) + 1)];
 		}
 		{
 			logProbability$var87 = new double[((((length$documents.length - 1) - 0) / 1) + 1)][];
@@ -697,8 +635,7 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			int[] t = w[i$var71];
 			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 				t[j] = DistributionSampling.sampleCategorical(RNG$, phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]], vocabSize);
 			}
 		}
@@ -717,10 +654,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, var57);
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -739,8 +674,7 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			int[] t = w[i$var71];
 			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 				t[j] = DistributionSampling.sampleCategorical(RNG$, phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]], vocabSize);
 			}
 		}
@@ -759,10 +693,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, var57);
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -779,10 +711,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, var57);
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -798,17 +728,13 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 					sample58(var56);
 			}
 			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					if(!fixedFlag$sample90)
-						sample90(i$var71, j);
-				}
+				for(int j = 0; j < length$documents[i$var71]; j += 1)
+					sample90(i$var71, j);
 			}
 		} else {
 			for(int i$var71 = (length$documents.length - ((((length$documents.length - 1) - 0) % 1) + 1)); i$var71 >= ((0 - 1) + 1); i$var71 -= 1) {
-				for(int j = (length$documents[i$var71] - ((((length$documents[i$var71] - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1) {
-					if(!fixedFlag$sample90)
-						sample90(i$var71, j);
-				}
+				for(int j = (length$documents[i$var71] - ((((length$documents[i$var71] - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1)
+					sample90(i$var71, j);
 			}
 			for(int var56 = (length$documents.length - ((((length$documents.length - 1) - 0) % 1) + 1)); var56 >= ((0 - 1) + 1); var56 -= 1) {
 				if(!fixedFlag$sample58)
@@ -846,22 +772,18 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				logProbability$var87[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample90[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			for(int j = 0; j < length$documents[i$var71]; j += 1)
 				logProbability$var90[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 		logProbability$w = 0.0;
-		if(!fixedProbFlag$sample93) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample93[((i$var71 - 0) / 1)][((j - 0) / 1)] = Double.NaN;
 		}
 	}
 
@@ -872,8 +794,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			logProbabilityValue$sample42();
 		if(fixedFlag$sample58)
 			logProbabilityValue$sample58();
-		if(fixedFlag$sample90)
-			logProbabilityValue$sample90();
 		logProbabilityValue$sample93();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$SingleThreadCPU_modelSingle.java
@@ -15,11 +15,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	private int[][] documents;
 	private boolean fixedFlag$sample42 = false;
 	private boolean fixedFlag$sample58 = false;
-	private boolean fixedFlag$sample90 = false;
 	private boolean fixedProbFlag$sample42 = false;
 	private boolean fixedProbFlag$sample58 = false;
-	private boolean fixedProbFlag$sample90 = false;
-	private boolean fixedProbFlag$sample93 = false;
 	private int[] length$documents;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -87,10 +84,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		// Should the probability of sample 42 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample42 = (fixedFlag$sample42 && fixedProbFlag$sample42);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedProbFlag$sample93);
 	}
 
 	// Getter for fixedFlag$sample58.
@@ -109,32 +102,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		// Should the probability of sample 58 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample58 = (fixedFlag$sample58 && fixedProbFlag$sample58);
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample90 = (fixedFlag$sample58 && fixedProbFlag$sample90);
-	}
-
-	// Getter for fixedFlag$sample90.
-	@Override
-	public final boolean get$fixedFlag$sample90() {
-		return fixedFlag$sample90;
-	}
-
-	// Setter for fixedFlag$sample90.
-	@Override
-	public final void set$fixedFlag$sample90(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample90 including if probabilities
-		// need to be updated.
-		fixedFlag$sample90 = cv$value;
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedProbFlag$sample90);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample93 = (fixedFlag$sample90 && fixedProbFlag$sample93);
 	}
 
 	// Getter for length$documents.
@@ -214,9 +181,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		
 		// Unset the fixed probability flag for sample 42 as it depends on phi.
 		fixedProbFlag$sample42 = false;
-		
-		// Unset the fixed probability flag for sample 93 as it depends on phi.
-		fixedProbFlag$sample93 = false;
 	}
 
 	// Getter for theta.
@@ -235,9 +199,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		
 		// Unset the fixed probability flag for sample 58 as it depends on theta.
 		fixedProbFlag$sample58 = false;
-		
-		// Unset the fixed probability flag for sample 90 as it depends on theta.
-		fixedProbFlag$sample90 = false;
 	}
 
 	// Getter for vocabSize.
@@ -510,235 +471,159 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	// Calculate the probability of the samples represented by sample90 using sampled
 	// values.
 	private final void logProbabilityValue$sample90() {
-		// Determine if we need to calculate the values for sample task 90 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample90) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// An accumulator for log probabilities.
-					double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					
-					// An accumulator for the distributed probability space covered.
-					double cv$probabilityReached = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					// The sample value to calculate the probability of generating
+					int cv$sampleValue = z[((i$var71 - 0) / 1)][((j - 0) / 1)];
 					{
-						// The sample value to calculate the probability of generating
-						int cv$sampleValue = z[((i$var71 - 0) / 1)][((j - 0) / 1)];
 						{
-							{
-								double[] var86 = theta[i$var71];
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(var86[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							double[] var86 = theta[i$var71];
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(var86[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
 						}
 					}
-					if((cv$probabilityReached == 0.0))
-						// Return negative infinity if no distribution probability space is reached.
-						cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					else
-						// Scale the probability relative to the observed distribution space.
-						cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-					double cv$sampleProbability = cv$distributionAccumulator;
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var87 = cv$sampleAccumulator;
-			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$z = cv$accumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedFlag$sample58);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-			}
-			double cv$sampleValue = logProbability$z;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var87 = cv$rvAccumulator;
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var87 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$z = cv$accumulator;
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample93 using sampled
 	// values.
 	private final void logProbabilityValue$sample93() {
-		// Determine if we need to calculate the values for sample task 93 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample93) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// An accumulator for log probabilities.
-					double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					
-					// An accumulator for the distributed probability space covered.
-					double cv$probabilityReached = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					// The sample value to calculate the probability of generating
+					int cv$sampleValue = w[i$var71][j];
 					{
-						// The sample value to calculate the probability of generating
-						int cv$sampleValue = w[i$var71][j];
 						{
-							{
-								double[] var89 = phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]];
-								
-								// Store the value of the function call, so the function call is only made once.
-								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(var89[cv$sampleValue]):Double.NEGATIVE_INFINITY));
-								
-								// Add the probability of this sample task to the distribution accumulator.
-								if((cv$weightedProbability < cv$distributionAccumulator))
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-								else {
-									// If the second value is -infinity.
-									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-										cv$distributionAccumulator = cv$weightedProbability;
-									else
-										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-								}
-								
-								// Add the probability of this distribution configuration to the accumulator.
-								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							double[] var89 = phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]];
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(var89[cv$sampleValue]):Double.NEGATIVE_INFINITY));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
 						}
 					}
-					if((cv$probabilityReached == 0.0))
-						// Return negative infinity if no distribution probability space is reached.
-						cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-					else
-						// Scale the probability relative to the observed distribution space.
-						cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-					double cv$sampleProbability = cv$distributionAccumulator;
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			}
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-			if(cv$sampleReached)
-				logProbability$var90 = cv$sampleAccumulator;
-			
-			// Only update the sample if it was reached, otherwise the NaN will be
-			// erroneously over written.
-			if(cv$sampleReached)
-				// Store the random variable instance probability
-				logProbability$var91 = cv$accumulator;
-			
-			// Update the variable probability
-			logProbability$w = (logProbability$w + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedFlag$sample90);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-			}
-			double cv$sampleValue = logProbability$var91;
-			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var90 = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$w = (logProbability$w + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var90 = cv$sampleAccumulator;
+		
+		// Only update the sample if it was reached, otherwise the NaN will be
+		// erroneously over written.
+		if(cv$sampleReached)
+			// Store the random variable instance probability
+			logProbability$var91 = cv$accumulator;
+		
+		// Update the variable probability
+		logProbability$w = (logProbability$w + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -1093,14 +978,11 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				w[i$var71] = new int[length$documents[i$var71]];
 		}
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample90) {
-			// Constructor for z
-			{
-				z = new int[((((length$documents.length - 1) - 0) / 1) + 1)][];
-				for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
-					z[((i$var71 - 0) / 1)] = new int[((((length$documents[i$var71] - 1) - 0) / 1) + 1)];
-			}
+		// Constructor for z
+		{
+			z = new int[((((length$documents.length - 1) - 0) / 1) + 1)][];
+			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
+				z[((i$var71 - 0) / 1)] = new int[((((length$documents[i$var71] - 1) - 0) / 1) + 1)];
 		}
 		
 		// Allocate scratch space
@@ -1123,8 +1005,7 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			int[] t = w[i$var71];
 			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 				t[j] = DistributionSampling.sampleCategorical(RNG$, phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]], vocabSize);
 			}
 		}
@@ -1146,10 +1027,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, var57);
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -1170,8 +1049,7 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			int[] t = w[i$var71];
 			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 				t[j] = DistributionSampling.sampleCategorical(RNG$, phi[z[((i$var71 - 0) / 1)][((j - 0) / 1)]], vocabSize);
 			}
 		}
@@ -1192,10 +1070,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, var57);
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -1215,10 +1091,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, var57);
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[((i$var71 - 0) / 1)][((j - 0) / 1)] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -1236,19 +1110,15 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 					sample58(var56);
 			}
 			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					if(!fixedFlag$sample90)
-						sample90(i$var71, j);
-				}
+				for(int j = 0; j < length$documents[i$var71]; j += 1)
+					sample90(i$var71, j);
 			}
 		}
 		// Infer the samples in reverse chronological order.
 		else {
 			for(int i$var71 = (length$documents.length - ((((length$documents.length - 1) - 0) % 1) + 1)); i$var71 >= ((0 - 1) + 1); i$var71 -= 1) {
-				for(int j = (length$documents[i$var71] - ((((length$documents[i$var71] - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1) {
-					if(!fixedFlag$sample90)
-						sample90(i$var71, j);
-				}
+				for(int j = (length$documents[i$var71] - ((((length$documents[i$var71] - 1) - 0) % 1) + 1)); j >= ((0 - 1) + 1); j -= 1)
+					sample90(i$var71, j);
 			}
 			for(int var56 = (length$documents.length - ((((length$documents.length - 1) - 0) % 1) + 1)); var56 >= ((0 - 1) + 1); var56 -= 1) {
 				if(!fixedFlag$sample58)
@@ -1293,12 +1163,10 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		if(!fixedProbFlag$sample58)
 			logProbability$var57 = Double.NaN;
 		logProbability$var87 = Double.NaN;
-		if(!fixedProbFlag$sample90)
-			logProbability$z = Double.NaN;
+		logProbability$z = Double.NaN;
 		logProbability$var90 = Double.NaN;
 		logProbability$w = 0.0;
-		if(!fixedProbFlag$sample93)
-			logProbability$var91 = Double.NaN;
+		logProbability$var91 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -1312,8 +1180,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			logProbabilityValue$sample42();
 		if(fixedFlag$sample58)
 			logProbabilityValue$sample58();
-		if(fixedFlag$sample90)
-			logProbabilityValue$sample90();
 		logProbabilityValue$sample93();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$SingleThreadCPU_optimisedModel.java
@@ -15,11 +15,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	private int[][] documents;
 	private boolean fixedFlag$sample42 = false;
 	private boolean fixedFlag$sample58 = false;
-	private boolean fixedFlag$sample90 = false;
 	private boolean fixedProbFlag$sample42 = false;
 	private boolean fixedProbFlag$sample58 = false;
-	private boolean fixedProbFlag$sample90 = false;
-	private boolean fixedProbFlag$sample93 = false;
 	private int[] length$documents;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -90,12 +87,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		// 
 		// Substituted "fixedFlag$sample42" with its value "cv$value".
 		fixedProbFlag$sample42 = (cv$value && fixedProbFlag$sample42);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample42" with its value "cv$value".
-		fixedProbFlag$sample93 = (cv$value && fixedProbFlag$sample93);
 	}
 
 	// Getter for fixedFlag$sample58.
@@ -116,38 +107,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		// 
 		// Substituted "fixedFlag$sample58" with its value "cv$value".
 		fixedProbFlag$sample58 = (cv$value && fixedProbFlag$sample58);
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample58" with its value "cv$value".
-		fixedProbFlag$sample90 = (cv$value && fixedProbFlag$sample90);
-	}
-
-	// Getter for fixedFlag$sample90.
-	@Override
-	public final boolean get$fixedFlag$sample90() {
-		return fixedFlag$sample90;
-	}
-
-	// Setter for fixedFlag$sample90.
-	@Override
-	public final void set$fixedFlag$sample90(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample90 including if probabilities
-		// need to be updated.
-		fixedFlag$sample90 = cv$value;
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample90" with its value "cv$value".
-		fixedProbFlag$sample90 = (cv$value && fixedProbFlag$sample90);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample90" with its value "cv$value".
-		fixedProbFlag$sample93 = (cv$value && fixedProbFlag$sample93);
 	}
 
 	// Getter for length$documents.
@@ -227,9 +186,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		
 		// Unset the fixed probability flag for sample 42 as it depends on phi.
 		fixedProbFlag$sample42 = false;
-		
-		// Unset the fixed probability flag for sample 93 as it depends on phi.
-		fixedProbFlag$sample93 = false;
 	}
 
 	// Getter for theta.
@@ -248,9 +204,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		
 		// Unset the fixed probability flag for sample 58 as it depends on theta.
 		fixedProbFlag$sample58 = false;
-		
-		// Unset the fixed probability flag for sample 90 as it depends on theta.
-		fixedProbFlag$sample90 = false;
 	}
 
 	// Getter for vocabSize.
@@ -455,183 +408,116 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	// Calculate the probability of the samples represented by sample90 using sampled
 	// values.
 	private final void logProbabilityValue$sample90() {
-		// Determine if we need to calculate the values for sample task 90 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample90) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = z[i$var71][j];
-					
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// An accumulator for log probabilities.
-					// 
-					// Store the value of the function call, so the function call is only made once.
-					// 
-					// Scale the probability relative to the observed distribution space.
-					// 
-					// Add the probability of this distribution configuration to the accumulator.
-					// 
-					// An accumulator for the distributed probability space covered.
-					// 
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// An accumulator for log probabilities.
-					// 
-					// Store the value of the function call, so the function call is only made once.
-					double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(theta[i$var71][cv$sampleValue]):Double.NEGATIVE_INFINITY);
-					
-					// Add the probability of this instance of the random variable to the probability
-					// of all instances of the random variable.
-					// 
-					// Add the probability of this sample task to the sample task accumulator.
-					// 
-					// Accumulator for sample probabilities for a specific instance of the random variable.
-					cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					// 
-					// Accumulator for sample probabilities for a specific instance of the random variable.
-					logProbability$var87[i$var71][j] = cv$distributionAccumulator;
-					
-					// Store the sample task probability
-					logProbability$sample90[i$var71][j] = cv$distributionAccumulator;
-				}
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = z[i$var71][j];
+				
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(theta[i$var71][cv$sampleValue]):Double.NEGATIVE_INFINITY);
+				
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				logProbability$var87[i$var71][j] = cv$distributionAccumulator;
+				
+				// Store the sample task probability
+				logProbability$sample90[i$var71][j] = cv$distributionAccumulator;
 			}
-			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedFlag$sample58);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// Variable declaration of cv$rvAccumulator moved.
-					double cv$rvAccumulator = logProbability$sample90[i$var71][j];
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var87[i$var71][j] = cv$rvAccumulator;
-				}
-			}
-			
-			// Update the variable probability
-			logProbability$z = (logProbability$z + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$z = (logProbability$z + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample93 using sampled
 	// values.
 	private final void logProbabilityValue$sample93() {
-		// Determine if we need to calculate the values for sample task 93 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample93) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = w[i$var71][j];
-					
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// An accumulator for log probabilities.
-					// 
-					// Store the value of the function call, so the function call is only made once.
-					// 
-					// Scale the probability relative to the observed distribution space.
-					// 
-					// Add the probability of this distribution configuration to the accumulator.
-					// 
-					// An accumulator for the distributed probability space covered.
-					// 
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// An accumulator for log probabilities.
-					// 
-					// Store the value of the function call, so the function call is only made once.
-					double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(phi[z[i$var71][j]][cv$sampleValue]):Double.NEGATIVE_INFINITY);
-					
-					// Add the probability of this instance of the random variable to the probability
-					// of all instances of the random variable.
-					// 
-					// Add the probability of this sample task to the sample task accumulator.
-					// 
-					// Accumulator for sample probabilities for a specific instance of the random variable.
-					cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					// 
-					// Accumulator for sample probabilities for a specific instance of the random variable.
-					logProbability$var90[i$var71][j] = cv$distributionAccumulator;
-					
-					// Store the sample task probability
-					logProbability$sample93[i$var71][j] = cv$distributionAccumulator;
-				}
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = w[i$var71][j];
+				
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(phi[z[i$var71][j]][cv$sampleValue]):Double.NEGATIVE_INFINITY);
+				
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				logProbability$var90[i$var71][j] = cv$distributionAccumulator;
+				
+				// Store the sample task probability
+				logProbability$sample93[i$var71][j] = cv$distributionAccumulator;
 			}
-			
-			// Update the variable probability
-			logProbability$w = (logProbability$w + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedFlag$sample90);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// Variable declaration of cv$rvAccumulator moved.
-					double cv$rvAccumulator = logProbability$sample93[i$var71][j];
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var90[i$var71][j] = cv$rvAccumulator;
-				}
-			}
-			
-			// Update the variable probability
-			logProbability$w = (logProbability$w + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$w = (logProbability$w + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -862,13 +748,10 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
 			w[i$var71] = new int[length$documents[i$var71]];
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample90) {
-			// Constructor for z
-			z = new int[length$documents.length][];
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
-				z[i$var71] = new int[length$documents[i$var71]];
-		}
+		// Constructor for z
+		z = new int[length$documents.length][];
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
+			z[i$var71] = new int[length$documents[i$var71]];
 		
 		// Constructor for logProbability$var87
 		logProbability$var87 = new double[length$documents.length][];
@@ -911,8 +794,7 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			int[] t = w[i$var71];
 			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 				t[j] = DistributionSampling.sampleCategorical(RNG$, phi[z[i$var71][j]], vocabSize);
 			}
 		}
@@ -934,13 +816,9 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			for(int var56 = 0; var56 < length$documents.length; var56 += 1)
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, theta[var56]);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -962,8 +840,7 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			int[] t = w[i$var71];
 			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 				t[j] = DistributionSampling.sampleCategorical(RNG$, phi[z[i$var71][j]], vocabSize);
 			}
 		}
@@ -984,13 +861,9 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			for(int var56 = 0; var56 < length$documents.length; var56 += 1)
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, theta[var56]);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -1010,13 +883,9 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			for(int var56 = 0; var56 < length$documents.length; var56 += 1)
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, theta[var56]);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -1036,23 +905,16 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				for(int var56 = 0; var56 < length$documents.length; var56 += 1)
 					sample58(var56);
 			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample90) {
-				for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-					for(int j = 0; j < length$documents[i$var71]; j += 1)
-						sample90(i$var71, j);
-				}
+			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+				for(int j = 0; j < length$documents[i$var71]; j += 1)
+					sample90(i$var71, j);
 			}
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample90) {
-				for(int i$var71 = (length$documents.length - 1); i$var71 >= 0; i$var71 -= 1) {
-					for(int j = (length$documents[i$var71] - 1); j >= 0; j -= 1)
-						sample90(i$var71, j);
-				}
+			for(int i$var71 = (length$documents.length - 1); i$var71 >= 0; i$var71 -= 1) {
+				for(int j = (length$documents[i$var71] - 1); j >= 0; j -= 1)
+					sample90(i$var71, j);
 			}
 			
 			// Constraints moved from conditionals in inner loops/scopes/etc.
@@ -1105,22 +967,18 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				logProbability$var87[i$var71][j] = Double.NaN;
 		}
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample90[i$var71][j] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample90[i$var71][j] = Double.NaN;
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			for(int j = 0; j < length$documents[i$var71]; j += 1)
 				logProbability$var90[i$var71][j] = Double.NaN;
 		}
 		logProbability$w = 0.0;
-		if(!fixedProbFlag$sample93) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample93[i$var71][j] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample93[i$var71][j] = Double.NaN;
 		}
 	}
 
@@ -1135,8 +993,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			logProbabilityValue$sample42();
 		if(fixedFlag$sample58)
 			logProbabilityValue$sample58();
-		if(fixedFlag$sample90)
-			logProbabilityValue$sample90();
 		logProbabilityValue$sample93();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$SingleThreadCPU_optimisedModelNoComments.java
@@ -13,11 +13,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	private int[][] documents;
 	private boolean fixedFlag$sample42 = false;
 	private boolean fixedFlag$sample58 = false;
-	private boolean fixedFlag$sample90 = false;
 	private boolean fixedProbFlag$sample42 = false;
 	private boolean fixedProbFlag$sample58 = false;
-	private boolean fixedProbFlag$sample90 = false;
-	private boolean fixedProbFlag$sample93 = false;
 	private int[] length$documents;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -74,7 +71,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	public final void set$fixedFlag$sample42(boolean cv$value) {
 		fixedFlag$sample42 = cv$value;
 		fixedProbFlag$sample42 = (cv$value && fixedProbFlag$sample42);
-		fixedProbFlag$sample93 = (cv$value && fixedProbFlag$sample93);
 	}
 
 	@Override
@@ -86,19 +82,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	public final void set$fixedFlag$sample58(boolean cv$value) {
 		fixedFlag$sample58 = cv$value;
 		fixedProbFlag$sample58 = (cv$value && fixedProbFlag$sample58);
-		fixedProbFlag$sample90 = (cv$value && fixedProbFlag$sample90);
-	}
-
-	@Override
-	public final boolean get$fixedFlag$sample90() {
-		return fixedFlag$sample90;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample90(boolean cv$value) {
-		fixedFlag$sample90 = cv$value;
-		fixedProbFlag$sample90 = (cv$value && fixedProbFlag$sample90);
-		fixedProbFlag$sample93 = (cv$value && fixedProbFlag$sample93);
 	}
 
 	@Override
@@ -160,7 +143,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	public final void set$phi(double[][] cv$value) {
 		phi = cv$value;
 		fixedProbFlag$sample42 = false;
-		fixedProbFlag$sample93 = false;
 	}
 
 	@Override
@@ -172,7 +154,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	public final void set$theta(double[][] cv$value) {
 		theta = cv$value;
 		fixedProbFlag$sample58 = false;
-		fixedProbFlag$sample90 = false;
 	}
 
 	@Override
@@ -243,67 +224,34 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	}
 
 	private final void logProbabilityValue$sample90() {
-		if(!fixedProbFlag$sample90) {
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					int cv$sampleValue = z[i$var71][j];
-					double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(theta[i$var71][cv$sampleValue]):Double.NEGATIVE_INFINITY);
-					cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-					logProbability$var87[i$var71][j] = cv$distributionAccumulator;
-					logProbability$sample90[i$var71][j] = cv$distributionAccumulator;
-				}
+		double cv$accumulator = 0.0;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				int cv$sampleValue = z[i$var71][j];
+				double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(theta[i$var71][cv$sampleValue]):Double.NEGATIVE_INFINITY);
+				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+				logProbability$var87[i$var71][j] = cv$distributionAccumulator;
+				logProbability$sample90[i$var71][j] = cv$distributionAccumulator;
 			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedFlag$sample58);
-		} else {
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$rvAccumulator = logProbability$sample90[i$var71][j];
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var87[i$var71][j] = cv$rvAccumulator;
-				}
-			}
-			logProbability$z = (logProbability$z + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			if(fixedFlag$sample90)
-				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		logProbability$z = (logProbability$z + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample93() {
-		if(!fixedProbFlag$sample93) {
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					int cv$sampleValue = w[i$var71][j];
-					double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(phi[z[i$var71][j]][cv$sampleValue]):Double.NEGATIVE_INFINITY);
-					cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
-					logProbability$var90[i$var71][j] = cv$distributionAccumulator;
-					logProbability$sample93[i$var71][j] = cv$distributionAccumulator;
-				}
+		double cv$accumulator = 0.0;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				int cv$sampleValue = w[i$var71][j];
+				double cv$distributionAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(phi[z[i$var71][j]][cv$sampleValue]):Double.NEGATIVE_INFINITY);
+				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+				logProbability$var90[i$var71][j] = cv$distributionAccumulator;
+				logProbability$sample93[i$var71][j] = cv$distributionAccumulator;
 			}
-			logProbability$w = (logProbability$w + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedFlag$sample90);
-		} else {
-			double cv$accumulator = 0.0;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					double cv$rvAccumulator = logProbability$sample93[i$var71][j];
-					cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-					logProbability$var90[i$var71][j] = cv$rvAccumulator;
-				}
-			}
-			logProbability$w = (logProbability$w + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		logProbability$w = (logProbability$w + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void sample42(int var41) {
@@ -383,11 +331,9 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		w = new int[length$documents.length][];
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
 			w[i$var71] = new int[length$documents[i$var71]];
-		if(!fixedFlag$sample90) {
-			z = new int[length$documents.length][];
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
-				z[i$var71] = new int[length$documents[i$var71]];
-		}
+		z = new int[length$documents.length][];
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
+			z[i$var71] = new int[length$documents[i$var71]];
 		logProbability$var87 = new double[length$documents.length][];
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
 			logProbability$var87[i$var71] = new double[length$documents[i$var71]];
@@ -416,8 +362,7 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			int[] t = w[i$var71];
 			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 				t[j] = DistributionSampling.sampleCategorical(RNG$, phi[z[i$var71][j]], vocabSize);
 			}
 		}
@@ -433,11 +378,9 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			for(int var56 = 0; var56 < length$documents.length; var56 += 1)
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, theta[var56]);
 		}
-		if(!fixedFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -454,8 +397,7 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			int[] t = w[i$var71];
 			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 				t[j] = DistributionSampling.sampleCategorical(RNG$, phi[z[i$var71][j]], vocabSize);
 			}
 		}
@@ -471,11 +413,9 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			for(int var56 = 0; var56 < length$documents.length; var56 += 1)
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, theta[var56]);
 		}
-		if(!fixedFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -489,11 +429,9 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			for(int var56 = 0; var56 < length$documents.length; var56 += 1)
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, theta[var56]);
 		}
-		if(!fixedFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -508,18 +446,14 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				for(int var56 = 0; var56 < length$documents.length; var56 += 1)
 					sample58(var56);
 			}
-			if(!fixedFlag$sample90) {
-				for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-					for(int j = 0; j < length$documents[i$var71]; j += 1)
-						sample90(i$var71, j);
-				}
+			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+				for(int j = 0; j < length$documents[i$var71]; j += 1)
+					sample90(i$var71, j);
 			}
 		} else {
-			if(!fixedFlag$sample90) {
-				for(int i$var71 = (length$documents.length - 1); i$var71 >= 0; i$var71 -= 1) {
-					for(int j = (length$documents[i$var71] - 1); j >= 0; j -= 1)
-						sample90(i$var71, j);
-				}
+			for(int i$var71 = (length$documents.length - 1); i$var71 >= 0; i$var71 -= 1) {
+				for(int j = (length$documents[i$var71] - 1); j >= 0; j -= 1)
+					sample90(i$var71, j);
 			}
 			if(!fixedFlag$sample58) {
 				for(int var56 = (length$documents.length - 1); var56 >= 0; var56 -= 1)
@@ -557,22 +491,18 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				logProbability$var87[i$var71][j] = Double.NaN;
 		}
 		logProbability$z = 0.0;
-		if(!fixedProbFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample90[i$var71][j] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample90[i$var71][j] = Double.NaN;
 		}
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			for(int j = 0; j < length$documents[i$var71]; j += 1)
 				logProbability$var90[i$var71][j] = Double.NaN;
 		}
 		logProbability$w = 0.0;
-		if(!fixedProbFlag$sample93) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					logProbability$sample93[i$var71][j] = Double.NaN;
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				logProbability$sample93[i$var71][j] = Double.NaN;
 		}
 	}
 
@@ -583,8 +513,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			logProbabilityValue$sample42();
 		if(fixedFlag$sample58)
 			logProbabilityValue$sample58();
-		if(fixedFlag$sample90)
-			logProbabilityValue$sample90();
 		logProbabilityValue$sample93();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest$SingleThreadCPU_optimisedModelSingle.java
@@ -15,11 +15,8 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	private int[][] documents;
 	private boolean fixedFlag$sample42 = false;
 	private boolean fixedFlag$sample58 = false;
-	private boolean fixedFlag$sample90 = false;
 	private boolean fixedProbFlag$sample42 = false;
 	private boolean fixedProbFlag$sample58 = false;
-	private boolean fixedProbFlag$sample90 = false;
-	private boolean fixedProbFlag$sample93 = false;
 	private int[] length$documents;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
@@ -89,12 +86,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		// 
 		// Substituted "fixedFlag$sample42" with its value "cv$value".
 		fixedProbFlag$sample42 = (cv$value && fixedProbFlag$sample42);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample42" with its value "cv$value".
-		fixedProbFlag$sample93 = (cv$value && fixedProbFlag$sample93);
 	}
 
 	// Getter for fixedFlag$sample58.
@@ -115,38 +106,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		// 
 		// Substituted "fixedFlag$sample58" with its value "cv$value".
 		fixedProbFlag$sample58 = (cv$value && fixedProbFlag$sample58);
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample58" with its value "cv$value".
-		fixedProbFlag$sample90 = (cv$value && fixedProbFlag$sample90);
-	}
-
-	// Getter for fixedFlag$sample90.
-	@Override
-	public final boolean get$fixedFlag$sample90() {
-		return fixedFlag$sample90;
-	}
-
-	// Setter for fixedFlag$sample90.
-	@Override
-	public final void set$fixedFlag$sample90(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample90 including if probabilities
-		// need to be updated.
-		fixedFlag$sample90 = cv$value;
-		
-		// Should the probability of sample 90 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample90" with its value "cv$value".
-		fixedProbFlag$sample90 = (cv$value && fixedProbFlag$sample90);
-		
-		// Should the probability of sample 93 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample90" with its value "cv$value".
-		fixedProbFlag$sample93 = (cv$value && fixedProbFlag$sample93);
 	}
 
 	// Getter for length$documents.
@@ -226,9 +185,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		
 		// Unset the fixed probability flag for sample 42 as it depends on phi.
 		fixedProbFlag$sample42 = false;
-		
-		// Unset the fixed probability flag for sample 93 as it depends on phi.
-		fixedProbFlag$sample93 = false;
 	}
 
 	// Getter for theta.
@@ -247,9 +203,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		
 		// Unset the fixed probability flag for sample 58 as it depends on theta.
 		fixedProbFlag$sample58 = false;
-		
-		// Unset the fixed probability flag for sample 90 as it depends on theta.
-		fixedProbFlag$sample90 = false;
 	}
 
 	// Getter for vocabSize.
@@ -488,204 +441,127 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 	// Calculate the probability of the samples represented by sample90 using sampled
 	// values.
 	private final void logProbabilityValue$sample90() {
-		// Determine if we need to calculate the values for sample task 90 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample90) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = z[i$var71][j];
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					// 
-					// Scale the probability relative to the observed distribution space.
-					// 
-					// Add the probability of this distribution configuration to the accumulator.
-					// 
-					// An accumulator for the distributed probability space covered.
-					// 
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// An accumulator for log probabilities.
-					// 
-					// Store the value of the function call, so the function call is only made once.
-					cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(theta[i$var71][cv$sampleValue]):Double.NEGATIVE_INFINITY));
-				}
-			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var87 = cv$sampleAccumulator;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = z[i$var71][j];
 				
-				// Store the random variable instance probability
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
 				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
+				// Scale the probability relative to the observed distribution space.
 				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$z = cv$sampleAccumulator;
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < noTopics))?Math.log(theta[i$var71][cv$sampleValue]):Double.NEGATIVE_INFINITY));
 			}
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var87 = cv$sampleAccumulator;
 			
-			// Add probability to model
+			// Store the random variable instance probability
 			// 
 			// Add the probability of this instance of the random variable to the probability
 			// of all instances of the random variable.
 			// 
 			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample90 = (fixedFlag$sample90 && fixedFlag$sample58);
+			logProbability$z = cv$sampleAccumulator;
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				if((0 < length$documents[i$var71]))
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-			}
-			if(cv$sampleReached)
-				logProbability$var87 = logProbability$z;
-			
-			// Add probability to model
-			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$z);
-			
-			// If this value is fixed, add it to the probability of this model producing the fixed
-			// values
-			if(fixedFlag$sample90)
-				// Variable declaration of cv$accumulator moved.
-				logProbability$$evidence = (logProbability$$evidence + logProbability$z);
-		}
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample93 using sampled
 	// values.
 	private final void logProbabilityValue$sample93() {
-		// Determine if we need to calculate the values for sample task 93 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample93) {
-			// Generating probabilities for sample task
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1) {
-					// The sample value to calculate the probability of generating
-					int cv$sampleValue = w[i$var71][j];
-					
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-					
-					// Add the probability of this sample task to the sample task accumulator.
-					// 
-					// Scale the probability relative to the observed distribution space.
-					// 
-					// Add the probability of this distribution configuration to the accumulator.
-					// 
-					// An accumulator for the distributed probability space covered.
-					// 
-					// Variable declaration of cv$distributionAccumulator moved.
-					// Declaration comment was:
-					// An accumulator for log probabilities.
-					// 
-					// Store the value of the function call, so the function call is only made once.
-					cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(phi[z[i$var71][j]][cv$sampleValue]):Double.NEGATIVE_INFINITY));
-				}
-			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(cv$sampleReached) {
-				logProbability$var90 = cv$sampleAccumulator;
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1) {
+				// The sample value to calculate the probability of generating
+				int cv$sampleValue = w[i$var71][j];
 				
-				// Store the random variable instance probability
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
 				// 
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
+				// Scale the probability relative to the observed distribution space.
 				// 
-				// Accumulator for probabilities of instances of the random variable
-				logProbability$var91 = cv$sampleAccumulator;
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue < vocabSize))?Math.log(phi[z[i$var71][j]][cv$sampleValue]):Double.NEGATIVE_INFINITY));
 			}
-			
-			// Update the variable probability
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$w = (logProbability$w + cv$sampleAccumulator);
-			
-			// Add probability to model
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample93 = (fixedFlag$sample42 && fixedFlag$sample90);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				if((0 < length$documents[i$var71]))
-					// Record that the sample was reached.
-					cv$sampleReached = true;
-			}
-			if(cv$sampleReached)
-				logProbability$var90 = logProbability$var91;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(cv$sampleReached) {
+			logProbability$var90 = cv$sampleAccumulator;
 			
-			// Update the variable probability
+			// Store the random variable instance probability
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$w = (logProbability$w + logProbability$var91);
-			
-			// Add probability to model
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
 			// 
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$model = (logProbability$$model + logProbability$var91);
-			
-			// Variable declaration of cv$accumulator moved.
-			logProbability$$evidence = (logProbability$$evidence + logProbability$var91);
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$var91 = cv$sampleAccumulator;
 		}
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$w = (logProbability$w + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Method to perform the inference steps to calculate new values for the samples generated
@@ -916,13 +792,10 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
 			w[i$var71] = new int[length$documents[i$var71]];
 		
-		// If z has not been set already allocate space.
-		if(!fixedFlag$sample90) {
-			// Constructor for z
-			z = new int[length$documents.length][];
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
-				z[i$var71] = new int[length$documents[i$var71]];
-		}
+		// Constructor for z
+		z = new int[length$documents.length][];
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1)
+			z[i$var71] = new int[length$documents[i$var71]];
 		
 		// Allocate scratch space
 		allocateScratch();
@@ -945,8 +818,7 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			int[] t = w[i$var71];
 			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 				t[j] = DistributionSampling.sampleCategorical(RNG$, phi[z[i$var71][j]], vocabSize);
 			}
 		}
@@ -968,13 +840,9 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			for(int var56 = 0; var56 < length$documents.length; var56 += 1)
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, theta[var56]);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -996,8 +864,7 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
 			int[] t = w[i$var71];
 			for(int j = 0; j < length$documents[i$var71]; j += 1) {
-				if(!fixedFlag$sample90)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 				t[j] = DistributionSampling.sampleCategorical(RNG$, phi[z[i$var71][j]], vocabSize);
 			}
 		}
@@ -1018,13 +885,9 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			for(int var56 = 0; var56 < length$documents.length; var56 += 1)
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, theta[var56]);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -1044,13 +907,9 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			for(int var56 = 0; var56 < length$documents.length; var56 += 1)
 				DistributionSampling.sampleDirichlet(RNG$, alpha, noTopics, theta[var56]);
 		}
-		
-		// Constraints moved from conditionals in inner loops/scopes/etc.
-		if(!fixedFlag$sample90) {
-			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-				for(int j = 0; j < length$documents[i$var71]; j += 1)
-					z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
-			}
+		for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+			for(int j = 0; j < length$documents[i$var71]; j += 1)
+				z[i$var71][j] = DistributionSampling.sampleCategorical(RNG$, theta[i$var71], noTopics);
 		}
 	}
 
@@ -1070,23 +929,16 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 				for(int var56 = 0; var56 < length$documents.length; var56 += 1)
 					sample58(var56);
 			}
-			
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample90) {
-				for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
-					for(int j = 0; j < length$documents[i$var71]; j += 1)
-						sample90(i$var71, j);
-				}
+			for(int i$var71 = 0; i$var71 < length$documents.length; i$var71 += 1) {
+				for(int j = 0; j < length$documents[i$var71]; j += 1)
+					sample90(i$var71, j);
 			}
 		}
 		// Infer the samples in reverse chronological order.
 		else {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!fixedFlag$sample90) {
-				for(int i$var71 = (length$documents.length - 1); i$var71 >= 0; i$var71 -= 1) {
-					for(int j = (length$documents[i$var71] - 1); j >= 0; j -= 1)
-						sample90(i$var71, j);
-				}
+			for(int i$var71 = (length$documents.length - 1); i$var71 >= 0; i$var71 -= 1) {
+				for(int j = (length$documents[i$var71] - 1); j >= 0; j -= 1)
+					sample90(i$var71, j);
 			}
 			
 			// Constraints moved from conditionals in inner loops/scopes/etc.
@@ -1135,12 +987,10 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 		if(!fixedProbFlag$sample58)
 			logProbability$var57 = Double.NaN;
 		logProbability$var87 = Double.NaN;
-		if(!fixedProbFlag$sample90)
-			logProbability$z = Double.NaN;
+		logProbability$z = Double.NaN;
 		logProbability$var90 = Double.NaN;
 		logProbability$w = 0.0;
-		if(!fixedProbFlag$sample93)
-			logProbability$var91 = Double.NaN;
+		logProbability$var91 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.
@@ -1154,8 +1004,6 @@ class LDATest$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreMo
 			logProbabilityValue$sample42();
 		if(fixedFlag$sample58)
 			logProbabilityValue$sample58();
-		if(fixedFlag$sample90)
-			logProbabilityValue$sample90();
 		logProbabilityValue$sample93();
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -117,7 +118,7 @@ public class LDATest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -151,17 +152,12 @@ public class LDATest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample90(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample90())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -344,7 +340,6 @@ public class LDATest extends Model {
         //Set fixed flags
         newCore.set$fixedFlag$sample42(oldCore.get$fixedFlag$sample42());
         newCore.set$fixedFlag$sample58(oldCore.get$fixedFlag$sample58());
-        newCore.set$fixedFlag$sample90(oldCore.get$fixedFlag$sample90());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -117,7 +118,7 @@ public class LDATest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -151,17 +152,12 @@ public class LDATest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample90(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample90())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -344,7 +340,6 @@ public class LDATest extends Model {
         //Set fixed flags
         newCore.set$fixedFlag$sample42(oldCore.get$fixedFlag$sample42());
         newCore.set$fixedFlag$sample58(oldCore.get$fixedFlag$sample58());
-        newCore.set$fixedFlag$sample90(oldCore.get$fixedFlag$sample90());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -117,7 +118,7 @@ public class LDATest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -151,17 +152,12 @@ public class LDATest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample90(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample90())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -344,7 +340,6 @@ public class LDATest extends Model {
         //Set fixed flags
         newCore.set$fixedFlag$sample42(oldCore.get$fixedFlag$sample42());
         newCore.set$fixedFlag$sample58(oldCore.get$fixedFlag$sample58());
-        newCore.set$fixedFlag$sample90(oldCore.get$fixedFlag$sample90());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -117,7 +118,7 @@ public class LDATest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -151,17 +152,12 @@ public class LDATest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample90(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample90())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -344,7 +340,6 @@ public class LDATest extends Model {
         //Set fixed flags
         newCore.set$fixedFlag$sample42(oldCore.get$fixedFlag$sample42());
         newCore.set$fixedFlag$sample58(oldCore.get$fixedFlag$sample58());
-        newCore.set$fixedFlag$sample90(oldCore.get$fixedFlag$sample90());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -117,7 +118,7 @@ public class LDATest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -151,17 +152,12 @@ public class LDATest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample90(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample90())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -344,7 +340,6 @@ public class LDATest extends Model {
         //Set fixed flags
         newCore.set$fixedFlag$sample42(oldCore.get$fixedFlag$sample42());
         newCore.set$fixedFlag$sample58(oldCore.get$fixedFlag$sample58());
-        newCore.set$fixedFlag$sample90(oldCore.get$fixedFlag$sample90());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LDATest/LDATest_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -117,7 +118,7 @@ public class LDATest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -151,17 +152,12 @@ public class LDATest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample90(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample90())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 
@@ -344,7 +340,6 @@ public class LDATest extends Model {
         //Set fixed flags
         newCore.set$fixedFlag$sample42(oldCore.get$fixedFlag$sample42());
         newCore.set$fixedFlag$sample58(oldCore.get$fixedFlag$sample58());
-        newCore.set$fixedFlag$sample90(oldCore.get$fixedFlag$sample90());
     }
 
     /**

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression2Fail/LinearRegression2Fail_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression2Fail/LinearRegression2Fail_model.java
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -134,7 +135,7 @@ public class LinearRegression2Fail extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression2Fail/LinearRegression2Fail_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression2Fail/LinearRegression2Fail_modelNoComments.java
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -134,7 +135,7 @@ public class LinearRegression2Fail extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression2Fail/LinearRegression2Fail_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression2Fail/LinearRegression2Fail_modelSingle.java
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -134,7 +135,7 @@ public class LinearRegression2Fail extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression2Fail/LinearRegression2Fail_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression2Fail/LinearRegression2Fail_optimisedModel.java
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -134,7 +135,7 @@ public class LinearRegression2Fail extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression2Fail/LinearRegression2Fail_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression2Fail/LinearRegression2Fail_optimisedModelNoComments.java
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -134,7 +135,7 @@ public class LinearRegression2Fail extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression2Fail/LinearRegression2Fail_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression2Fail/LinearRegression2Fail_optimisedModelSingle.java
@@ -3,6 +3,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -134,7 +135,7 @@ public class LinearRegression2Fail extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression3Fail/LinearRegressionWrongNameFail_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression3Fail/LinearRegressionWrongNameFail_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionWrongNameFail extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression3Fail/LinearRegressionWrongNameFail_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression3Fail/LinearRegressionWrongNameFail_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionWrongNameFail extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression3Fail/LinearRegressionWrongNameFail_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression3Fail/LinearRegressionWrongNameFail_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionWrongNameFail extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression3Fail/LinearRegressionWrongNameFail_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression3Fail/LinearRegressionWrongNameFail_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionWrongNameFail extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression3Fail/LinearRegressionWrongNameFail_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression3Fail/LinearRegressionWrongNameFail_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionWrongNameFail extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression3Fail/LinearRegressionWrongNameFail_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegression3Fail/LinearRegressionWrongNameFail_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionWrongNameFail extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic/LinearRegressionBasic_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic/LinearRegressionBasic_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionBasic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic/LinearRegressionBasic_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic/LinearRegressionBasic_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionBasic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic/LinearRegressionBasic_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic/LinearRegressionBasic_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionBasic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic/LinearRegressionBasic_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic/LinearRegressionBasic_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionBasic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic/LinearRegressionBasic_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic/LinearRegressionBasic_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionBasic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic/LinearRegressionBasic_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic/LinearRegressionBasic_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionBasic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic2/LinearRegressionBasic2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic2/LinearRegressionBasic2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionBasic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic2/LinearRegressionBasic2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic2/LinearRegressionBasic2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionBasic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic2/LinearRegressionBasic2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic2/LinearRegressionBasic2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionBasic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic2/LinearRegressionBasic2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic2/LinearRegressionBasic2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionBasic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic2/LinearRegressionBasic2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic2/LinearRegressionBasic2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionBasic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic2/LinearRegressionBasic2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionBasic2/LinearRegressionBasic2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionBasic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionTest/LinearRegressionTest_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionTest/LinearRegressionTest_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionTest/LinearRegressionTest_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionTest/LinearRegressionTest_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionTest/LinearRegressionTest_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionTest/LinearRegressionTest_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionTest/LinearRegressionTest_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionTest/LinearRegressionTest_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionTest/LinearRegressionTest_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionTest/LinearRegressionTest_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionTest/LinearRegressionTest_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LinearRegressionTest/LinearRegressionTest_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -136,7 +137,7 @@ public class LinearRegressionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LogitRegressionTest/LogitRegressionTest_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LogitRegressionTest/LogitRegressionTest_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public class LogitRegressionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LogitRegressionTest/LogitRegressionTest_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LogitRegressionTest/LogitRegressionTest_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public class LogitRegressionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LogitRegressionTest/LogitRegressionTest_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LogitRegressionTest/LogitRegressionTest_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public class LogitRegressionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LogitRegressionTest/LogitRegressionTest_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LogitRegressionTest/LogitRegressionTest_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public class LogitRegressionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LogitRegressionTest/LogitRegressionTest_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LogitRegressionTest/LogitRegressionTest_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public class LogitRegressionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LogitRegressionTest/LogitRegressionTest_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LogitRegressionTest/LogitRegressionTest_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public class LogitRegressionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/MultinomialBernoulli/MultinomialBernoulli_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/MultinomialBernoulli/MultinomialBernoulli_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class MultinomialBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/MultinomialBernoulli/MultinomialBernoulli_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/MultinomialBernoulli/MultinomialBernoulli_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class MultinomialBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/MultinomialBernoulli/MultinomialBernoulli_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/MultinomialBernoulli/MultinomialBernoulli_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class MultinomialBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/MultinomialBernoulli/MultinomialBernoulli_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/MultinomialBernoulli/MultinomialBernoulli_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class MultinomialBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/MultinomialBernoulli/MultinomialBernoulli_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/MultinomialBernoulli/MultinomialBernoulli_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class MultinomialBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/MultinomialBernoulli/MultinomialBernoulli_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/MultinomialBernoulli/MultinomialBernoulli_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class MultinomialBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK2/NullModelMK2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK2/NullModelMK2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class NullModelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK2/NullModelMK2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK2/NullModelMK2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class NullModelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK2/NullModelMK2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK2/NullModelMK2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class NullModelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK2/NullModelMK2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK2/NullModelMK2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class NullModelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK2/NullModelMK2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK2/NullModelMK2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class NullModelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK2/NullModelMK2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK2/NullModelMK2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class NullModelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK3/NullModelMK3_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK3/NullModelMK3_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class NullModelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK3/NullModelMK3_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK3/NullModelMK3_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class NullModelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK3/NullModelMK3_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK3/NullModelMK3_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class NullModelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK3/NullModelMK3_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK3/NullModelMK3_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class NullModelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK3/NullModelMK3_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK3/NullModelMK3_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class NullModelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK3/NullModelMK3_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/NullModelMK3/NullModelMK3_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class NullModelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK1/ParallelMK1_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK1/ParallelMK1_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class ParallelMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample20(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample20())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK1/ParallelMK1_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK1/ParallelMK1_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class ParallelMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample20(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample20())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK1/ParallelMK1_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK1/ParallelMK1_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class ParallelMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample20(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample20())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK1/ParallelMK1_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK1/ParallelMK1_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class ParallelMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample20(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample20())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK1/ParallelMK1_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK1/ParallelMK1_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class ParallelMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample20(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample20())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK1/ParallelMK1_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK1/ParallelMK1_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class ParallelMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample20(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample20())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK2/ParallelMK2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK2/ParallelMK2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class ParallelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample26(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample26())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK2/ParallelMK2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK2/ParallelMK2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class ParallelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample26(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample26())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK2/ParallelMK2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK2/ParallelMK2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class ParallelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample26(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample26())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK2/ParallelMK2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK2/ParallelMK2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class ParallelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample26(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample26())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK2/ParallelMK2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK2/ParallelMK2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class ParallelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample26(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample26())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK2/ParallelMK2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK2/ParallelMK2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class ParallelMK2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample26(fixed);
-            }
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample26())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            return Immutability.DETERMINISTIC;
         }
     };
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK3/ParallelMK3_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK3/ParallelMK3_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK3/ParallelMK3_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK3/ParallelMK3_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK3/ParallelMK3_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK3/ParallelMK3_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK3/ParallelMK3_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK3/ParallelMK3_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK3/ParallelMK3_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK3/ParallelMK3_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK3/ParallelMK3_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK3/ParallelMK3_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK4/ParallelMK4_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK4/ParallelMK4_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK4/ParallelMK4_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK4/ParallelMK4_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK4/ParallelMK4_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK4/ParallelMK4_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK4/ParallelMK4_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK4/ParallelMK4_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK4/ParallelMK4_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK4/ParallelMK4_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK4/ParallelMK4_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK4/ParallelMK4_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK5/ParallelMK5_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK5/ParallelMK5_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK5/ParallelMK5_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK5/ParallelMK5_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK5/ParallelMK5_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK5/ParallelMK5_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK5/ParallelMK5_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK5/ParallelMK5_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK5/ParallelMK5_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK5/ParallelMK5_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK5/ParallelMK5_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ParallelMK5/ParallelMK5_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ParallelMK5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/PoissonDecayMK1/PoissonDecayMK1_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/PoissonDecayMK1/PoissonDecayMK1_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class PoissonDecayMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/PoissonDecayMK1/PoissonDecayMK1_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/PoissonDecayMK1/PoissonDecayMK1_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class PoissonDecayMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/PoissonDecayMK1/PoissonDecayMK1_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/PoissonDecayMK1/PoissonDecayMK1_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class PoissonDecayMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/PoissonDecayMK1/PoissonDecayMK1_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/PoissonDecayMK1/PoissonDecayMK1_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class PoissonDecayMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/PoissonDecayMK1/PoissonDecayMK1_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/PoissonDecayMK1/PoissonDecayMK1_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class PoissonDecayMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/PoissonDecayMK1/PoissonDecayMK1_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/PoissonDecayMK1/PoissonDecayMK1_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class PoissonDecayMK1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray/RaggedArray_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray/RaggedArray_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray/RaggedArray_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray/RaggedArray_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray/RaggedArray_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray/RaggedArray_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray/RaggedArray_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray/RaggedArray_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray/RaggedArray_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray/RaggedArray_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray/RaggedArray_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray/RaggedArray_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray2/RaggedArray2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray2/RaggedArray2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray2/RaggedArray2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray2/RaggedArray2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray2/RaggedArray2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray2/RaggedArray2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray2/RaggedArray2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray2/RaggedArray2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray2/RaggedArray2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray2/RaggedArray2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray2/RaggedArray2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray2/RaggedArray2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray3/RaggedArray3_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray3/RaggedArray3_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray3/RaggedArray3_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray3/RaggedArray3_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray3/RaggedArray3_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray3/RaggedArray3_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray3/RaggedArray3_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray3/RaggedArray3_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray3/RaggedArray3_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray3/RaggedArray3_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray3/RaggedArray3_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray3/RaggedArray3_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray3 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray4/RaggedArray4_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray4/RaggedArray4_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray4/RaggedArray4_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray4/RaggedArray4_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray4/RaggedArray4_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray4/RaggedArray4_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray4/RaggedArray4_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray4/RaggedArray4_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray4/RaggedArray4_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray4/RaggedArray4_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray4/RaggedArray4_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray4/RaggedArray4_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray4 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray5/RaggedArray5_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray5/RaggedArray5_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray5/RaggedArray5_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray5/RaggedArray5_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray5/RaggedArray5_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray5/RaggedArray5_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray5/RaggedArray5_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray5/RaggedArray5_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray5/RaggedArray5_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray5/RaggedArray5_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray5/RaggedArray5_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray5/RaggedArray5_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray5 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray6/RaggedArray6_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray6/RaggedArray6_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray6/RaggedArray6_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray6/RaggedArray6_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray6/RaggedArray6_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray6/RaggedArray6_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray6/RaggedArray6_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray6/RaggedArray6_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray6/RaggedArray6_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray6/RaggedArray6_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray6/RaggedArray6_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/RaggedArray6/RaggedArray6_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class RaggedArray6 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest/ReductionTest_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest/ReductionTest_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class ReductionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest/ReductionTest_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest/ReductionTest_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class ReductionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest/ReductionTest_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest/ReductionTest_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class ReductionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest/ReductionTest_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest/ReductionTest_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class ReductionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest/ReductionTest_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest/ReductionTest_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class ReductionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest/ReductionTest_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest/ReductionTest_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class ReductionTest extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/UniformBernoulli/UniformBernoulli_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/UniformBernoulli/UniformBernoulli_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class UniformBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/UniformBernoulli/UniformBernoulli_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/UniformBernoulli/UniformBernoulli_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class UniformBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/UniformBernoulli/UniformBernoulli_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/UniformBernoulli/UniformBernoulli_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class UniformBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/UniformBernoulli/UniformBernoulli_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/UniformBernoulli/UniformBernoulli_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class UniformBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/UniformBernoulli/UniformBernoulli_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/UniformBernoulli/UniformBernoulli_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class UniformBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/UniformBernoulli/UniformBernoulli_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/UniformBernoulli/UniformBernoulli_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class UniformBernoulli extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic/Vulcano2012basic_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic/Vulcano2012basic_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class Vulcano2012basic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic/Vulcano2012basic_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic/Vulcano2012basic_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class Vulcano2012basic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic/Vulcano2012basic_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic/Vulcano2012basic_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class Vulcano2012basic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic/Vulcano2012basic_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic/Vulcano2012basic_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class Vulcano2012basic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic/Vulcano2012basic_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic/Vulcano2012basic_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class Vulcano2012basic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic/Vulcano2012basic_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic/Vulcano2012basic_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class Vulcano2012basic extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$CoreInterface_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$CoreInterface_model.java
@@ -35,6 +35,12 @@ interface Vulcano2012basic2$CoreInterface extends org.sandwood.runtime.internal.
 	// Setter for fixedFlag$sample26.
 	public void set$fixedFlag$sample26(boolean cv$value);
 
+	// Getter for fixedFlag$sample82.
+	public boolean get$fixedFlag$sample82();
+
+	// Setter for fixedFlag$sample82.
+	public void set$fixedFlag$sample82(boolean cv$value);
+
 	// Getter for logProbability$Sales.
 	public double get$logProbability$Sales();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$CoreInterface_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$CoreInterface_modelNoComments.java
@@ -12,6 +12,8 @@ interface Vulcano2012basic2$CoreInterface extends org.sandwood.runtime.internal.
 	public double[] get$expedNorm();
 	public boolean get$fixedFlag$sample26();
 	public void set$fixedFlag$sample26(boolean cv$value);
+	public boolean get$fixedFlag$sample82();
+	public void set$fixedFlag$sample82(boolean cv$value);
 	public double get$logProbability$Sales();
 	public double get$logProbability$exped();
 	public double get$logProbability$expedNorm();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$CoreInterface_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$CoreInterface_modelSingle.java
@@ -35,6 +35,12 @@ interface Vulcano2012basic2$CoreInterface extends org.sandwood.runtime.internal.
 	// Setter for fixedFlag$sample26.
 	public void set$fixedFlag$sample26(boolean cv$value);
 
+	// Getter for fixedFlag$sample82.
+	public boolean get$fixedFlag$sample82();
+
+	// Setter for fixedFlag$sample82.
+	public void set$fixedFlag$sample82(boolean cv$value);
+
 	// Getter for logProbability$Sales.
 	public double get$logProbability$Sales();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$CoreInterface_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$CoreInterface_optimisedModel.java
@@ -35,6 +35,12 @@ interface Vulcano2012basic2$CoreInterface extends org.sandwood.runtime.internal.
 	// Setter for fixedFlag$sample26.
 	public void set$fixedFlag$sample26(boolean cv$value);
 
+	// Getter for fixedFlag$sample82.
+	public boolean get$fixedFlag$sample82();
+
+	// Setter for fixedFlag$sample82.
+	public void set$fixedFlag$sample82(boolean cv$value);
+
 	// Getter for logProbability$Sales.
 	public double get$logProbability$Sales();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$CoreInterface_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$CoreInterface_optimisedModelNoComments.java
@@ -12,6 +12,8 @@ interface Vulcano2012basic2$CoreInterface extends org.sandwood.runtime.internal.
 	public double[] get$expedNorm();
 	public boolean get$fixedFlag$sample26();
 	public void set$fixedFlag$sample26(boolean cv$value);
+	public boolean get$fixedFlag$sample82();
+	public void set$fixedFlag$sample82(boolean cv$value);
 	public double get$logProbability$Sales();
 	public double get$logProbability$exped();
 	public double get$logProbability$expedNorm();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$CoreInterface_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$CoreInterface_optimisedModelSingle.java
@@ -35,6 +35,12 @@ interface Vulcano2012basic2$CoreInterface extends org.sandwood.runtime.internal.
 	// Setter for fixedFlag$sample26.
 	public void set$fixedFlag$sample26(boolean cv$value);
 
+	// Getter for fixedFlag$sample82.
+	public boolean get$fixedFlag$sample82();
+
+	// Setter for fixedFlag$sample82.
+	public void set$fixedFlag$sample82(boolean cv$value);
+
 	// Getter for logProbability$Sales.
 	public double get$logProbability$Sales();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$MultiThreadCPU_model.java
@@ -13,6 +13,7 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 	private double[] exped;
 	private double[] expedNorm;
 	private boolean fixedFlag$sample26 = false;
+	private boolean fixedFlag$sample82 = false;
 	private boolean fixedProbFlag$sample149 = false;
 	private boolean fixedProbFlag$sample26 = false;
 	private boolean fixedProbFlag$sample82 = false;
@@ -125,6 +126,18 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 		// Should the probability of sample 149 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample149 = (fixedFlag$sample26 && fixedProbFlag$sample149);
+	}
+
+	// Getter for fixedFlag$sample82.
+	@Override
+	public final boolean get$fixedFlag$sample82() {
+		return fixedFlag$sample82;
+	}
+
+	// Setter for fixedFlag$sample82.
+	@Override
+	public final void set$fixedFlag$sample82(boolean cv$value) {
+		fixedFlag$sample82 = cv$value;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -3051,8 +3064,10 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 				
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
-					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
-						sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1) {
+						if(!fixedFlag$sample82)
+							sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+					}
 			}
 		);
 		
@@ -3311,8 +3326,10 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 				
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
-					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
-						sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1) {
+						if(!fixedFlag$sample82)
+							sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+					}
 			}
 		);
 		
@@ -3752,28 +3769,34 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample82 = false;
+		
+		// Propagating values back from observations into the models intermediate variables.
 		{
-			// Deep copy between arrays
-			int[][] cv$source1 = ObsSales;
-			int[][] cv$target1 = Sales;
-			int cv$length1 = cv$target1.length;
-			for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
-				int[] cv$source2 = cv$source1[cv$index1];
-				int[] cv$target2 = cv$target1[cv$index1];
-				int cv$length2 = cv$target2.length;
-				for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
-					cv$target2[cv$index2] = cv$source2[cv$index2];
+			{
+				// Deep copy between arrays
+				int[][] cv$source1 = ObsSales;
+				int[][] cv$target1 = Sales;
+				int cv$length1 = cv$target1.length;
+				for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
+					int[] cv$source2 = cv$source1[cv$index1];
+					int[] cv$target2 = cv$target1[cv$index1];
+					int cv$length2 = cv$target2.length;
+					for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
+						cv$target2[cv$index2] = cv$source2[cv$index2];
+				}
 			}
-		}
-		for(int t$var105 = (T - ((((T - 1) - 0) % 1) + 1)); t$var105 >= ((0 - 1) + 1); t$var105 -= 1) {
-			int[] weekly_sales;
-			weekly_sales = Sales[t$var105];
-			int cv$multinomialSum148 = 0;
-			
-			// Sum the number of samples in the multinomial output.
-			for(int cv$multinomialIndex148 = 0; cv$multinomialIndex148 < weekly_sales.length; cv$multinomialIndex148 += 1)
-				cv$multinomialSum148 = (weekly_sales[cv$multinomialIndex148] + cv$multinomialSum148);
-			sales_sum[t$var105] = cv$multinomialSum148;
+			for(int t$var105 = (T - ((((T - 1) - 0) % 1) + 1)); t$var105 >= ((0 - 1) + 1); t$var105 -= 1) {
+				int[] weekly_sales;
+				weekly_sales = Sales[t$var105];
+				int cv$multinomialSum148 = 0;
+				
+				// Sum the number of samples in the multinomial output.
+				for(int cv$multinomialIndex148 = 0; cv$multinomialIndex148 < weekly_sales.length; cv$multinomialIndex148 += 1)
+					cv$multinomialSum148 = (weekly_sales[cv$multinomialIndex148] + cv$multinomialSum148);
+				sales_sum[t$var105] = cv$multinomialSum148;
+			}
 		}
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$MultiThreadCPU_modelNoComments.java
@@ -11,6 +11,7 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 	private double[] exped;
 	private double[] expedNorm;
 	private boolean fixedFlag$sample26 = false;
+	private boolean fixedFlag$sample82 = false;
 	private boolean fixedProbFlag$sample149 = false;
 	private boolean fixedProbFlag$sample26 = false;
 	private boolean fixedProbFlag$sample82 = false;
@@ -102,6 +103,16 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 		fixedFlag$sample26 = cv$value;
 		fixedProbFlag$sample26 = (fixedFlag$sample26 && fixedProbFlag$sample26);
 		fixedProbFlag$sample149 = (fixedFlag$sample26 && fixedProbFlag$sample149);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample82() {
+		return fixedFlag$sample82;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample82(boolean cv$value) {
+		fixedFlag$sample82 = cv$value;
 	}
 
 	@Override
@@ -2121,8 +2132,10 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 		);
 		parallelFor(RNG$, 0, T, 1,
 			(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
-				for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
-						sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+				for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1) {
+						if(!fixedFlag$sample82)
+							sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+					}
 			}
 		);
 		parallelFor(RNG$, 0, T, 1,
@@ -2250,8 +2263,10 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 		);
 		parallelFor(RNG$, 0, T, 1,
 			(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
-				for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
-						sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+				for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1) {
+						if(!fixedFlag$sample82)
+							sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+					}
 			}
 		);
 		parallelFor(RNG$, 0, T, 1,
@@ -2491,25 +2506,28 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 
 	@Override
 	public final void propagateObservedValues() {
+		fixedFlag$sample82 = false;
 		{
-			int[][] cv$source1 = ObsSales;
-			int[][] cv$target1 = Sales;
-			int cv$length1 = cv$target1.length;
-			for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
-				int[] cv$source2 = cv$source1[cv$index1];
-				int[] cv$target2 = cv$target1[cv$index1];
-				int cv$length2 = cv$target2.length;
-				for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
-					cv$target2[cv$index2] = cv$source2[cv$index2];
+			{
+				int[][] cv$source1 = ObsSales;
+				int[][] cv$target1 = Sales;
+				int cv$length1 = cv$target1.length;
+				for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
+					int[] cv$source2 = cv$source1[cv$index1];
+					int[] cv$target2 = cv$target1[cv$index1];
+					int cv$length2 = cv$target2.length;
+					for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
+						cv$target2[cv$index2] = cv$source2[cv$index2];
+				}
 			}
-		}
-		for(int t$var105 = (T - ((((T - 1) - 0) % 1) + 1)); t$var105 >= ((0 - 1) + 1); t$var105 -= 1) {
-			int[] weekly_sales;
-			weekly_sales = Sales[t$var105];
-			int cv$multinomialSum148 = 0;
-			for(int cv$multinomialIndex148 = 0; cv$multinomialIndex148 < weekly_sales.length; cv$multinomialIndex148 += 1)
-				cv$multinomialSum148 = (weekly_sales[cv$multinomialIndex148] + cv$multinomialSum148);
-			sales_sum[t$var105] = cv$multinomialSum148;
+			for(int t$var105 = (T - ((((T - 1) - 0) % 1) + 1)); t$var105 >= ((0 - 1) + 1); t$var105 -= 1) {
+				int[] weekly_sales;
+				weekly_sales = Sales[t$var105];
+				int cv$multinomialSum148 = 0;
+				for(int cv$multinomialIndex148 = 0; cv$multinomialIndex148 < weekly_sales.length; cv$multinomialIndex148 += 1)
+					cv$multinomialSum148 = (weekly_sales[cv$multinomialIndex148] + cv$multinomialSum148);
+				sales_sum[t$var105] = cv$multinomialSum148;
+			}
 		}
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$MultiThreadCPU_modelSingle.java
@@ -13,6 +13,7 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 	private double[] exped;
 	private double[] expedNorm;
 	private boolean fixedFlag$sample26 = false;
+	private boolean fixedFlag$sample82 = false;
 	private boolean fixedProbFlag$sample149 = false;
 	private boolean fixedProbFlag$sample26 = false;
 	private boolean fixedProbFlag$sample82 = false;
@@ -125,6 +126,18 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 		// Should the probability of sample 149 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample149 = (fixedFlag$sample26 && fixedProbFlag$sample149);
+	}
+
+	// Getter for fixedFlag$sample82.
+	@Override
+	public final boolean get$fixedFlag$sample82() {
+		return fixedFlag$sample82;
+	}
+
+	// Setter for fixedFlag$sample82.
+	@Override
+	public final void set$fixedFlag$sample82(boolean cv$value) {
+		fixedFlag$sample82 = cv$value;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -3044,8 +3057,10 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 				
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
-					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
-						sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1) {
+						if(!fixedFlag$sample82)
+							sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+					}
 			}
 		);
 		
@@ -3304,8 +3319,10 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 				
 					// Inner loop for running batches of iterations, each batch has its own random number
 					// generator.
-					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
-						sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1) {
+						if(!fixedFlag$sample82)
+							sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+					}
 			}
 		);
 		
@@ -3740,28 +3757,34 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample82 = false;
+		
+		// Propagating values back from observations into the models intermediate variables.
 		{
-			// Deep copy between arrays
-			int[][] cv$source1 = ObsSales;
-			int[][] cv$target1 = Sales;
-			int cv$length1 = cv$target1.length;
-			for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
-				int[] cv$source2 = cv$source1[cv$index1];
-				int[] cv$target2 = cv$target1[cv$index1];
-				int cv$length2 = cv$target2.length;
-				for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
-					cv$target2[cv$index2] = cv$source2[cv$index2];
+			{
+				// Deep copy between arrays
+				int[][] cv$source1 = ObsSales;
+				int[][] cv$target1 = Sales;
+				int cv$length1 = cv$target1.length;
+				for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
+					int[] cv$source2 = cv$source1[cv$index1];
+					int[] cv$target2 = cv$target1[cv$index1];
+					int cv$length2 = cv$target2.length;
+					for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
+						cv$target2[cv$index2] = cv$source2[cv$index2];
+				}
 			}
-		}
-		for(int t$var105 = (T - ((((T - 1) - 0) % 1) + 1)); t$var105 >= ((0 - 1) + 1); t$var105 -= 1) {
-			int[] weekly_sales;
-			weekly_sales = Sales[t$var105];
-			int cv$multinomialSum148 = 0;
-			
-			// Sum the number of samples in the multinomial output.
-			for(int cv$multinomialIndex148 = 0; cv$multinomialIndex148 < weekly_sales.length; cv$multinomialIndex148 += 1)
-				cv$multinomialSum148 = (weekly_sales[cv$multinomialIndex148] + cv$multinomialSum148);
-			sales_sum[t$var105] = cv$multinomialSum148;
+			for(int t$var105 = (T - ((((T - 1) - 0) % 1) + 1)); t$var105 >= ((0 - 1) + 1); t$var105 -= 1) {
+				int[] weekly_sales;
+				weekly_sales = Sales[t$var105];
+				int cv$multinomialSum148 = 0;
+				
+				// Sum the number of samples in the multinomial output.
+				for(int cv$multinomialIndex148 = 0; cv$multinomialIndex148 < weekly_sales.length; cv$multinomialIndex148 += 1)
+					cv$multinomialSum148 = (weekly_sales[cv$multinomialIndex148] + cv$multinomialSum148);
+				sales_sum[t$var105] = cv$multinomialSum148;
+			}
 		}
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$MultiThreadCPU_optimisedModel.java
@@ -13,6 +13,7 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 	private double[] exped;
 	private double[] expedNorm;
 	private boolean fixedFlag$sample26 = false;
+	private boolean fixedFlag$sample82 = false;
 	private boolean fixedProbFlag$sample149 = false;
 	private boolean fixedProbFlag$sample26 = false;
 	private boolean fixedProbFlag$sample82 = false;
@@ -129,6 +130,18 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 		// 
 		// Substituted "fixedFlag$sample26" with its value "cv$value".
 		fixedProbFlag$sample149 = (cv$value && fixedProbFlag$sample149);
+	}
+
+	// Getter for fixedFlag$sample82.
+	@Override
+	public final boolean get$fixedFlag$sample82() {
+		return fixedFlag$sample82;
+	}
+
+	// Setter for fixedFlag$sample82.
+	@Override
+	public final void set$fixedFlag$sample82(boolean cv$value) {
+		fixedFlag$sample82 = cv$value;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -1620,16 +1633,19 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 			);
 		}
 		
-		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-		parallelFor(RNG$, 0, T, 1,
-			(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
-				
-					// Inner loop for running batches of iterations, each batch has its own random number
-					// generator.
-					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
-						sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
-			}
-		);
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample82)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, T, 1,
+				(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
+							sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+				}
+			);
+
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, T, 1,
@@ -1872,16 +1888,19 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 			}
 		);
 		
-		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-		parallelFor(RNG$, 0, T, 1,
-			(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
-				
-					// Inner loop for running batches of iterations, each batch has its own random number
-					// generator.
-					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
-						sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
-			}
-		);
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample82)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, T, 1,
+				(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
+							sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+				}
+			);
+
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, T, 1,
@@ -2296,7 +2315,8 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
-		// Propagating values back from observations into the models intermediate variables.
+		// Reset any fixed flags on observed values
+		fixedFlag$sample82 = false;
 		int cv$length1 = Sales.length;
 		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
 			int[] cv$source2 = ObsSales[cv$index1];

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$MultiThreadCPU_optimisedModelNoComments.java
@@ -11,6 +11,7 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 	private double[] exped;
 	private double[] expedNorm;
 	private boolean fixedFlag$sample26 = false;
+	private boolean fixedFlag$sample82 = false;
 	private boolean fixedProbFlag$sample149 = false;
 	private boolean fixedProbFlag$sample26 = false;
 	private boolean fixedProbFlag$sample82 = false;
@@ -102,6 +103,16 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 		fixedFlag$sample26 = cv$value;
 		fixedProbFlag$sample26 = (cv$value && fixedProbFlag$sample26);
 		fixedProbFlag$sample149 = (cv$value && fixedProbFlag$sample149);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample82() {
+		return fixedFlag$sample82;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample82(boolean cv$value) {
+		fixedFlag$sample82 = cv$value;
 	}
 
 	@Override
@@ -598,12 +609,14 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 				}
 			);
 		}
-		parallelFor(RNG$, 0, T, 1,
-			(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
-				for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
-						sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
-			}
-		);
+		if(!fixedFlag$sample82)
+			parallelFor(RNG$, 0, T, 1,
+				(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
+							sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+				}
+			);
+
 		parallelFor(RNG$, 0, T, 1,
 			(int forStart$index$t$var105, int forEnd$index$t$var105, int threadID$index$t$var105, org.sandwood.random.internal.Rng RNG$1) -> { 
 				for(int index$t$var105 = forStart$index$t$var105; index$t$var105 < forEnd$index$t$var105; index$t$var105 += 1) {
@@ -713,12 +726,14 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 						expedNorm[j$var63] = (exped[j$var63] / (r * reduceVar$sum$15$1));
 			}
 		);
-		parallelFor(RNG$, 0, T, 1,
-			(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
-				for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
-						sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
-			}
-		);
+		if(!fixedFlag$sample82)
+			parallelFor(RNG$, 0, T, 1,
+				(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
+							sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+				}
+			);
+
 		parallelFor(RNG$, 0, T, 1,
 			(int forStart$index$t$var105, int forEnd$index$t$var105, int threadID$index$t$var105, org.sandwood.random.internal.Rng RNG$1) -> { 
 				for(int index$t$var105 = forStart$index$t$var105; index$t$var105 < forEnd$index$t$var105; index$t$var105 += 1) {
@@ -929,6 +944,7 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 
 	@Override
 	public final void propagateObservedValues() {
+		fixedFlag$sample82 = false;
 		int cv$length1 = Sales.length;
 		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
 			int[] cv$source2 = ObsSales[cv$index1];

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$MultiThreadCPU_optimisedModelSingle.java
@@ -13,6 +13,7 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 	private double[] exped;
 	private double[] expedNorm;
 	private boolean fixedFlag$sample26 = false;
+	private boolean fixedFlag$sample82 = false;
 	private boolean fixedProbFlag$sample149 = false;
 	private boolean fixedProbFlag$sample26 = false;
 	private boolean fixedProbFlag$sample82 = false;
@@ -129,6 +130,18 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 		// 
 		// Substituted "fixedFlag$sample26" with its value "cv$value".
 		fixedProbFlag$sample149 = (cv$value && fixedProbFlag$sample149);
+	}
+
+	// Getter for fixedFlag$sample82.
+	@Override
+	public final boolean get$fixedFlag$sample82() {
+		return fixedFlag$sample82;
+	}
+
+	// Setter for fixedFlag$sample82.
+	@Override
+	public final void set$fixedFlag$sample82(boolean cv$value) {
+		fixedFlag$sample82 = cv$value;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -1663,16 +1676,19 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 			);
 		}
 		
-		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-		parallelFor(RNG$, 0, T, 1,
-			(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
-				
-					// Inner loop for running batches of iterations, each batch has its own random number
-					// generator.
-					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
-						sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
-			}
-		);
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample82)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, T, 1,
+				(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
+							sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+				}
+			);
+
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, T, 1,
@@ -1915,16 +1931,19 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 			}
 		);
 		
-		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
-		parallelFor(RNG$, 0, T, 1,
-			(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
-				
-					// Inner loop for running batches of iterations, each batch has its own random number
-					// generator.
-					for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
-						sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
-			}
-		);
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample82)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, T, 1,
+				(int forStart$t$var78, int forEnd$t$var78, int threadID$t$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int t$var78 = forStart$t$var78; t$var78 < forEnd$t$var78; t$var78 += 1)
+							sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$1, 0.5);
+				}
+			);
+
 		
 		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
 		parallelFor(RNG$, 0, T, 1,
@@ -2334,7 +2353,8 @@ class Vulcano2012basic2$MultiThreadCPU extends org.sandwood.runtime.internal.mod
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
-		// Propagating values back from observations into the models intermediate variables.
+		// Reset any fixed flags on observed values
+		fixedFlag$sample82 = false;
 		int cv$length1 = Sales.length;
 		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
 			int[] cv$source2 = ObsSales[cv$index1];

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$SingleThreadCPU_model.java
@@ -13,6 +13,7 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 	private double[] exped;
 	private double[] expedNorm;
 	private boolean fixedFlag$sample26 = false;
+	private boolean fixedFlag$sample82 = false;
 	private boolean fixedProbFlag$sample149 = false;
 	private boolean fixedProbFlag$sample26 = false;
 	private boolean fixedProbFlag$sample82 = false;
@@ -125,6 +126,18 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 		// Should the probability of sample 149 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample149 = (fixedFlag$sample26 && fixedProbFlag$sample149);
+	}
+
+	// Getter for fixedFlag$sample82.
+	@Override
+	public final boolean get$fixedFlag$sample82() {
+		return fixedFlag$sample82;
+	}
+
+	// Setter for fixedFlag$sample82.
+	@Override
+	public final void set$fixedFlag$sample82(boolean cv$value) {
+		fixedFlag$sample82 = cv$value;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -3018,8 +3031,10 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 			if(!fixedFlag$sample26)
 				expedNorm[j$var63] = (exped[j$var63] / (r * sum));
 		}
-		for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
-			sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		for(int t$var78 = 0; t$var78 < T; t$var78 += 1) {
+			if(!fixedFlag$sample82)
+				sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		}
 		for(int t$var105 = 0; t$var105 < T; t$var105 += 1) {
 			for(int j$var116 = 0; j$var116 < noProducts; j$var116 += 1) {
 				if(!fixedFlag$sample26)
@@ -3153,8 +3168,10 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 		sum = reduceVar$sum$5;
 		for(int j$var63 = 0; j$var63 < noProducts; j$var63 += 1)
 			expedNorm[j$var63] = (exped[j$var63] / (r * sum));
-		for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
-			sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		for(int t$var78 = 0; t$var78 < T; t$var78 += 1) {
+			if(!fixedFlag$sample82)
+				sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		}
 		for(int t$var105 = 0; t$var105 < T; t$var105 += 1) {
 			for(int j$var116 = 0; j$var116 < noProducts; j$var116 += 1)
 				weekly_ut[((t$var105 - 0) / 1)][j$var116] = (expedNorm[j$var116] * Avail[t$var105][j$var116]);
@@ -3444,28 +3461,34 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample82 = false;
+		
+		// Propagating values back from observations into the models intermediate variables.
 		{
-			// Deep copy between arrays
-			int[][] cv$source1 = ObsSales;
-			int[][] cv$target1 = Sales;
-			int cv$length1 = cv$target1.length;
-			for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
-				int[] cv$source2 = cv$source1[cv$index1];
-				int[] cv$target2 = cv$target1[cv$index1];
-				int cv$length2 = cv$target2.length;
-				for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
-					cv$target2[cv$index2] = cv$source2[cv$index2];
+			{
+				// Deep copy between arrays
+				int[][] cv$source1 = ObsSales;
+				int[][] cv$target1 = Sales;
+				int cv$length1 = cv$target1.length;
+				for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
+					int[] cv$source2 = cv$source1[cv$index1];
+					int[] cv$target2 = cv$target1[cv$index1];
+					int cv$length2 = cv$target2.length;
+					for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
+						cv$target2[cv$index2] = cv$source2[cv$index2];
+				}
 			}
-		}
-		for(int t$var105 = (T - ((((T - 1) - 0) % 1) + 1)); t$var105 >= ((0 - 1) + 1); t$var105 -= 1) {
-			int[] weekly_sales;
-			weekly_sales = Sales[t$var105];
-			int cv$multinomialSum148 = 0;
-			
-			// Sum the number of samples in the multinomial output.
-			for(int cv$multinomialIndex148 = 0; cv$multinomialIndex148 < weekly_sales.length; cv$multinomialIndex148 += 1)
-				cv$multinomialSum148 = (weekly_sales[cv$multinomialIndex148] + cv$multinomialSum148);
-			sales_sum[t$var105] = cv$multinomialSum148;
+			for(int t$var105 = (T - ((((T - 1) - 0) % 1) + 1)); t$var105 >= ((0 - 1) + 1); t$var105 -= 1) {
+				int[] weekly_sales;
+				weekly_sales = Sales[t$var105];
+				int cv$multinomialSum148 = 0;
+				
+				// Sum the number of samples in the multinomial output.
+				for(int cv$multinomialIndex148 = 0; cv$multinomialIndex148 < weekly_sales.length; cv$multinomialIndex148 += 1)
+					cv$multinomialSum148 = (weekly_sales[cv$multinomialIndex148] + cv$multinomialSum148);
+				sales_sum[t$var105] = cv$multinomialSum148;
+			}
 		}
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$SingleThreadCPU_modelNoComments.java
@@ -11,6 +11,7 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 	private double[] exped;
 	private double[] expedNorm;
 	private boolean fixedFlag$sample26 = false;
+	private boolean fixedFlag$sample82 = false;
 	private boolean fixedProbFlag$sample149 = false;
 	private boolean fixedProbFlag$sample26 = false;
 	private boolean fixedProbFlag$sample82 = false;
@@ -102,6 +103,16 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 		fixedFlag$sample26 = cv$value;
 		fixedProbFlag$sample26 = (fixedFlag$sample26 && fixedProbFlag$sample26);
 		fixedProbFlag$sample149 = (fixedFlag$sample26 && fixedProbFlag$sample149);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample82() {
+		return fixedFlag$sample82;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample82(boolean cv$value) {
+		fixedFlag$sample82 = cv$value;
 	}
 
 	@Override
@@ -2107,8 +2118,10 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 			if(!fixedFlag$sample26)
 				expedNorm[j$var63] = (exped[j$var63] / (r * sum));
 		}
-		for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
-			sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		for(int t$var78 = 0; t$var78 < T; t$var78 += 1) {
+			if(!fixedFlag$sample82)
+				sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		}
 		for(int t$var105 = 0; t$var105 < T; t$var105 += 1) {
 			for(int j$var116 = 0; j$var116 < noProducts; j$var116 += 1) {
 				if(!fixedFlag$sample26)
@@ -2178,8 +2191,10 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 		sum = reduceVar$sum$5;
 		for(int j$var63 = 0; j$var63 < noProducts; j$var63 += 1)
 			expedNorm[j$var63] = (exped[j$var63] / (r * sum));
-		for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
-			sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		for(int t$var78 = 0; t$var78 < T; t$var78 += 1) {
+			if(!fixedFlag$sample82)
+				sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		}
 		for(int t$var105 = 0; t$var105 < T; t$var105 += 1) {
 			for(int j$var116 = 0; j$var116 < noProducts; j$var116 += 1)
 				weekly_ut[((t$var105 - 0) / 1)][j$var116] = (expedNorm[j$var116] * Avail[t$var105][j$var116]);
@@ -2348,25 +2363,28 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 
 	@Override
 	public final void propagateObservedValues() {
+		fixedFlag$sample82 = false;
 		{
-			int[][] cv$source1 = ObsSales;
-			int[][] cv$target1 = Sales;
-			int cv$length1 = cv$target1.length;
-			for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
-				int[] cv$source2 = cv$source1[cv$index1];
-				int[] cv$target2 = cv$target1[cv$index1];
-				int cv$length2 = cv$target2.length;
-				for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
-					cv$target2[cv$index2] = cv$source2[cv$index2];
+			{
+				int[][] cv$source1 = ObsSales;
+				int[][] cv$target1 = Sales;
+				int cv$length1 = cv$target1.length;
+				for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
+					int[] cv$source2 = cv$source1[cv$index1];
+					int[] cv$target2 = cv$target1[cv$index1];
+					int cv$length2 = cv$target2.length;
+					for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
+						cv$target2[cv$index2] = cv$source2[cv$index2];
+				}
 			}
-		}
-		for(int t$var105 = (T - ((((T - 1) - 0) % 1) + 1)); t$var105 >= ((0 - 1) + 1); t$var105 -= 1) {
-			int[] weekly_sales;
-			weekly_sales = Sales[t$var105];
-			int cv$multinomialSum148 = 0;
-			for(int cv$multinomialIndex148 = 0; cv$multinomialIndex148 < weekly_sales.length; cv$multinomialIndex148 += 1)
-				cv$multinomialSum148 = (weekly_sales[cv$multinomialIndex148] + cv$multinomialSum148);
-			sales_sum[t$var105] = cv$multinomialSum148;
+			for(int t$var105 = (T - ((((T - 1) - 0) % 1) + 1)); t$var105 >= ((0 - 1) + 1); t$var105 -= 1) {
+				int[] weekly_sales;
+				weekly_sales = Sales[t$var105];
+				int cv$multinomialSum148 = 0;
+				for(int cv$multinomialIndex148 = 0; cv$multinomialIndex148 < weekly_sales.length; cv$multinomialIndex148 += 1)
+					cv$multinomialSum148 = (weekly_sales[cv$multinomialIndex148] + cv$multinomialSum148);
+				sales_sum[t$var105] = cv$multinomialSum148;
+			}
 		}
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$SingleThreadCPU_modelSingle.java
@@ -13,6 +13,7 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 	private double[] exped;
 	private double[] expedNorm;
 	private boolean fixedFlag$sample26 = false;
+	private boolean fixedFlag$sample82 = false;
 	private boolean fixedProbFlag$sample149 = false;
 	private boolean fixedProbFlag$sample26 = false;
 	private boolean fixedProbFlag$sample82 = false;
@@ -125,6 +126,18 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 		// Should the probability of sample 149 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample149 = (fixedFlag$sample26 && fixedProbFlag$sample149);
+	}
+
+	// Getter for fixedFlag$sample82.
+	@Override
+	public final boolean get$fixedFlag$sample82() {
+		return fixedFlag$sample82;
+	}
+
+	// Setter for fixedFlag$sample82.
+	@Override
+	public final void set$fixedFlag$sample82(boolean cv$value) {
+		fixedFlag$sample82 = cv$value;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -3011,8 +3024,10 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 			if(!fixedFlag$sample26)
 				expedNorm[j$var63] = (exped[j$var63] / (r * sum));
 		}
-		for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
-			sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		for(int t$var78 = 0; t$var78 < T; t$var78 += 1) {
+			if(!fixedFlag$sample82)
+				sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		}
 		for(int t$var105 = 0; t$var105 < T; t$var105 += 1) {
 			for(int j$var116 = 0; j$var116 < noProducts; j$var116 += 1) {
 				if(!fixedFlag$sample26)
@@ -3146,8 +3161,10 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 		sum = reduceVar$sum$5;
 		for(int j$var63 = 0; j$var63 < noProducts; j$var63 += 1)
 			expedNorm[j$var63] = (exped[j$var63] / (r * sum));
-		for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
-			sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		for(int t$var78 = 0; t$var78 < T; t$var78 += 1) {
+			if(!fixedFlag$sample82)
+				sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		}
 		for(int t$var105 = 0; t$var105 < T; t$var105 += 1) {
 			for(int j$var116 = 0; j$var116 < noProducts; j$var116 += 1)
 				weekly_ut[((t$var105 - 0) / 1)][j$var116] = (expedNorm[j$var116] * Avail[t$var105][j$var116]);
@@ -3432,28 +3449,34 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
+		// Reset any fixed flags on observed values
+		fixedFlag$sample82 = false;
+		
+		// Propagating values back from observations into the models intermediate variables.
 		{
-			// Deep copy between arrays
-			int[][] cv$source1 = ObsSales;
-			int[][] cv$target1 = Sales;
-			int cv$length1 = cv$target1.length;
-			for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
-				int[] cv$source2 = cv$source1[cv$index1];
-				int[] cv$target2 = cv$target1[cv$index1];
-				int cv$length2 = cv$target2.length;
-				for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
-					cv$target2[cv$index2] = cv$source2[cv$index2];
+			{
+				// Deep copy between arrays
+				int[][] cv$source1 = ObsSales;
+				int[][] cv$target1 = Sales;
+				int cv$length1 = cv$target1.length;
+				for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
+					int[] cv$source2 = cv$source1[cv$index1];
+					int[] cv$target2 = cv$target1[cv$index1];
+					int cv$length2 = cv$target2.length;
+					for(int cv$index2 = 0; cv$index2 < cv$length2; cv$index2 += 1)
+						cv$target2[cv$index2] = cv$source2[cv$index2];
+				}
 			}
-		}
-		for(int t$var105 = (T - ((((T - 1) - 0) % 1) + 1)); t$var105 >= ((0 - 1) + 1); t$var105 -= 1) {
-			int[] weekly_sales;
-			weekly_sales = Sales[t$var105];
-			int cv$multinomialSum148 = 0;
-			
-			// Sum the number of samples in the multinomial output.
-			for(int cv$multinomialIndex148 = 0; cv$multinomialIndex148 < weekly_sales.length; cv$multinomialIndex148 += 1)
-				cv$multinomialSum148 = (weekly_sales[cv$multinomialIndex148] + cv$multinomialSum148);
-			sales_sum[t$var105] = cv$multinomialSum148;
+			for(int t$var105 = (T - ((((T - 1) - 0) % 1) + 1)); t$var105 >= ((0 - 1) + 1); t$var105 -= 1) {
+				int[] weekly_sales;
+				weekly_sales = Sales[t$var105];
+				int cv$multinomialSum148 = 0;
+				
+				// Sum the number of samples in the multinomial output.
+				for(int cv$multinomialIndex148 = 0; cv$multinomialIndex148 < weekly_sales.length; cv$multinomialIndex148 += 1)
+					cv$multinomialSum148 = (weekly_sales[cv$multinomialIndex148] + cv$multinomialSum148);
+				sales_sum[t$var105] = cv$multinomialSum148;
+			}
 		}
 	}
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$SingleThreadCPU_optimisedModel.java
@@ -13,6 +13,7 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 	private double[] exped;
 	private double[] expedNorm;
 	private boolean fixedFlag$sample26 = false;
+	private boolean fixedFlag$sample82 = false;
 	private boolean fixedProbFlag$sample149 = false;
 	private boolean fixedProbFlag$sample26 = false;
 	private boolean fixedProbFlag$sample82 = false;
@@ -129,6 +130,18 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 		// 
 		// Substituted "fixedFlag$sample26" with its value "cv$value".
 		fixedProbFlag$sample149 = (cv$value && fixedProbFlag$sample149);
+	}
+
+	// Getter for fixedFlag$sample82.
+	@Override
+	public final boolean get$fixedFlag$sample82() {
+		return fixedFlag$sample82;
+	}
+
+	// Setter for fixedFlag$sample82.
+	@Override
+	public final void set$fixedFlag$sample82(boolean cv$value) {
+		fixedFlag$sample82 = cv$value;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -1590,8 +1603,12 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 				// Substituted "sum" with its value "reduceVar$sum$4".
 				expedNorm[j$var63] = (exped[j$var63] / (r * reduceVar$sum$4));
 		}
-		for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
-			sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample82) {
+			for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
+				sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		}
 		for(int t$var105 = 0; t$var105 < T; t$var105 += 1) {
 			// Constraints moved from conditionals in inner loops/scopes/etc.
 			if(!fixedFlag$sample26) {
@@ -1711,8 +1728,12 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 		for(int j$var63 = 0; j$var63 < noProducts; j$var63 += 1)
 			// Substituted "sum" with its value "reduceVar$sum$5".
 			expedNorm[j$var63] = (exped[j$var63] / (r * reduceVar$sum$5));
-		for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
-			sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample82) {
+			for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
+				sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		}
 		for(int t$var105 = 0; t$var105 < T; t$var105 += 1) {
 			for(int j$var116 = 0; j$var116 < noProducts; j$var116 += 1)
 				weekly_ut[t$var105][j$var116] = (expedNorm[j$var116] * Avail[t$var105][j$var116]);
@@ -1973,7 +1994,8 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
-		// Propagating values back from observations into the models intermediate variables.
+		// Reset any fixed flags on observed values
+		fixedFlag$sample82 = false;
 		int cv$length1 = Sales.length;
 		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
 			int[] cv$source2 = ObsSales[cv$index1];

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$SingleThreadCPU_optimisedModelNoComments.java
@@ -11,6 +11,7 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 	private double[] exped;
 	private double[] expedNorm;
 	private boolean fixedFlag$sample26 = false;
+	private boolean fixedFlag$sample82 = false;
 	private boolean fixedProbFlag$sample149 = false;
 	private boolean fixedProbFlag$sample26 = false;
 	private boolean fixedProbFlag$sample82 = false;
@@ -102,6 +103,16 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 		fixedFlag$sample26 = cv$value;
 		fixedProbFlag$sample26 = (cv$value && fixedProbFlag$sample26);
 		fixedProbFlag$sample149 = (cv$value && fixedProbFlag$sample149);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample82() {
+		return fixedFlag$sample82;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample82(boolean cv$value) {
+		fixedFlag$sample82 = cv$value;
 	}
 
 	@Override
@@ -585,8 +596,10 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 			for(int j$var63 = 0; j$var63 < noProducts; j$var63 += 1)
 				expedNorm[j$var63] = (exped[j$var63] / (r * reduceVar$sum$4));
 		}
-		for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
-			sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		if(!fixedFlag$sample82) {
+			for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
+				sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		}
 		for(int t$var105 = 0; t$var105 < T; t$var105 += 1) {
 			if(!fixedFlag$sample26) {
 				for(int j$var116 = 0; j$var116 < noProducts; j$var116 += 1)
@@ -640,8 +653,10 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 		sum = reduceVar$sum$5;
 		for(int j$var63 = 0; j$var63 < noProducts; j$var63 += 1)
 			expedNorm[j$var63] = (exped[j$var63] / (r * reduceVar$sum$5));
-		for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
-			sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		if(!fixedFlag$sample82) {
+			for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
+				sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		}
 		for(int t$var105 = 0; t$var105 < T; t$var105 += 1) {
 			for(int j$var116 = 0; j$var116 < noProducts; j$var116 += 1)
 				weekly_ut[t$var105][j$var116] = (expedNorm[j$var116] * Avail[t$var105][j$var116]);
@@ -781,6 +796,7 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 
 	@Override
 	public final void propagateObservedValues() {
+		fixedFlag$sample82 = false;
 		int cv$length1 = Sales.length;
 		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
 			int[] cv$source2 = ObsSales[cv$index1];

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2$SingleThreadCPU_optimisedModelSingle.java
@@ -13,6 +13,7 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 	private double[] exped;
 	private double[] expedNorm;
 	private boolean fixedFlag$sample26 = false;
+	private boolean fixedFlag$sample82 = false;
 	private boolean fixedProbFlag$sample149 = false;
 	private boolean fixedProbFlag$sample26 = false;
 	private boolean fixedProbFlag$sample82 = false;
@@ -129,6 +130,18 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 		// 
 		// Substituted "fixedFlag$sample26" with its value "cv$value".
 		fixedProbFlag$sample149 = (cv$value && fixedProbFlag$sample149);
+	}
+
+	// Getter for fixedFlag$sample82.
+	@Override
+	public final boolean get$fixedFlag$sample82() {
+		return fixedFlag$sample82;
+	}
+
+	// Setter for fixedFlag$sample82.
+	@Override
+	public final void set$fixedFlag$sample82(boolean cv$value) {
+		fixedFlag$sample82 = cv$value;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -1633,8 +1646,12 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 				// Substituted "sum" with its value "reduceVar$sum$4".
 				expedNorm[j$var63] = (exped[j$var63] / (r * reduceVar$sum$4));
 		}
-		for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
-			sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample82) {
+			for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
+				sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		}
 		for(int t$var105 = 0; t$var105 < T; t$var105 += 1) {
 			// Constraints moved from conditionals in inner loops/scopes/etc.
 			if(!fixedFlag$sample26) {
@@ -1754,8 +1771,12 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 		for(int j$var63 = 0; j$var63 < noProducts; j$var63 += 1)
 			// Substituted "sum" with its value "reduceVar$sum$5".
 			expedNorm[j$var63] = (exped[j$var63] / (r * reduceVar$sum$5));
-		for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
-			sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample82) {
+			for(int t$var78 = 0; t$var78 < T; t$var78 += 1)
+				sales_sum[t$var78] = DistributionSampling.samplePoisson(RNG$, 0.5);
+		}
 		for(int t$var105 = 0; t$var105 < T; t$var105 += 1) {
 			for(int j$var116 = 0; j$var116 < noProducts; j$var116 += 1)
 				weekly_ut[t$var105][j$var116] = (expedNorm[j$var116] * Avail[t$var105][j$var116]);
@@ -2011,7 +2032,8 @@ class Vulcano2012basic2$SingleThreadCPU extends org.sandwood.runtime.internal.mo
 	// Method to propagate observed values back into the model.
 	@Override
 	public final void propagateObservedValues() {
-		// Propagating values back from observations into the models intermediate variables.
+		// Reset any fixed flags on observed values
+		fixedFlag$sample82 = false;
 		int cv$length1 = Sales.length;
 		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1) {
 			int[] cv$source2 = ObsSales[cv$index1];

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class Vulcano2012basic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -142,7 +143,7 @@ public class Vulcano2012basic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class Vulcano2012basic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -142,7 +143,7 @@ public class Vulcano2012basic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class Vulcano2012basic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -142,7 +143,7 @@ public class Vulcano2012basic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class Vulcano2012basic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -142,7 +143,7 @@ public class Vulcano2012basic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class Vulcano2012basic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -142,7 +143,7 @@ public class Vulcano2012basic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/Vulcano2012basic2/Vulcano2012basic2_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class Vulcano2012basic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -142,7 +143,7 @@ public class Vulcano2012basic2 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$CoreInterface_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$CoreInterface_model.java
@@ -2,12 +2,6 @@ package org.sandwood.compiler.tests.parser;
 
 interface Conditional1$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
 
-	// Getter for fixedFlag$sample16.
-	public boolean get$fixedFlag$sample16();
-
-	// Setter for fixedFlag$sample16.
-	public void set$fixedFlag$sample16(boolean cv$value);
-
 	// Getter for fixedFlag$sample4.
 	public boolean get$fixedFlag$sample4();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$CoreInterface_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$CoreInterface_modelNoComments.java
@@ -1,8 +1,6 @@
 package org.sandwood.compiler.tests.parser;
 
 interface Conditional1$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
-	public boolean get$fixedFlag$sample16();
-	public void set$fixedFlag$sample16(boolean cv$value);
 	public boolean get$fixedFlag$sample4();
 	public void set$fixedFlag$sample4(boolean cv$value);
 	public boolean get$guard();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$CoreInterface_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$CoreInterface_modelSingle.java
@@ -2,12 +2,6 @@ package org.sandwood.compiler.tests.parser;
 
 interface Conditional1$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
 
-	// Getter for fixedFlag$sample16.
-	public boolean get$fixedFlag$sample16();
-
-	// Setter for fixedFlag$sample16.
-	public void set$fixedFlag$sample16(boolean cv$value);
-
 	// Getter for fixedFlag$sample4.
 	public boolean get$fixedFlag$sample4();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$CoreInterface_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$CoreInterface_optimisedModel.java
@@ -2,12 +2,6 @@ package org.sandwood.compiler.tests.parser;
 
 interface Conditional1$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
 
-	// Getter for fixedFlag$sample16.
-	public boolean get$fixedFlag$sample16();
-
-	// Setter for fixedFlag$sample16.
-	public void set$fixedFlag$sample16(boolean cv$value);
-
 	// Getter for fixedFlag$sample4.
 	public boolean get$fixedFlag$sample4();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$CoreInterface_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$CoreInterface_optimisedModelNoComments.java
@@ -1,8 +1,6 @@
 package org.sandwood.compiler.tests.parser;
 
 interface Conditional1$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
-	public boolean get$fixedFlag$sample16();
-	public void set$fixedFlag$sample16(boolean cv$value);
 	public boolean get$fixedFlag$sample4();
 	public void set$fixedFlag$sample4(boolean cv$value);
 	public boolean get$guard();

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$CoreInterface_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$CoreInterface_optimisedModelSingle.java
@@ -2,12 +2,6 @@ package org.sandwood.compiler.tests.parser;
 
 interface Conditional1$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
 
-	// Getter for fixedFlag$sample16.
-	public boolean get$fixedFlag$sample16();
-
-	// Setter for fixedFlag$sample16.
-	public void set$fixedFlag$sample16(boolean cv$value);
-
 	// Getter for fixedFlag$sample4.
 	public boolean get$fixedFlag$sample4();
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$MultiThreadCPU_model.java
@@ -7,9 +7,7 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample16 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -29,24 +27,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		super(target);
 	}
 
-	// Getter for fixedFlag$sample16.
-	@Override
-	public final boolean get$fixedFlag$sample16() {
-		return fixedFlag$sample16;
-	}
-
-	// Setter for fixedFlag$sample16.
-	@Override
-	public final void set$fixedFlag$sample16(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample16 including if probabilities
-		// need to be updated.
-		fixedFlag$sample16 = cv$value;
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedProbFlag$sample16);
-	}
-
 	// Getter for fixedFlag$sample4.
 	@Override
 	public final boolean get$fixedFlag$sample4() {
@@ -63,10 +43,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// Should the probability of sample 4 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample4 = (fixedFlag$sample4 && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample16 = (fixedFlag$sample4 && fixedProbFlag$sample16);
 	}
 
 	// Getter for guard.
@@ -84,9 +60,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on guard.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -146,158 +119,101 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	// Setter for var14.
 	@Override
 	public final void set$var14(double cv$value) {
-		// Set flags for all the side effects of var14 including if probabilities need to
-		// be updated.
 		var14 = cv$value;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on var14.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = var14;
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = var14;
 					{
-						{
-							double var11 = 0.0;
-							double var12 = 1.0;
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((var11 <= cv$sampleValue) && (cv$sampleValue < var12))?(-Math.log((var12 - var11))):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var11 = 0.0;
+						double var12 = 1.0;
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((var11 <= cv$sampleValue) && (cv$sampleValue < var12))?(-Math.log((var12 - var11))):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var13 = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample16 = cv$sampleProbability;
-				
-				// Guard to ensure that value is only updated once for this probability.
-				boolean cv$guard$value = false;
-				
-				// Add probability to constructed variables that have guards, so need per sample probabilities
-				// from the combined probability
-				{
-					if(!guard) {
-						// If the probability of the variable has not already been updated
-						if(!cv$guard$value) {
-							// Set the guard so the update is only applied once.
-							cv$guard$value = true;
-							
-							// Update the variable probability
-							logProbability$value = (logProbability$value + cv$sampleProbability);
-						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedFlag$sample4);
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var13 = cv$sampleAccumulator;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample16;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var13 = cv$rvAccumulator;
-				
-				// Guard to ensure that value is only updated once for this probability.
-				boolean cv$guard$value = false;
-				
-				// Add probability to constructed variables that have guards, so need per sample probabilities
-				// from the combined probability
-				{
-					if(!guard) {
-						// If the probability of the variable has not already been updated
-						if(!cv$guard$value) {
-							// Set the guard so the update is only applied once.
-							cv$guard$value = true;
-							
-							// Update the variable probability
-							logProbability$value = (logProbability$value + cv$sampleValue);
-						}
+			// Store the sample task probability
+			logProbability$sample16 = cv$sampleProbability;
+			
+			// Guard to ensure that value is only updated once for this probability.
+			boolean cv$guard$value = false;
+			
+			// Add probability to constructed variables that have guards, so need per sample probabilities
+			// from the combined probability
+			{
+				if(!guard) {
+					// If the probability of the variable has not already been updated
+					if(!cv$guard$value) {
+						// Set the guard so the update is only applied once.
+						cv$guard$value = true;
+						
+						// Update the variable probability
+						logProbability$value = (logProbability$value + cv$sampleProbability);
 					}
 				}
 			}
-			
-			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		
+		// Update the variable probability
+		logProbability$var14 = (logProbability$var14 + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -601,10 +517,8 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			if(!fixedFlag$sample4)
 				value = 1.0;
 		} else {
-			if(!fixedFlag$sample16)
-				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample16))
-				value = var14;
+			var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value = var14;
 		}
 	}
 
@@ -616,17 +530,15 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						// Observation reached
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					// Observation reached
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -639,10 +551,8 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value = 1.0;
 		else {
-			if(!fixedFlag$sample16)
-				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample16))
-				value = var14;
+			var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value = var14;
 		}
 	}
 
@@ -653,17 +563,15 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						// Observation reached
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					// Observation reached
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -675,17 +583,15 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						// Observation reached
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					// Observation reached
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -728,8 +634,7 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		logProbability$var13 = Double.NaN;
 		logProbability$var14 = 0.0;
 		logProbability$value = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$MultiThreadCPU_modelNoComments.java
@@ -5,9 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 
 class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements Conditional1$CoreInterface {
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample16 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -28,17 +26,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	}
 
 	@Override
-	public final boolean get$fixedFlag$sample16() {
-		return fixedFlag$sample16;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample16(boolean cv$value) {
-		fixedFlag$sample16 = cv$value;
-		fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedProbFlag$sample16);
-	}
-
-	@Override
 	public final boolean get$fixedFlag$sample4() {
 		return fixedFlag$sample4;
 	}
@@ -47,7 +34,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	public final void set$fixedFlag$sample4(boolean cv$value) {
 		fixedFlag$sample4 = cv$value;
 		fixedProbFlag$sample4 = (fixedFlag$sample4 && fixedProbFlag$sample4);
-		fixedProbFlag$sample16 = (fixedFlag$sample4 && fixedProbFlag$sample16);
 	}
 
 	@Override
@@ -59,7 +45,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	public final void set$guard(boolean cv$value) {
 		guard = cv$value;
 		fixedProbFlag$sample4 = false;
-		fixedProbFlag$sample16 = false;
 	}
 
 	@Override
@@ -110,84 +95,57 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	@Override
 	public final void set$var14(double cv$value) {
 		var14 = cv$value;
-		fixedProbFlag$sample16 = false;
 	}
 
 	private final void logProbabilityValue$sample16() {
-		if(!fixedProbFlag$sample16) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				double cv$sampleValue = var14;
 				{
-					double cv$sampleValue = var14;
 					{
-						{
-							double var11 = 0.0;
-							double var12 = 1.0;
-							double cv$weightedProbability = (Math.log(1.0) + (((var11 <= cv$sampleValue) && (cv$sampleValue < var12))?(-Math.log((var12 - var11))):Double.NEGATIVE_INFINITY));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var11 = 0.0;
+						double var12 = 1.0;
+						double cv$weightedProbability = (Math.log(1.0) + (((var11 <= cv$sampleValue) && (cv$sampleValue < var12))?(-Math.log((var12 - var11))):Double.NEGATIVE_INFINITY));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var13 = cv$sampleAccumulator;
-				logProbability$sample16 = cv$sampleProbability;
-				boolean cv$guard$value = false;
-				{
-					if(!guard) {
-						if(!cv$guard$value) {
-							cv$guard$value = true;
-							logProbability$value = (logProbability$value + cv$sampleProbability);
-						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
 			}
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedFlag$sample4);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample16;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var13 = cv$rvAccumulator;
-				boolean cv$guard$value = false;
-				{
-					if(!guard) {
-						if(!cv$guard$value) {
-							cv$guard$value = true;
-							logProbability$value = (logProbability$value + cv$sampleValue);
-						}
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var13 = cv$sampleAccumulator;
+			logProbability$sample16 = cv$sampleProbability;
+			boolean cv$guard$value = false;
+			{
+				if(!guard) {
+					if(!cv$guard$value) {
+						cv$guard$value = true;
+						logProbability$value = (logProbability$value + cv$sampleProbability);
 					}
 				}
 			}
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		logProbability$var14 = (logProbability$var14 + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample4() {
@@ -364,10 +322,8 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			if(!fixedFlag$sample4)
 				value = 1.0;
 		} else {
-			if(!fixedFlag$sample16)
-				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample16))
-				value = var14;
+			var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value = var14;
 		}
 	}
 
@@ -376,15 +332,13 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -395,10 +349,8 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value = 1.0;
 		else {
-			if(!fixedFlag$sample16)
-				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample16))
-				value = var14;
+			var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value = var14;
 		}
 	}
 
@@ -407,15 +359,13 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -424,15 +374,13 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -460,8 +408,7 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		logProbability$var13 = Double.NaN;
 		logProbability$var14 = 0.0;
 		logProbability$value = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	@Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$MultiThreadCPU_modelSingle.java
@@ -7,9 +7,7 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample16 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -29,24 +27,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		super(target);
 	}
 
-	// Getter for fixedFlag$sample16.
-	@Override
-	public final boolean get$fixedFlag$sample16() {
-		return fixedFlag$sample16;
-	}
-
-	// Setter for fixedFlag$sample16.
-	@Override
-	public final void set$fixedFlag$sample16(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample16 including if probabilities
-		// need to be updated.
-		fixedFlag$sample16 = cv$value;
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedProbFlag$sample16);
-	}
-
 	// Getter for fixedFlag$sample4.
 	@Override
 	public final boolean get$fixedFlag$sample4() {
@@ -63,10 +43,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// Should the probability of sample 4 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample4 = (fixedFlag$sample4 && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample16 = (fixedFlag$sample4 && fixedProbFlag$sample16);
 	}
 
 	// Getter for guard.
@@ -84,9 +60,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on guard.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -146,163 +119,105 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	// Setter for var14.
 	@Override
 	public final void set$var14(double cv$value) {
-		// Set flags for all the side effects of var14 including if probabilities need to
-		// be updated.
 		var14 = cv$value;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on var14.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = var14;
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = var14;
 					{
-						{
-							double var11 = 0.0;
-							double var12 = 1.0;
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((var11 <= cv$sampleValue) && (cv$sampleValue < var12))?(-Math.log((var12 - var11))):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var11 = 0.0;
+						double var12 = 1.0;
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((var11 <= cv$sampleValue) && (cv$sampleValue < var12))?(-Math.log((var12 - var11))):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Only update the sample if it was reached, otherwise the NaN will be
-				// erroneously over written.
-				if(cv$sampleReached)
-					// Store the sample task probability
-					logProbability$sample16 = cv$sampleProbability;
-				
-				// Guard to ensure that value is only updated once for this probability.
-				boolean cv$guard$value = false;
-				
-				// Add probability to constructed variables that have guards, so need per sample probabilities
-				// from the combined probability
-				{
-					if(!guard) {
-						// If the probability of the variable has not already been updated
-						if(!cv$guard$value) {
-							// Set the guard so the update is only applied once.
-							cv$guard$value = true;
-							
-							// Update the variable probability
-							logProbability$value = (logProbability$value + cv$sampleProbability);
-						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			
+			// Only update the sample if it was reached, otherwise the NaN will be
+			// erroneously over written.
 			if(cv$sampleReached)
-				logProbability$var13 = cv$sampleAccumulator;
+				// Store the sample task probability
+				logProbability$sample16 = cv$sampleProbability;
 			
-			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
+			// Guard to ensure that value is only updated once for this probability.
+			boolean cv$guard$value = false;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedFlag$sample4);
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$sampleValue = logProbability$sample16;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Guard to ensure that value is only updated once for this probability.
-				boolean cv$guard$value = false;
-				
-				// Add probability to constructed variables that have guards, so need per sample probabilities
-				// from the combined probability
-				{
-					if(!guard) {
-						// If the probability of the variable has not already been updated
-						if(!cv$guard$value) {
-							// Set the guard so the update is only applied once.
-							cv$guard$value = true;
-							
-							// Update the variable probability
-							logProbability$value = (logProbability$value + cv$sampleValue);
-						}
+			// Add probability to constructed variables that have guards, so need per sample probabilities
+			// from the combined probability
+			{
+				if(!guard) {
+					// If the probability of the variable has not already been updated
+					if(!cv$guard$value) {
+						// Set the guard so the update is only applied once.
+						cv$guard$value = true;
+						
+						// Update the variable probability
+						logProbability$value = (logProbability$value + cv$sampleProbability);
 					}
 				}
 			}
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var13 = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var13 = cv$sampleAccumulator;
+		
+		// Update the variable probability
+		logProbability$var14 = (logProbability$var14 + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -606,10 +521,8 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			if(!fixedFlag$sample4)
 				value = 1.0;
 		} else {
-			if(!fixedFlag$sample16)
-				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample16))
-				value = var14;
+			var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value = var14;
 		}
 	}
 
@@ -621,17 +534,15 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						// Observation reached
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					// Observation reached
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -644,10 +555,8 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value = 1.0;
 		else {
-			if(!fixedFlag$sample16)
-				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample16))
-				value = var14;
+			var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value = var14;
 		}
 	}
 
@@ -658,17 +567,15 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						// Observation reached
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					// Observation reached
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -680,17 +587,15 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						// Observation reached
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					// Observation reached
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -733,8 +638,7 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		logProbability$var13 = Double.NaN;
 		logProbability$var14 = 0.0;
 		logProbability$value = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$MultiThreadCPU_optimisedModel.java
@@ -7,9 +7,7 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample16 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -27,26 +25,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 
 	public Conditional1$MultiThreadCPU(ExecutionTarget target) {
 		super(target);
-	}
-
-	// Getter for fixedFlag$sample16.
-	@Override
-	public final boolean get$fixedFlag$sample16() {
-		return fixedFlag$sample16;
-	}
-
-	// Setter for fixedFlag$sample16.
-	@Override
-	public final void set$fixedFlag$sample16(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample16 including if probabilities
-		// need to be updated.
-		fixedFlag$sample16 = cv$value;
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample16" with its value "cv$value".
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	// Getter for fixedFlag$sample4.
@@ -67,12 +45,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// 
 		// Substituted "fixedFlag$sample4" with its value "cv$value".
 		fixedProbFlag$sample4 = (cv$value && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample4" with its value "cv$value".
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	// Getter for guard.
@@ -90,9 +62,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on guard.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -152,102 +121,69 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	// Setter for var14.
 	@Override
 	public final void set$var14(double cv$value) {
-		// Set flags for all the side effects of var14 including if probabilities need to
-		// be updated.
 		var14 = cv$value;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on var14.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		if(!guard) {
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = (((0.0 <= var14) && (var14 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
 			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = (((0.0 <= var14) && (var14 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = cv$distributionAccumulator;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var13 = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample16 = cv$distributionAccumulator;
-				
-				// Update the variable probability
-				logProbability$value = (logProbability$value + cv$distributionAccumulator);
-			}
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = cv$distributionAccumulator;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var13 = cv$distributionAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample16 = cv$distributionAccumulator;
 			
 			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedFlag$sample4);
+			logProbability$value = (logProbability$value + cv$distributionAccumulator);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				cv$accumulator = logProbability$sample16;
-				logProbability$var13 = logProbability$sample16;
-				
-				// Update the variable probability
-				logProbability$value = (logProbability$value + logProbability$sample16);
-			}
-			
-			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$var14 = (logProbability$var14 + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -535,10 +471,8 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			if(!fixedFlag$sample4)
 				value = 1.0;
 		} else {
-			if(!fixedFlag$sample16)
-				var14 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample16))
-				value = var14;
+			var14 = DistributionSampling.sampleUniform(RNG$);
+			value = var14;
 		}
 	}
 
@@ -560,10 +494,8 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value = 1.0;
 		else {
-			if(!fixedFlag$sample16)
-				var14 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample16))
-				value = var14;
+			var14 = DistributionSampling.sampleUniform(RNG$);
+			value = var14;
 		}
 	}
 
@@ -616,8 +548,7 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		logProbability$var13 = Double.NaN;
 		logProbability$var14 = 0.0;
 		logProbability$value = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$MultiThreadCPU_optimisedModelNoComments.java
@@ -5,9 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 
 class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements Conditional1$CoreInterface {
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample16 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -28,17 +26,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	}
 
 	@Override
-	public final boolean get$fixedFlag$sample16() {
-		return fixedFlag$sample16;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample16(boolean cv$value) {
-		fixedFlag$sample16 = cv$value;
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
-	}
-
-	@Override
 	public final boolean get$fixedFlag$sample4() {
 		return fixedFlag$sample4;
 	}
@@ -47,7 +34,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	public final void set$fixedFlag$sample4(boolean cv$value) {
 		fixedFlag$sample4 = cv$value;
 		fixedProbFlag$sample4 = (cv$value && fixedProbFlag$sample4);
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	@Override
@@ -59,7 +45,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	public final void set$guard(boolean cv$value) {
 		guard = cv$value;
 		fixedProbFlag$sample4 = false;
-		fixedProbFlag$sample16 = false;
 	}
 
 	@Override
@@ -110,34 +95,20 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	@Override
 	public final void set$var14(double cv$value) {
 		var14 = cv$value;
-		fixedProbFlag$sample16 = false;
 	}
 
 	private final void logProbabilityValue$sample16() {
-		if(!fixedProbFlag$sample16) {
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				double cv$distributionAccumulator = (((0.0 <= var14) && (var14 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
-				cv$accumulator = cv$distributionAccumulator;
-				logProbability$var13 = cv$distributionAccumulator;
-				logProbability$sample16 = cv$distributionAccumulator;
-				logProbability$value = (logProbability$value + cv$distributionAccumulator);
-			}
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedFlag$sample4);
-		} else {
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				cv$accumulator = logProbability$sample16;
-				logProbability$var13 = logProbability$sample16;
-				logProbability$value = (logProbability$value + logProbability$sample16);
-			}
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		if(!guard) {
+			double cv$distributionAccumulator = (((0.0 <= var14) && (var14 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
+			cv$accumulator = cv$distributionAccumulator;
+			logProbability$var13 = cv$distributionAccumulator;
+			logProbability$sample16 = cv$distributionAccumulator;
+			logProbability$value = (logProbability$value + cv$distributionAccumulator);
 		}
+		logProbability$var14 = (logProbability$var14 + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample4() {
@@ -206,10 +177,8 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			if(!fixedFlag$sample4)
 				value = 1.0;
 		} else {
-			if(!fixedFlag$sample16)
-				var14 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample16))
-				value = var14;
+			var14 = DistributionSampling.sampleUniform(RNG$);
+			value = var14;
 		}
 	}
 
@@ -226,10 +195,8 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value = 1.0;
 		else {
-			if(!fixedFlag$sample16)
-				var14 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample16))
-				value = var14;
+			var14 = DistributionSampling.sampleUniform(RNG$);
+			value = var14;
 		}
 	}
 
@@ -264,8 +231,7 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		logProbability$var13 = Double.NaN;
 		logProbability$var14 = 0.0;
 		logProbability$value = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	@Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$MultiThreadCPU_optimisedModelSingle.java
@@ -7,9 +7,7 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample16 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -27,26 +25,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 
 	public Conditional1$MultiThreadCPU(ExecutionTarget target) {
 		super(target);
-	}
-
-	// Getter for fixedFlag$sample16.
-	@Override
-	public final boolean get$fixedFlag$sample16() {
-		return fixedFlag$sample16;
-	}
-
-	// Setter for fixedFlag$sample16.
-	@Override
-	public final void set$fixedFlag$sample16(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample16 including if probabilities
-		// need to be updated.
-		fixedFlag$sample16 = cv$value;
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample16" with its value "cv$value".
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	// Getter for fixedFlag$sample4.
@@ -67,12 +45,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		// 
 		// Substituted "fixedFlag$sample4" with its value "cv$value".
 		fixedProbFlag$sample4 = (cv$value && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample4" with its value "cv$value".
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	// Getter for guard.
@@ -90,9 +62,6 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on guard.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -152,122 +121,82 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 	// Setter for var14.
 	@Override
 	public final void set$var14(double cv$value) {
-		// Set flags for all the side effects of var14 including if probabilities need to
-		// be updated.
 		var14 = cv$value;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on var14.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = (((0.0 <= var14) && (var14 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
+			
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
 			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+			cv$sampleAccumulator = cv$distributionAccumulator;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = (((0.0 <= var14) && (var14 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$sampleAccumulator = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample16 = cv$distributionAccumulator;
-				
-				// Update the variable probability
-				logProbability$value = (logProbability$value + cv$distributionAccumulator);
-			}
-			if(cv$sampleReached)
-				logProbability$var13 = cv$sampleAccumulator;
+			// Store the sample task probability
+			logProbability$sample16 = cv$distributionAccumulator;
 			
 			// Update the variable probability
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$var14 = (logProbability$var14 + cv$sampleAccumulator);
-			
-			// Add probability to model
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedFlag$sample4);
+			logProbability$value = (logProbability$value + cv$distributionAccumulator);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				cv$rvAccumulator = logProbability$sample16;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Update the variable probability
-				logProbability$value = (logProbability$value + logProbability$sample16);
-			}
-			if(cv$sampleReached)
-				logProbability$var13 = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$rvAccumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$rvAccumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$rvAccumulator);
-		}
+		if(cv$sampleReached)
+			logProbability$var13 = cv$sampleAccumulator;
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$var14 = (logProbability$var14 + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -555,10 +484,8 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 			if(!fixedFlag$sample4)
 				value = 1.0;
 		} else {
-			if(!fixedFlag$sample16)
-				var14 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample16))
-				value = var14;
+			var14 = DistributionSampling.sampleUniform(RNG$);
+			value = var14;
 		}
 	}
 
@@ -580,10 +507,8 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		if(guard)
 			value = 1.0;
 		else {
-			if(!fixedFlag$sample16)
-				var14 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample16))
-				value = var14;
+			var14 = DistributionSampling.sampleUniform(RNG$);
+			value = var14;
 		}
 	}
 
@@ -636,8 +561,7 @@ class Conditional1$MultiThreadCPU extends org.sandwood.runtime.internal.model.Co
 		logProbability$var13 = Double.NaN;
 		logProbability$var14 = 0.0;
 		logProbability$value = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$SingleThreadCPU_model.java
@@ -7,9 +7,7 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample16 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -29,24 +27,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		super(target);
 	}
 
-	// Getter for fixedFlag$sample16.
-	@Override
-	public final boolean get$fixedFlag$sample16() {
-		return fixedFlag$sample16;
-	}
-
-	// Setter for fixedFlag$sample16.
-	@Override
-	public final void set$fixedFlag$sample16(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample16 including if probabilities
-		// need to be updated.
-		fixedFlag$sample16 = cv$value;
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedProbFlag$sample16);
-	}
-
 	// Getter for fixedFlag$sample4.
 	@Override
 	public final boolean get$fixedFlag$sample4() {
@@ -63,10 +43,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		// Should the probability of sample 4 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample4 = (fixedFlag$sample4 && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample16 = (fixedFlag$sample4 && fixedProbFlag$sample16);
 	}
 
 	// Getter for guard.
@@ -84,9 +60,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on guard.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -146,158 +119,101 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for var14.
 	@Override
 	public final void set$var14(double cv$value) {
-		// Set flags for all the side effects of var14 including if probabilities need to
-		// be updated.
 		var14 = cv$value;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on var14.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				double cv$sampleAccumulator = 0.0;
-				
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = var14;
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = var14;
 					{
-						{
-							double var11 = 0.0;
-							double var12 = 1.0;
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((var11 <= cv$sampleValue) && (cv$sampleValue < var12))?(-Math.log((var12 - var11))):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var11 = 0.0;
+						double var12 = 1.0;
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((var11 <= cv$sampleValue) && (cv$sampleValue < var12))?(-Math.log((var12 - var11))):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var13 = cv$sampleAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample16 = cv$sampleProbability;
-				
-				// Guard to ensure that value is only updated once for this probability.
-				boolean cv$guard$value = false;
-				
-				// Add probability to constructed variables that have guards, so need per sample probabilities
-				// from the combined probability
-				{
-					if(!guard) {
-						// If the probability of the variable has not already been updated
-						if(!cv$guard$value) {
-							// Set the guard so the update is only applied once.
-							cv$guard$value = true;
-							
-							// Update the variable probability
-							logProbability$value = (logProbability$value + cv$sampleProbability);
-						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
 			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedFlag$sample4);
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var13 = cv$sampleAccumulator;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample16;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var13 = cv$rvAccumulator;
-				
-				// Guard to ensure that value is only updated once for this probability.
-				boolean cv$guard$value = false;
-				
-				// Add probability to constructed variables that have guards, so need per sample probabilities
-				// from the combined probability
-				{
-					if(!guard) {
-						// If the probability of the variable has not already been updated
-						if(!cv$guard$value) {
-							// Set the guard so the update is only applied once.
-							cv$guard$value = true;
-							
-							// Update the variable probability
-							logProbability$value = (logProbability$value + cv$sampleValue);
-						}
+			// Store the sample task probability
+			logProbability$sample16 = cv$sampleProbability;
+			
+			// Guard to ensure that value is only updated once for this probability.
+			boolean cv$guard$value = false;
+			
+			// Add probability to constructed variables that have guards, so need per sample probabilities
+			// from the combined probability
+			{
+				if(!guard) {
+					// If the probability of the variable has not already been updated
+					if(!cv$guard$value) {
+						// Set the guard so the update is only applied once.
+						cv$guard$value = true;
+						
+						// Update the variable probability
+						logProbability$value = (logProbability$value + cv$sampleProbability);
 					}
 				}
 			}
-			
-			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		
+		// Update the variable probability
+		logProbability$var14 = (logProbability$var14 + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -601,10 +517,8 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			if(!fixedFlag$sample4)
 				value = 1.0;
 		} else {
-			if(!fixedFlag$sample16)
-				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample16))
-				value = var14;
+			var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value = var14;
 		}
 	}
 
@@ -616,17 +530,15 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						// Observation reached
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					// Observation reached
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -639,10 +551,8 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value = 1.0;
 		else {
-			if(!fixedFlag$sample16)
-				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample16))
-				value = var14;
+			var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value = var14;
 		}
 	}
 
@@ -653,17 +563,15 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						// Observation reached
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					// Observation reached
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -675,17 +583,15 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						// Observation reached
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					// Observation reached
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -728,8 +634,7 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$var13 = Double.NaN;
 		logProbability$var14 = 0.0;
 		logProbability$value = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$SingleThreadCPU_modelNoComments.java
@@ -5,9 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 
 class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements Conditional1$CoreInterface {
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample16 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -28,17 +26,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	}
 
 	@Override
-	public final boolean get$fixedFlag$sample16() {
-		return fixedFlag$sample16;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample16(boolean cv$value) {
-		fixedFlag$sample16 = cv$value;
-		fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedProbFlag$sample16);
-	}
-
-	@Override
 	public final boolean get$fixedFlag$sample4() {
 		return fixedFlag$sample4;
 	}
@@ -47,7 +34,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void set$fixedFlag$sample4(boolean cv$value) {
 		fixedFlag$sample4 = cv$value;
 		fixedProbFlag$sample4 = (fixedFlag$sample4 && fixedProbFlag$sample4);
-		fixedProbFlag$sample16 = (fixedFlag$sample4 && fixedProbFlag$sample16);
 	}
 
 	@Override
@@ -59,7 +45,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void set$guard(boolean cv$value) {
 		guard = cv$value;
 		fixedProbFlag$sample4 = false;
-		fixedProbFlag$sample16 = false;
 	}
 
 	@Override
@@ -110,84 +95,57 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$var14(double cv$value) {
 		var14 = cv$value;
-		fixedProbFlag$sample16 = false;
 	}
 
 	private final void logProbabilityValue$sample16() {
-		if(!fixedProbFlag$sample16) {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$sampleAccumulator = 0.0;
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				double cv$probabilityReached = 0.0;
+		double cv$accumulator = 0.0;
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				double cv$sampleValue = var14;
 				{
-					double cv$sampleValue = var14;
 					{
-						{
-							double var11 = 0.0;
-							double var12 = 1.0;
-							double cv$weightedProbability = (Math.log(1.0) + (((var11 <= cv$sampleValue) && (cv$sampleValue < var12))?(-Math.log((var12 - var11))):Double.NEGATIVE_INFINITY));
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var11 = 0.0;
+						double var12 = 1.0;
+						double cv$weightedProbability = (Math.log(1.0) + (((var11 <= cv$sampleValue) && (cv$sampleValue < var12))?(-Math.log((var12 - var11))):Double.NEGATIVE_INFINITY));
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				cv$sampleReached = true;
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
-				logProbability$var13 = cv$sampleAccumulator;
-				logProbability$sample16 = cv$sampleProbability;
-				boolean cv$guard$value = false;
-				{
-					if(!guard) {
-						if(!cv$guard$value) {
-							cv$guard$value = true;
-							logProbability$value = (logProbability$value + cv$sampleProbability);
-						}
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
 			}
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedFlag$sample4);
-		} else {
-			double cv$accumulator = 0.0;
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$rvAccumulator = 0.0;
-				double cv$sampleValue = logProbability$sample16;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				cv$sampleReached = true;
-				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-				logProbability$var13 = cv$rvAccumulator;
-				boolean cv$guard$value = false;
-				{
-					if(!guard) {
-						if(!cv$guard$value) {
-							cv$guard$value = true;
-							logProbability$value = (logProbability$value + cv$sampleValue);
-						}
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleReached = true;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var13 = cv$sampleAccumulator;
+			logProbability$sample16 = cv$sampleProbability;
+			boolean cv$guard$value = false;
+			{
+				if(!guard) {
+					if(!cv$guard$value) {
+						cv$guard$value = true;
+						logProbability$value = (logProbability$value + cv$sampleProbability);
 					}
 				}
 			}
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		logProbability$var14 = (logProbability$var14 + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample4() {
@@ -364,10 +322,8 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			if(!fixedFlag$sample4)
 				value = 1.0;
 		} else {
-			if(!fixedFlag$sample16)
-				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample16))
-				value = var14;
+			var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value = var14;
 		}
 	}
 
@@ -376,15 +332,13 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -395,10 +349,8 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value = 1.0;
 		else {
-			if(!fixedFlag$sample16)
-				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample16))
-				value = var14;
+			var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value = var14;
 		}
 	}
 
@@ -407,15 +359,13 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -424,15 +374,13 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -460,8 +408,7 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$var13 = Double.NaN;
 		logProbability$var14 = 0.0;
 		logProbability$value = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	@Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$SingleThreadCPU_modelSingle.java
@@ -7,9 +7,7 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample16 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -29,24 +27,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		super(target);
 	}
 
-	// Getter for fixedFlag$sample16.
-	@Override
-	public final boolean get$fixedFlag$sample16() {
-		return fixedFlag$sample16;
-	}
-
-	// Setter for fixedFlag$sample16.
-	@Override
-	public final void set$fixedFlag$sample16(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample16 including if probabilities
-		// need to be updated.
-		fixedFlag$sample16 = cv$value;
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedProbFlag$sample16);
-	}
-
 	// Getter for fixedFlag$sample4.
 	@Override
 	public final boolean get$fixedFlag$sample4() {
@@ -63,10 +43,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		// Should the probability of sample 4 be set to fixed. This will only every change
 		// the flag to false.
 		fixedProbFlag$sample4 = (fixedFlag$sample4 && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		fixedProbFlag$sample16 = (fixedFlag$sample4 && fixedProbFlag$sample16);
 	}
 
 	// Getter for guard.
@@ -84,9 +60,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on guard.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -146,163 +119,105 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for var14.
 	@Override
 	public final void set$var14(double cv$value) {
-		// Set flags for all the side effects of var14 including if probabilities need to
-		// be updated.
 		var14 = cv$value;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on var14.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
-			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
 			
-			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				// An accumulator for log probabilities.
-				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				
-				// An accumulator for the distributed probability space covered.
-				double cv$probabilityReached = 0.0;
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = var14;
 				{
-					// The sample value to calculate the probability of generating
-					double cv$sampleValue = var14;
 					{
-						{
-							double var11 = 0.0;
-							double var12 = 1.0;
-							
-							// Store the value of the function call, so the function call is only made once.
-							double cv$weightedProbability = (Math.log(1.0) + (((var11 <= cv$sampleValue) && (cv$sampleValue < var12))?(-Math.log((var12 - var11))):Double.NEGATIVE_INFINITY));
-							
-							// Add the probability of this sample task to the distribution accumulator.
-							if((cv$weightedProbability < cv$distributionAccumulator))
-								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
-							else {
-								// If the second value is -infinity.
-								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
-									cv$distributionAccumulator = cv$weightedProbability;
-								else
-									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
-							}
-							
-							// Add the probability of this distribution configuration to the accumulator.
-							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						double var11 = 0.0;
+						double var12 = 1.0;
+						
+						// Store the value of the function call, so the function call is only made once.
+						double cv$weightedProbability = (Math.log(1.0) + (((var11 <= cv$sampleValue) && (cv$sampleValue < var12))?(-Math.log((var12 - var11))):Double.NEGATIVE_INFINITY));
+						
+						// Add the probability of this sample task to the distribution accumulator.
+						if((cv$weightedProbability < cv$distributionAccumulator))
+							cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+						else {
+							// If the second value is -infinity.
+							if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+								cv$distributionAccumulator = cv$weightedProbability;
+							else
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
 						}
-					}
-				}
-				if((cv$probabilityReached == 0.0))
-					// Return negative infinity if no distribution probability space is reached.
-					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
-				else
-					// Scale the probability relative to the observed distribution space.
-					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
-				double cv$sampleProbability = cv$distributionAccumulator;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
-				
-				// Only update the sample if it was reached, otherwise the NaN will be
-				// erroneously over written.
-				if(cv$sampleReached)
-					// Store the sample task probability
-					logProbability$sample16 = cv$sampleProbability;
-				
-				// Guard to ensure that value is only updated once for this probability.
-				boolean cv$guard$value = false;
-				
-				// Add probability to constructed variables that have guards, so need per sample probabilities
-				// from the combined probability
-				{
-					if(!guard) {
-						// If the probability of the variable has not already been updated
-						if(!cv$guard$value) {
-							// Set the guard so the update is only applied once.
-							cv$guard$value = true;
-							
-							// Update the variable probability
-							logProbability$value = (logProbability$value + cv$sampleProbability);
-						}
+						
+						// Add the probability of this distribution configuration to the accumulator.
+						cv$probabilityReached = (cv$probabilityReached + 1.0);
 					}
 				}
 			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
 			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			
+			// Only update the sample if it was reached, otherwise the NaN will be
+			// erroneously over written.
 			if(cv$sampleReached)
-				logProbability$var13 = cv$sampleAccumulator;
+				// Store the sample task probability
+				logProbability$sample16 = cv$sampleProbability;
 			
-			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
+			// Guard to ensure that value is only updated once for this probability.
+			boolean cv$guard$value = false;
 			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedFlag$sample4);
-		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				double cv$sampleValue = logProbability$sample16;
-				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Guard to ensure that value is only updated once for this probability.
-				boolean cv$guard$value = false;
-				
-				// Add probability to constructed variables that have guards, so need per sample probabilities
-				// from the combined probability
-				{
-					if(!guard) {
-						// If the probability of the variable has not already been updated
-						if(!cv$guard$value) {
-							// Set the guard so the update is only applied once.
-							cv$guard$value = true;
-							
-							// Update the variable probability
-							logProbability$value = (logProbability$value + cv$sampleValue);
-						}
+			// Add probability to constructed variables that have guards, so need per sample probabilities
+			// from the combined probability
+			{
+				if(!guard) {
+					// If the probability of the variable has not already been updated
+					if(!cv$guard$value) {
+						// Set the guard so the update is only applied once.
+						cv$guard$value = true;
+						
+						// Update the variable probability
+						logProbability$value = (logProbability$value + cv$sampleProbability);
 					}
 				}
 			}
-			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
-			if(cv$sampleReached)
-				logProbability$var13 = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 		}
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+		if(cv$sampleReached)
+			logProbability$var13 = cv$sampleAccumulator;
+		
+		// Update the variable probability
+		logProbability$var14 = (logProbability$var14 + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -606,10 +521,8 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			if(!fixedFlag$sample4)
 				value = 1.0;
 		} else {
-			if(!fixedFlag$sample16)
-				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample16))
-				value = var14;
+			var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value = var14;
 		}
 	}
 
@@ -621,17 +534,15 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						// Observation reached
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					// Observation reached
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -644,10 +555,8 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value = 1.0;
 		else {
-			if(!fixedFlag$sample16)
-				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
-			if(!(fixedFlag$sample4 && fixedFlag$sample16))
-				value = var14;
+			var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			value = var14;
 		}
 	}
 
@@ -658,17 +567,15 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						// Observation reached
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					// Observation reached
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -680,17 +587,15 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(!fixedFlag$sample4)
 			guard = DistributionSampling.sampleBernoulli(RNG$, 0.5);
 		if(!guard) {
-			if(!fixedFlag$sample16) {
-				// Track if it is possible to reach an observed variable
-				boolean observationGuard$var14 = false;
-				{
-					if(!guard)
-						// Observation reached
-						observationGuard$var14 = true;
-				}
-				if(!observationGuard$var14)
-					var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
+			// Track if it is possible to reach an observed variable
+			boolean observationGuard$var14 = false;
+			{
+				if(!guard)
+					// Observation reached
+					observationGuard$var14 = true;
 			}
+			if(!observationGuard$var14)
+				var14 = (0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$)));
 		}
 	}
 
@@ -733,8 +638,7 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$var13 = Double.NaN;
 		logProbability$var14 = 0.0;
 		logProbability$value = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$SingleThreadCPU_optimisedModel.java
@@ -7,9 +7,7 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample16 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -27,26 +25,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	public Conditional1$SingleThreadCPU(ExecutionTarget target) {
 		super(target);
-	}
-
-	// Getter for fixedFlag$sample16.
-	@Override
-	public final boolean get$fixedFlag$sample16() {
-		return fixedFlag$sample16;
-	}
-
-	// Setter for fixedFlag$sample16.
-	@Override
-	public final void set$fixedFlag$sample16(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample16 including if probabilities
-		// need to be updated.
-		fixedFlag$sample16 = cv$value;
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample16" with its value "cv$value".
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	// Getter for fixedFlag$sample4.
@@ -67,12 +45,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		// 
 		// Substituted "fixedFlag$sample4" with its value "cv$value".
 		fixedProbFlag$sample4 = (cv$value && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample4" with its value "cv$value".
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	// Getter for guard.
@@ -90,9 +62,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on guard.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -152,102 +121,69 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for var14.
 	@Override
 	public final void set$var14(double cv$value) {
-		// Set flags for all the side effects of var14 including if probabilities need to
-		// be updated.
 		var14 = cv$value;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on var14.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for probabilities of instances of the random variable
+		double cv$accumulator = 0.0;
+		if(!guard) {
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = (((0.0 <= var14) && (var14 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
 			// Accumulator for probabilities of instances of the random variable
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = (((0.0 <= var14) && (var14 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
-				
-				// Add the probability of this instance of the random variable to the probability
-				// of all instances of the random variable.
-				// 
-				// Accumulator for probabilities of instances of the random variable
-				// 
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$accumulator = cv$distributionAccumulator;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				logProbability$var13 = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample16 = cv$distributionAccumulator;
-				
-				// Update the variable probability
-				logProbability$value = (logProbability$value + cv$distributionAccumulator);
-			}
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			cv$accumulator = cv$distributionAccumulator;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$var13 = cv$distributionAccumulator;
+			
+			// Store the sample task probability
+			logProbability$sample16 = cv$distributionAccumulator;
 			
 			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedFlag$sample4);
+			logProbability$value = (logProbability$value + cv$distributionAccumulator);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				cv$accumulator = logProbability$sample16;
-				logProbability$var13 = logProbability$sample16;
-				
-				// Update the variable probability
-				logProbability$value = (logProbability$value + logProbability$sample16);
-			}
-			
-			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-		}
+		
+		// Update the variable probability
+		logProbability$var14 = (logProbability$var14 + cv$accumulator);
+		
+		// Add probability to model
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -535,10 +471,8 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			if(!fixedFlag$sample4)
 				value = 1.0;
 		} else {
-			if(!fixedFlag$sample16)
-				var14 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample16))
-				value = var14;
+			var14 = DistributionSampling.sampleUniform(RNG$);
+			value = var14;
 		}
 	}
 
@@ -560,10 +494,8 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value = 1.0;
 		else {
-			if(!fixedFlag$sample16)
-				var14 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample16))
-				value = var14;
+			var14 = DistributionSampling.sampleUniform(RNG$);
+			value = var14;
 		}
 	}
 
@@ -616,8 +548,7 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$var13 = Double.NaN;
 		logProbability$var14 = 0.0;
 		logProbability$value = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$SingleThreadCPU_optimisedModelNoComments.java
@@ -5,9 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 
 class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements Conditional1$CoreInterface {
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample16 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -28,17 +26,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	}
 
 	@Override
-	public final boolean get$fixedFlag$sample16() {
-		return fixedFlag$sample16;
-	}
-
-	@Override
-	public final void set$fixedFlag$sample16(boolean cv$value) {
-		fixedFlag$sample16 = cv$value;
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
-	}
-
-	@Override
 	public final boolean get$fixedFlag$sample4() {
 		return fixedFlag$sample4;
 	}
@@ -47,7 +34,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void set$fixedFlag$sample4(boolean cv$value) {
 		fixedFlag$sample4 = cv$value;
 		fixedProbFlag$sample4 = (cv$value && fixedProbFlag$sample4);
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	@Override
@@ -59,7 +45,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	public final void set$guard(boolean cv$value) {
 		guard = cv$value;
 		fixedProbFlag$sample4 = false;
-		fixedProbFlag$sample16 = false;
 	}
 
 	@Override
@@ -110,34 +95,20 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	@Override
 	public final void set$var14(double cv$value) {
 		var14 = cv$value;
-		fixedProbFlag$sample16 = false;
 	}
 
 	private final void logProbabilityValue$sample16() {
-		if(!fixedProbFlag$sample16) {
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				double cv$distributionAccumulator = (((0.0 <= var14) && (var14 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
-				cv$accumulator = cv$distributionAccumulator;
-				logProbability$var13 = cv$distributionAccumulator;
-				logProbability$sample16 = cv$distributionAccumulator;
-				logProbability$value = (logProbability$value + cv$distributionAccumulator);
-			}
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
-			fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedFlag$sample4);
-		} else {
-			double cv$accumulator = 0.0;
-			if(!guard) {
-				cv$accumulator = logProbability$sample16;
-				logProbability$var13 = logProbability$sample16;
-				logProbability$value = (logProbability$value + logProbability$sample16);
-			}
-			logProbability$var14 = (logProbability$var14 + cv$accumulator);
-			logProbability$$model = (logProbability$$model + cv$accumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		double cv$accumulator = 0.0;
+		if(!guard) {
+			double cv$distributionAccumulator = (((0.0 <= var14) && (var14 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
+			cv$accumulator = cv$distributionAccumulator;
+			logProbability$var13 = cv$distributionAccumulator;
+			logProbability$sample16 = cv$distributionAccumulator;
+			logProbability$value = (logProbability$value + cv$distributionAccumulator);
 		}
+		logProbability$var14 = (logProbability$var14 + cv$accumulator);
+		logProbability$$model = (logProbability$$model + cv$accumulator);
+		logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
 	}
 
 	private final void logProbabilityValue$sample4() {
@@ -206,10 +177,8 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			if(!fixedFlag$sample4)
 				value = 1.0;
 		} else {
-			if(!fixedFlag$sample16)
-				var14 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample16))
-				value = var14;
+			var14 = DistributionSampling.sampleUniform(RNG$);
+			value = var14;
 		}
 	}
 
@@ -226,10 +195,8 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value = 1.0;
 		else {
-			if(!fixedFlag$sample16)
-				var14 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample16))
-				value = var14;
+			var14 = DistributionSampling.sampleUniform(RNG$);
+			value = var14;
 		}
 	}
 
@@ -264,8 +231,7 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$var13 = Double.NaN;
 		logProbability$var14 = 0.0;
 		logProbability$value = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	@Override

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1$SingleThreadCPU_optimisedModelSingle.java
@@ -7,9 +7,7 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	
 	// Declare the variables for the model.
 	private double[] cv$var4$stateProbabilityGlobal;
-	private boolean fixedFlag$sample16 = false;
 	private boolean fixedFlag$sample4 = false;
-	private boolean fixedProbFlag$sample16 = false;
 	private boolean fixedProbFlag$sample4 = false;
 	private boolean guard;
 	private double logProbability$$evidence;
@@ -27,26 +25,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 
 	public Conditional1$SingleThreadCPU(ExecutionTarget target) {
 		super(target);
-	}
-
-	// Getter for fixedFlag$sample16.
-	@Override
-	public final boolean get$fixedFlag$sample16() {
-		return fixedFlag$sample16;
-	}
-
-	// Setter for fixedFlag$sample16.
-	@Override
-	public final void set$fixedFlag$sample16(boolean cv$value) {
-		// Set flags for all the side effects of fixedFlag$sample16 including if probabilities
-		// need to be updated.
-		fixedFlag$sample16 = cv$value;
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample16" with its value "cv$value".
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	// Getter for fixedFlag$sample4.
@@ -67,12 +45,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		// 
 		// Substituted "fixedFlag$sample4" with its value "cv$value".
 		fixedProbFlag$sample4 = (cv$value && fixedProbFlag$sample4);
-		
-		// Should the probability of sample 16 be set to fixed. This will only every change
-		// the flag to false.
-		// 
-		// Substituted "fixedFlag$sample4" with its value "cv$value".
-		fixedProbFlag$sample16 = (cv$value && fixedProbFlag$sample16);
 	}
 
 	// Getter for guard.
@@ -90,9 +62,6 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		
 		// Unset the fixed probability flag for sample 4 as it depends on guard.
 		fixedProbFlag$sample4 = false;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on guard.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Getter for logProbability$$evidence.
@@ -152,122 +121,82 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 	// Setter for var14.
 	@Override
 	public final void set$var14(double cv$value) {
-		// Set flags for all the side effects of var14 including if probabilities need to
-		// be updated.
 		var14 = cv$value;
-		
-		// Unset the fixed probability flag for sample 16 as it depends on var14.
-		fixedProbFlag$sample16 = false;
 	}
 
 	// Calculate the probability of the samples represented by sample16 using sampled
 	// values.
 	private final void logProbabilityValue$sample16() {
-		// Determine if we need to calculate the values for sample task 16 or if we should
-		// just use cached values.
-		if(!fixedProbFlag$sample16) {
-			// Generating probabilities for sample task
+		// Generating probabilities for sample task
+		// Accumulator for sample probabilities for a specific instance of the random variable.
+		double cv$sampleAccumulator = 0.0;
+		
+		// A guard to check if the sample value is ever reached.
+		boolean cv$sampleReached = false;
+		if(!guard) {
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = (((0.0 <= var14) && (var14 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
+			
+			// Record that the sample was reached.
+			cv$sampleReached = true;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
 			// Accumulator for sample probabilities for a specific instance of the random variable.
-			double cv$sampleAccumulator = 0.0;
+			cv$sampleAccumulator = cv$distributionAccumulator;
 			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				// 
-				// Scale the probability relative to the observed distribution space.
-				// 
-				// Add the probability of this distribution configuration to the accumulator.
-				// 
-				// An accumulator for the distributed probability space covered.
-				// 
-				// Variable declaration of cv$distributionAccumulator moved.
-				// Declaration comment was:
-				// An accumulator for log probabilities.
-				// 
-				// Store the value of the function call, so the function call is only made once.
-				// 
-				// The sample value to calculate the probability of generating
-				double cv$distributionAccumulator = (((0.0 <= var14) && (var14 < 1.0))?0.0:Double.NEGATIVE_INFINITY);
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Add the probability of this sample task to the sample task accumulator.
-				// 
-				// Accumulator for sample probabilities for a specific instance of the random variable.
-				cv$sampleAccumulator = cv$distributionAccumulator;
-				
-				// Store the sample task probability
-				logProbability$sample16 = cv$distributionAccumulator;
-				
-				// Update the variable probability
-				logProbability$value = (logProbability$value + cv$distributionAccumulator);
-			}
-			if(cv$sampleReached)
-				logProbability$var13 = cv$sampleAccumulator;
+			// Store the sample task probability
+			logProbability$sample16 = cv$distributionAccumulator;
 			
 			// Update the variable probability
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$var14 = (logProbability$var14 + cv$sampleAccumulator);
-			
-			// Add probability to model
-			// 
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
-			
-			// Add the probability of this instance of the random variable to the probability
-			// of all instances of the random variable.
-			// 
-			// Accumulator for probabilities of instances of the random variable
-			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
-			
-			// Now the probability is calculated store if it can be cached or if it needs to be
-			// recalculated next time.
-			fixedProbFlag$sample16 = (fixedFlag$sample16 && fixedFlag$sample4);
+			logProbability$value = (logProbability$value + cv$distributionAccumulator);
 		}
-		// Using cached values.
-		else {
-			// Updating random variable and model probabilities using cached probabilities for
-			// this sample
-			double cv$rvAccumulator = 0.0;
-			
-			// A guard to check if the sample value is ever reached.
-			boolean cv$sampleReached = false;
-			if(!guard) {
-				cv$rvAccumulator = logProbability$sample16;
-				
-				// Record that the sample was reached.
-				cv$sampleReached = true;
-				
-				// Update the variable probability
-				logProbability$value = (logProbability$value + logProbability$sample16);
-			}
-			if(cv$sampleReached)
-				logProbability$var13 = cv$rvAccumulator;
-			
-			// Update the variable probability
-			logProbability$var14 = (logProbability$var14 + cv$rvAccumulator);
-			
-			// Add probability to model
-			logProbability$$model = (logProbability$$model + cv$rvAccumulator);
-			logProbability$$evidence = (logProbability$$evidence + cv$rvAccumulator);
-		}
+		if(cv$sampleReached)
+			logProbability$var13 = cv$sampleAccumulator;
+		
+		// Update the variable probability
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$var14 = (logProbability$var14 + cv$sampleAccumulator);
+		
+		// Add probability to model
+		// 
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+		
+		// Add the probability of this instance of the random variable to the probability
+		// of all instances of the random variable.
+		// 
+		// Accumulator for probabilities of instances of the random variable
+		logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
 	}
 
 	// Calculate the probability of the samples represented by sample4 using sampled values.
@@ -555,10 +484,8 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 			if(!fixedFlag$sample4)
 				value = 1.0;
 		} else {
-			if(!fixedFlag$sample16)
-				var14 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample16))
-				value = var14;
+			var14 = DistributionSampling.sampleUniform(RNG$);
+			value = var14;
 		}
 	}
 
@@ -580,10 +507,8 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		if(guard)
 			value = 1.0;
 		else {
-			if(!fixedFlag$sample16)
-				var14 = DistributionSampling.sampleUniform(RNG$);
-			if((!fixedFlag$sample4 || !fixedFlag$sample16))
-				value = var14;
+			var14 = DistributionSampling.sampleUniform(RNG$);
+			value = var14;
 		}
 	}
 
@@ -636,8 +561,7 @@ class Conditional1$SingleThreadCPU extends org.sandwood.runtime.internal.model.C
 		logProbability$var13 = Double.NaN;
 		logProbability$var14 = 0.0;
 		logProbability$value = 0.0;
-		if(!fixedProbFlag$sample16)
-			logProbability$sample16 = Double.NaN;
+		logProbability$sample16 = Double.NaN;
 	}
 
 	// Construct the evidence probabilities.

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1_model.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Conditional1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class Conditional1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -204,7 +200,6 @@ public class Conditional1 extends Model {
             newCore.set$var14(oldCore.get$var14());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1_modelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Conditional1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class Conditional1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -204,7 +200,6 @@ public class Conditional1 extends Model {
             newCore.set$var14(oldCore.get$var14());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1_modelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Conditional1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class Conditional1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -204,7 +200,6 @@ public class Conditional1 extends Model {
             newCore.set$var14(oldCore.get$var14());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1_optimisedModel.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Conditional1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class Conditional1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -204,7 +200,6 @@ public class Conditional1 extends Model {
             newCore.set$var14(oldCore.get$var14());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1_optimisedModelNoComments.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Conditional1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class Conditional1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -204,7 +200,6 @@ public class Conditional1 extends Model {
             newCore.set$var14(oldCore.get$var14());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/conditional1/Conditional1_optimisedModelSingle.java
@@ -5,6 +5,7 @@ import org.sandwood.runtime.model.ExecutionTarget;
 import org.sandwood.runtime.model.variables.*;
 import org.sandwood.runtime.internal.model.variables.*;
 import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class Conditional1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            throw new SandwoodException("Variables that are fixed by observing other variables cannot be directly fixed. Please change the observed variable instead.");
+            throw new SandwoodException("An observed variables can only have the value fixed to the observed value if the value is consumed by another random variable.");
         }
 
         @Override
@@ -97,17 +98,12 @@ public class Conditional1 extends Model {
 
         @Override
         public void setFixed(boolean fixed) {
-            synchronized(model) {
-                system$c.set$fixedFlag$sample16(fixed);
-            }
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
 
         @Override
         public Immutability isFixed() {
-            if(system$c.get$fixedFlag$sample16())
-                return Immutability.FIXED;
-            else
-                return Immutability.FREE;
+            throw new SandwoodRuntimeException("This method should never be called on a private variable.");
         }
     };
 
@@ -204,7 +200,6 @@ public class Conditional1 extends Model {
             newCore.set$var14(oldCore.get$var14());
 
         //Set fixed flags
-        newCore.set$fixedFlag$sample16(oldCore.get$fixedFlag$sample16());
         newCore.set$fixedFlag$sample4(oldCore.get$fixedFlag$sample4());
     }
 

--- a/Sandwood/runtime/src/main/java/org/sandwood/runtime/internal/model/variables/ComputedVariableInternal.java
+++ b/Sandwood/runtime/src/main/java/org/sandwood/runtime/internal/model/variables/ComputedVariableInternal.java
@@ -146,7 +146,7 @@ public abstract class ComputedVariableInternal
     @Override
     public final RetentionPolicy getRetentionPolicy() {
         synchronized(model) {
-            if(isFixed() == Immutability.FIXED)
+            if(!isPrivate && isFixed() == Immutability.FIXED)
                 return RetentionPolicy.NA;
             else
                 return p;

--- a/Sandwood/runtime/src/main/java/org/sandwood/runtime/model/variables/ComputedVariable.java
+++ b/Sandwood/runtime/src/main/java/org/sandwood/runtime/model/variables/ComputedVariable.java
@@ -39,7 +39,12 @@ public interface ComputedVariable extends HasProbability, Variable {
         /**
          * This value is always the same in inference code as it is observed.
          */
-        OBSERVED
+        OBSERVED,
+        /**
+         * This value is always the same in inference code as it is observed, and its value can be fixed to the value it
+         * had when inferring values when performing forward execution of the model.
+         */
+        OBSERVED_FIXABLE
     }
 
     /**


### PR DESCRIPTION
### Description
Making the set variables whose values can be fixed an explicit property of traces and extending this set to include observed variables that are consumed by other sample tasks. This additional has also allowed the removal of tests to fixed flags that will never be set to true, and along with this the setting of fixed probability flags that will also never be set to true.
