### PR TITLE
Improved trace generation

### DIFF
--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/ArrayConstructTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/ArrayConstructTask.java
@@ -129,7 +129,14 @@ public class ArrayConstructTask<A extends Variable<A>> extends ProducingDataflow
 
     @Override
     public void constructTrace(TraceConstructionDesc desc) {
+        // Push null to remove the current restrictions due to length type as this is now in a scalar world again.
+        desc.lengthTypes.push(null);
+        // Continue the trace via the length parameter
         super.constructTrace(desc);
+        // Then restore the length
+        desc.lengthTypes.pop();
+
+        // Continue the trace via any outer arrays.
         if(output.isSubArray()) {
             output.getOuterArrayDesc().getGetTask().constructTrace(desc);
         }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/GetArrayLengthTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/GetArrayLengthTask.java
@@ -78,7 +78,9 @@ public class GetArrayLengthTask extends NumberProducingDataflowTaskImplementatio
     @Override
     public void constructTrace(TraceConstructionDesc desc) {
         desc.trace.push(new DataflowTaskArgDesc(this, 0));
+        desc.lengthTypes.push(array.getType());
         array.instanceHandle().constructTrace(desc);
+        desc.lengthTypes.pop();
         desc.trace.pop();
     }
 

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/GetTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/GetTask.java
@@ -172,9 +172,11 @@ public abstract class GetTask<A extends Variable<A>> extends ProducingDataflowTa
         }
         desc.trace.pop();
 
-        // Explore the index
+        // Explore the index deactivating any length restrictions at the same time.
         desc.trace.push(new DataflowTaskArgDesc(this, 1));
+        desc.lengthTypes.push(null);
         index.constructTrace(desc);
+        desc.lengthTypes.pop();
         desc.trace.pop();
     }
 

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/PutTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/PutTask.java
@@ -32,6 +32,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.ProducingDataflowTaskImplementa
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ForTask;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableName;
+import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
 import org.sandwood.compiler.dataflowGraph.variables.auxillary.DataflowTaskArgDesc;
 import org.sandwood.compiler.dataflowGraph.variables.auxillary.VariableWrapper;
@@ -605,16 +606,28 @@ public class PutTask<A extends Variable<A>> extends ProducingDataflowTaskImpleme
                     // If this is an array variable then the value being placed into the array is
                     // another array. As such all possible puts to this array that could affect the
                     // original get are required.
-                    if(in.getType().isArray()) {
-
-                        in.constructTrace(desc);
+                    Type<?> type = in.getType();
+                    if(type.isArray()) {
+                        // If the value being put is the same type as an array whose length is currently being tracked,
+                        // jump straight to the array constructor, skipping the exploration of any put operations on the
+                        // array.
+                        if(type.equals(desc.lengthTypes.peek()))
+                            in.instanceHandle().constructTrace(desc);
+                        else
+                            in.constructTrace(desc);
                     } else {
                         // We are starting a new trace through arrays as we are following
                         // the index or a scalar value variable, so clear the initial get field.
                         desc.arrayEntryPoint = null;
 
+                        // We are exploring a scalar so remove the restrictions due to length type.
+                        desc.lengthTypes.push(null);
+
                         // Explore the trace
                         in.constructTrace(desc);
+
+                        // Reinstate the guard
+                        desc.lengthTypes.pop();
 
                         // Restore the get task for this trace.
                         desc.arrayEntryPoint = arrayEntryPoint;

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/TraceConstructionDesc.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/TraceConstructionDesc.java
@@ -23,6 +23,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.arrayTasks.GetTask;
 import org.sandwood.compiler.dataflowGraph.tasks.arrayTasks.PutTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ForTask;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
+import org.sandwood.compiler.dataflowGraph.variables.VariableType.ArrayType;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
 
@@ -37,6 +38,7 @@ public class TraceConstructionDesc {
     public boolean firstPut = true;
     public final Set<Variable<?>> seenVar;
     private final Map<ArrayVariable<?>, Map<Integer, Set<IntVariable>>> restrictedIndexes;
+    public final Stack<ArrayType<?>> lengthTypes = new Stack<>();
 
     public TraceConstructionDesc(Variable<?> sink, TraceCallback c) {
         this.sink = sink;
@@ -44,6 +46,7 @@ public class TraceConstructionDesc {
         this.c = c;
         restrictedIndexes = new HashMap<>();
         seenVar = new HashSet<>();
+        lengthTypes.push(null);
     }
 
     public void addRestrictedIndexes(PutTask<?> task) {

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$MultiThreadCPU_model.java
@@ -14,8 +14,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 	private boolean fixedFlag$sample101 = false;
 	private boolean fixedProbFlag$sample101 = false;
 	private boolean fixedProbFlag$sample165 = false;
-	private boolean[][][] guard$sample101poisson164$global;
-	private boolean[][][] guard$sample101put160$global;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
 	private double logProbability$arr;
@@ -639,9 +637,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 						// 
 						// Looking for a path between Sample 101 and consumer double[][] 153.
 						{
-							// Guard to check that at most one copy of the code is executed for a given random
-							// variable instance.
-							boolean[][] guard$sample101put160 = guard$sample101put160$global[threadID$cv$i$var80];
 							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 								if((i$var80 == i$var119)) {
 									for(int j = 0; j < time_dim; j += 1) {
@@ -651,131 +646,32 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 													if((t == index$t$3_4)) {
 														for(int index$i$3_5 = 0; index$i$3_5 < n_ac; index$i$3_5 += 1) {
 															if((i$var119 == index$i$3_5)) {
-																{
-																	// Set the flags to false
-																	guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$4_4 = (0 + 1); index$t$4_4 < T; index$t$4_4 += 1) {
-													if((t == index$t$4_4)) {
-														for(int index$i$4_5 = 0; index$i$4_5 < n_ac; index$i$4_5 += 1) {
-															if((i$var119 == index$i$4_5)) {
 																if(((0 <= j) && (j < time_dim))) {
 																	{
-																		// Set the flags to false
-																		guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$5_4 = (0 + 1); index$t$5_4 < T; index$t$5_4 += 1) {
-													if((t == index$t$5_4)) {
-														for(int index$i$5_5 = 0; index$i$5_5 < n_ac; index$i$5_5 += 1) {
-															if((i$var119 == index$i$5_5)) {
-																{
-																	if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																		// The body will execute, so should not be executed again
-																		guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
 																		{
-																			double[] var139 = sum_t[index$t$5_4];
+																			double[] var139 = sum_t[index$t$3_4];
 																			
 																			// Reduction of array null
 																			// 
 																			// A generated name to prevent name collisions if the reduction is implemented more
 																			// than once in inference and probability code. Initialize the variable to the unit
 																			// value
-																			double reduceVar$var151$12 = 0.0;
+																			double reduceVar$var151$9 = 0.0;
 																			
 																			// For each index in the array to be reduced
 																			for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 																				// Set the left hand term of the reduction function to the return variable value.
-																				double x = reduceVar$var151$12;
+																				double x = reduceVar$var151$9;
 																				
 																				// Set the right hand term to a value from the array var141
-																				double y = time_impact[index$t$5_4][index$i$5_5][cv$reduction152Index];
+																				double y = time_impact[index$t$3_4][index$i$3_5][cv$reduction152Index];
 																				
 																				// Execute the reduction function, saving the result into the return value.
 																				// 
 																				// Copy the result of the reduction into the variable returned by the reduction.
-																				reduceVar$var151$12 = (x + y);
+																				reduceVar$var151$9 = (x + y);
 																			}
-																			var139[index$i$5_5] = reduceVar$var151$12;
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$6_4 = (0 + 1); index$t$6_4 < T; index$t$6_4 += 1) {
-													if((t == index$t$6_4)) {
-														for(int index$i$6_5 = 0; index$i$6_5 < n_ac; index$i$6_5 += 1) {
-															if((i$var119 == index$i$6_5)) {
-																if(((0 <= j) && (j < time_dim))) {
-																	{
-																		if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																			// The body will execute, so should not be executed again
-																			guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																			{
-																				double[] var139 = sum_t[index$t$6_4];
-																				
-																				// Reduction of array null
-																				// 
-																				// A generated name to prevent name collisions if the reduction is implemented more
-																				// than once in inference and probability code. Initialize the variable to the unit
-																				// value
-																				double reduceVar$var151$13 = 0.0;
-																				
-																				// For each index in the array to be reduced
-																				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																					// Set the left hand term of the reduction function to the return variable value.
-																					double x = reduceVar$var151$13;
-																					
-																					// Set the right hand term to a value from the array var141
-																					double y = time_impact[index$t$6_4][index$i$6_5][cv$reduction152Index];
-																					
-																					// Execute the reduction function, saving the result into the return value.
-																					// 
-																					// Copy the result of the reduction into the variable returned by the reduction.
-																					reduceVar$var151$13 = (x + y);
-																				}
-																				var139[index$i$6_5] = reduceVar$var151$13;
-																			}
+																			var139[index$i$3_5] = reduceVar$var151$9;
 																		}
 																	}
 																}
@@ -811,129 +707,64 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 					{
 						// Looking for a path between Sample 101 and consumer Poisson 157.
 						{
-							// Guard to check that at most one copy of the code is executed for a given random
-							// variable instance.
-							boolean[][] guard$sample101poisson164 = guard$sample101poisson164$global[threadID$cv$i$var80];
+							double traceTempVariable$var134$4_1 = cv$currentValue;
 							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 								if((i$var80 == i$var119)) {
 									for(int j = 0; j < time_dim; j += 1) {
 										if((var95 == j)) {
 											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$7_4 = (0 + 1); index$t$7_4 < T; index$t$7_4 += 1) {
-													if((t == index$t$7_4)) {
-														for(int index$i$7_5 = 0; index$i$7_5 < n_ac; index$i$7_5 += 1) {
-															if((i$var119 == index$i$7_5)) {
-																{
-																	for(int index$t$7_6 = (0 + 1); index$t$7_6 < T; index$t$7_6 += 1) {
-																		if((index$t$7_4 == index$t$7_6)) {
-																			for(int index$i$7_7 = 0; index$i$7_7 < n_ac; index$i$7_7 += 1) {
-																				if((index$i$7_5 == index$i$7_7))
-																					// Set the flags to false
-																					guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$8_4 = (0 + 1); index$t$8_4 < T; index$t$8_4 += 1) {
-													if((t == index$t$8_4)) {
-														for(int index$i$8_5 = 0; index$i$8_5 < n_ac; index$i$8_5 += 1) {
-															if((i$var119 == index$i$8_5)) {
+												double traceTempVariable$x$4_5 = (TimeFeat[t][j] * traceTempVariable$var134$4_1);
+												for(int index$t$4_6 = (0 + 1); index$t$4_6 < T; index$t$4_6 += 1) {
+													if((t == index$t$4_6)) {
+														for(int index$i$4_7 = 0; index$i$4_7 < n_ac; index$i$4_7 += 1) {
+															if((i$var119 == index$i$4_7)) {
 																if(((0 <= j) && (j < time_dim))) {
 																	{
-																		for(int index$t$8_6 = (0 + 1); index$t$8_6 < T; index$t$8_6 += 1) {
-																			if((index$t$8_4 == index$t$8_6)) {
-																				for(int index$i$8_7 = 0; index$i$8_7 < n_ac; index$i$8_7 += 1) {
-																					if((index$i$8_5 == index$i$8_7))
-																						// Set the flags to false
-																						guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																				}
+																		if((0 < time_dim)) {
+																			// Reduction of array null
+																			// 
+																			// A generated name to prevent name collisions if the reduction is implemented more
+																			// than once in inference and probability code. Initialize the variable to the unit
+																			// value
+																			double reduceVar$var151$10 = 0.0;
+																			
+																			// Reduce for every value except a masked value which will be skipped.
+																			for(int cv$reduction673Index = 0; cv$reduction673Index < j; cv$reduction673Index += 1) {
+																				// Set the left hand term of the reduction function to the return variable value.
+																				double x = reduceVar$var151$10;
+																				
+																				// Set the right hand term to a value from the array var141
+																				double y = time_impact[index$t$4_6][index$i$4_7][cv$reduction673Index];
+																				
+																				// Execute the reduction function, saving the result into the return value.
+																				// 
+																				// Copy the result of the reduction into the variable returned by the reduction.
+																				reduceVar$var151$10 = (x + y);
 																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							double traceTempVariable$var134$9_1 = cv$currentValue;
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$9_5 = (0 + 1); index$t$9_5 < T; index$t$9_5 += 1) {
-													if((t == index$t$9_5)) {
-														for(int index$i$9_6 = 0; index$i$9_6 < n_ac; index$i$9_6 += 1) {
-															if((i$var119 == index$i$9_6)) {
-																{
-																	if((0 < time_dim)) {
-																		// Reduction of array null
-																		// 
-																		// A generated name to prevent name collisions if the reduction is implemented more
-																		// than once in inference and probability code. Initialize the variable to the unit
-																		// value
-																		double reduceVar$var151$14 = time_impact[index$t$9_5][index$i$9_6][0];
-																		
-																		// Reduce for every value except a masked value which will be skipped.
-																		for(int cv$reduction1129Index = 0; cv$reduction1129Index < 0; cv$reduction1129Index += 1) {
-																			// Set the left hand term of the reduction function to the return variable value.
-																			double x = reduceVar$var151$14;
+																			for(int cv$reduction673Index = (j + 1); cv$reduction673Index < time_dim; cv$reduction673Index += 1) {
+																				// Set the left hand term of the reduction function to the return variable value.
+																				double x = reduceVar$var151$10;
+																				
+																				// Set the right hand term to a value from the array var141
+																				double y = time_impact[index$t$4_6][index$i$4_7][cv$reduction673Index];
+																				
+																				// Execute the reduction function, saving the result into the return value.
+																				// 
+																				// Execute the reduction function, saving the result into the return value.
+																				// 
+																				// Copy the result of the reduction into the variable returned by the reduction.
+																				reduceVar$var151$10 = (x + y);
+																			}
+																			double cv$reduced152 = reduceVar$var151$10;
 																			
-																			// Set the right hand term to a value from the array var141
-																			double y = time_impact[index$t$9_5][index$i$9_6][cv$reduction1129Index];
-																			
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
 																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$14 = (x + y);
-																		}
-																		for(int cv$reduction1129Index = (0 + 1); cv$reduction1129Index < time_dim; cv$reduction1129Index += 1) {
-																			// Set the left hand term of the reduction function to the return variable value.
-																			double x = reduceVar$var151$14;
-																			
-																			// Set the right hand term to a value from the array var141
-																			double y = time_impact[index$t$9_5][index$i$9_6][cv$reduction1129Index];
-																			
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
-																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$14 = (x + y);
-																		}
-																		double cv$reduced152 = reduceVar$var151$14;
-																		
-																		// Copy the result of the reduction into the variable returned by the reduction.
-																		reduceVar$var151$14 = (0.0 + cv$reduced152);
-																		double traceTempVariable$var151$9_7 = reduceVar$var151$14;
-																		double traceTempVariable$var156$9_8 = traceTempVariable$var151$9_7;
-																		for(int index$t$9_9 = (0 + 1); index$t$9_9 < T; index$t$9_9 += 1) {
-																			if((index$t$9_5 == index$t$9_9)) {
-																				for(int index$i$9_10 = 0; index$i$9_10 < n_ac; index$i$9_10 += 1) {
-																					if((index$i$9_6 == index$i$9_10)) {
-																						if(!guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																							// The body will execute, so should not be executed again
-																							guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																							
+																			reduceVar$var151$10 = (traceTempVariable$x$4_5 + cv$reduced152);
+																			double traceTempVariable$var151$4_8 = reduceVar$var151$10;
+																			double traceTempVariable$var156$4_9 = traceTempVariable$var151$4_8;
+																			for(int index$t$4_10 = (0 + 1); index$t$4_10 < T; index$t$4_10 += 1) {
+																				if((index$t$4_6 == index$t$4_10)) {
+																					for(int index$i$4_11 = 0; index$i$4_11 < n_ac; index$i$4_11 += 1) {
+																						if((index$i$4_7 == index$i$4_11)) {
 																							// Processing sample task 165 of consumer random variable null.
 																							{
 																								// Set an accumulator to sum the probabilities for each possible configuration of
@@ -950,19 +781,19 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 																												double cv$temp$2$var156;
 																												{
 																													// Constructing a random variable input for use later.
-																													double var156 = traceTempVariable$var156$9_8;
+																													double var156 = traceTempVariable$var156$4_9;
 																													cv$temp$2$var156 = var156;
 																												}
 																												
 																												// Record the probability of sample task 165 generating output with current configuration.
-																												if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)) < cv$accumulatedConsumerProbabilities))
-																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
 																												else {
 																													// If the second value is -infinity.
 																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156));
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156));
 																													else
-																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)));
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)));
 																												}
 																												
 																												// Recorded the probability of reaching sample task 165 with the current configuration.
@@ -986,139 +817,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 																										cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
 																									else
 																										cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
-																								}
-																							}
-																						}
-																					}
-																				}
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							double traceTempVariable$var134$10_1 = cv$currentValue;
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												double traceTempVariable$x$10_5 = (TimeFeat[t][j] * traceTempVariable$var134$10_1);
-												for(int index$t$10_6 = (0 + 1); index$t$10_6 < T; index$t$10_6 += 1) {
-													if((t == index$t$10_6)) {
-														for(int index$i$10_7 = 0; index$i$10_7 < n_ac; index$i$10_7 += 1) {
-															if((i$var119 == index$i$10_7)) {
-																if(((0 <= j) && (j < time_dim))) {
-																	{
-																		if((0 < time_dim)) {
-																			// Reduction of array null
-																			// 
-																			// A generated name to prevent name collisions if the reduction is implemented more
-																			// than once in inference and probability code. Initialize the variable to the unit
-																			// value
-																			double reduceVar$var151$15 = 0.0;
-																			
-																			// Reduce for every value except a masked value which will be skipped.
-																			for(int cv$reduction1175Index = 0; cv$reduction1175Index < j; cv$reduction1175Index += 1) {
-																				// Set the left hand term of the reduction function to the return variable value.
-																				double x = reduceVar$var151$15;
-																				
-																				// Set the right hand term to a value from the array var141
-																				double y = time_impact[index$t$10_6][index$i$10_7][cv$reduction1175Index];
-																				
-																				// Execute the reduction function, saving the result into the return value.
-																				// 
-																				// Copy the result of the reduction into the variable returned by the reduction.
-																				reduceVar$var151$15 = (x + y);
-																			}
-																			for(int cv$reduction1175Index = (j + 1); cv$reduction1175Index < time_dim; cv$reduction1175Index += 1) {
-																				// Set the left hand term of the reduction function to the return variable value.
-																				double x = reduceVar$var151$15;
-																				
-																				// Set the right hand term to a value from the array var141
-																				double y = time_impact[index$t$10_6][index$i$10_7][cv$reduction1175Index];
-																				
-																				// Execute the reduction function, saving the result into the return value.
-																				// 
-																				// Execute the reduction function, saving the result into the return value.
-																				// 
-																				// Copy the result of the reduction into the variable returned by the reduction.
-																				reduceVar$var151$15 = (x + y);
-																			}
-																			double cv$reduced152 = reduceVar$var151$15;
-																			
-																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$15 = (traceTempVariable$x$10_5 + cv$reduced152);
-																			double traceTempVariable$var151$10_8 = reduceVar$var151$15;
-																			double traceTempVariable$var156$10_9 = traceTempVariable$var151$10_8;
-																			for(int index$t$10_10 = (0 + 1); index$t$10_10 < T; index$t$10_10 += 1) {
-																				if((index$t$10_6 == index$t$10_10)) {
-																					for(int index$i$10_11 = 0; index$i$10_11 < n_ac; index$i$10_11 += 1) {
-																						if((index$i$10_7 == index$i$10_11)) {
-																							if(!guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																								// The body will execute, so should not be executed again
-																								guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																								
-																								// Processing sample task 165 of consumer random variable null.
-																								{
-																									// Set an accumulator to sum the probabilities for each possible configuration of
-																									// inputs.
-																									double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
-																									
-																									// Set an accumulator to record the consumer distributions not seen. Initially set
-																									// to 1 as seen values will be deducted from this value.
-																									double cv$consumerDistributionProbabilityAccumulator = 1.0;
-																									{
-																										{
-																											{
-																												{
-																													double cv$temp$3$var156;
-																													{
-																														// Constructing a random variable input for use later.
-																														double var156 = traceTempVariable$var156$10_9;
-																														cv$temp$3$var156 = var156;
-																													}
-																													
-																													// Record the probability of sample task 165 generating output with current configuration.
-																													if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)) < cv$accumulatedConsumerProbabilities))
-																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
-																													else {
-																														// If the second value is -infinity.
-																														if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																															cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156));
-																														else
-																															cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)));
-																													}
-																													
-																													// Recorded the probability of reaching sample task 165 with the current configuration.
-																													cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
-																												}
-																											}
-																										}
-																									}
-																									
-																									// A check to ensure rounding of floating point values can never result in a negative
-																									// value.
-																									cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
-																									
-																									// Multiply (log space add) in the probability of the sample task to the overall probability
-																									// for this configuration of the source random variable.
-																									if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
-																										cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
-																									else {
-																										// If the second value is -infinity.
-																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																											cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
-																										else
-																											cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
-																									}
 																								}
 																							}
 																						}
@@ -1207,143 +905,41 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 				// 
 				// Looking for a path between Sample 101 and consumer double[][] 153.
 				{
-					// Guard to check that at most one copy of the code is executed for a given random
-					// variable instance.
-					boolean[][] guard$sample101put160 = guard$sample101put160$global[threadID$cv$i$var80];
 					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 						if((i$var80 == i$var119)) {
 							for(int j = 0; j < time_dim; j += 1) {
 								if((var95 == j)) {
 									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$17_4 = (0 + 1); index$t$17_4 < T; index$t$17_4 += 1) {
-											if((t == index$t$17_4)) {
-												for(int index$i$17_5 = 0; index$i$17_5 < n_ac; index$i$17_5 += 1) {
-													if((i$var119 == index$i$17_5)) {
-														{
-															// Set the flags to false
-															guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$18_4 = (0 + 1); index$t$18_4 < T; index$t$18_4 += 1) {
-											if((t == index$t$18_4)) {
-												for(int index$i$18_5 = 0; index$i$18_5 < n_ac; index$i$18_5 += 1) {
-													if((i$var119 == index$i$18_5)) {
+										for(int index$t$9_4 = (0 + 1); index$t$9_4 < T; index$t$9_4 += 1) {
+											if((t == index$t$9_4)) {
+												for(int index$i$9_5 = 0; index$i$9_5 < n_ac; index$i$9_5 += 1) {
+													if((i$var119 == index$i$9_5)) {
 														if(((0 <= j) && (j < time_dim))) {
 															{
-																// Set the flags to false
-																guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$19_4 = (0 + 1); index$t$19_4 < T; index$t$19_4 += 1) {
-											if((t == index$t$19_4)) {
-												for(int index$i$19_5 = 0; index$i$19_5 < n_ac; index$i$19_5 += 1) {
-													if((i$var119 == index$i$19_5)) {
-														{
-															if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																// The body will execute, so should not be executed again
-																guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
 																{
-																	double[] var139 = sum_t[index$t$19_4];
+																	double[] var139 = sum_t[index$t$9_4];
 																	
 																	// Reduction of array null
 																	// 
 																	// A generated name to prevent name collisions if the reduction is implemented more
 																	// than once in inference and probability code. Initialize the variable to the unit
 																	// value
-																	double reduceVar$var151$16 = 0.0;
+																	double reduceVar$var151$11 = 0.0;
 																	
 																	// For each index in the array to be reduced
 																	for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 																		// Set the left hand term of the reduction function to the return variable value.
-																		double x = reduceVar$var151$16;
+																		double x = reduceVar$var151$11;
 																		
 																		// Set the right hand term to a value from the array var141
-																		double y = time_impact[index$t$19_4][index$i$19_5][cv$reduction152Index];
+																		double y = time_impact[index$t$9_4][index$i$9_5][cv$reduction152Index];
 																		
 																		// Execute the reduction function, saving the result into the return value.
 																		// 
 																		// Copy the result of the reduction into the variable returned by the reduction.
-																		reduceVar$var151$16 = (x + y);
+																		reduceVar$var151$11 = (x + y);
 																	}
-																	var139[index$i$19_5] = reduceVar$var151$16;
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$20_4 = (0 + 1); index$t$20_4 < T; index$t$20_4 += 1) {
-											if((t == index$t$20_4)) {
-												for(int index$i$20_5 = 0; index$i$20_5 < n_ac; index$i$20_5 += 1) {
-													if((i$var119 == index$i$20_5)) {
-														if(((0 <= j) && (j < time_dim))) {
-															{
-																if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																	// The body will execute, so should not be executed again
-																	guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																	{
-																		double[] var139 = sum_t[index$t$20_4];
-																		
-																		// Reduction of array null
-																		// 
-																		// A generated name to prevent name collisions if the reduction is implemented more
-																		// than once in inference and probability code. Initialize the variable to the unit
-																		// value
-																		double reduceVar$var151$17 = 0.0;
-																		
-																		// For each index in the array to be reduced
-																		for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																			// Set the left hand term of the reduction function to the return variable value.
-																			double x = reduceVar$var151$17;
-																			
-																			// Set the right hand term to a value from the array var141
-																			double y = time_impact[index$t$20_4][index$i$20_5][cv$reduction152Index];
-																			
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
-																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$17 = (x + y);
-																		}
-																		var139[index$i$20_5] = reduceVar$var151$17;
-																	}
+																	var139[index$i$9_5] = reduceVar$var151$11;
 																}
 															}
 														}
@@ -1365,62 +961,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 	// here prevents repeated allocation and deallocation, and makes the code more amenable
 	// to GPU execution.
 	@Override
-	public final void allocateScratch() {
-		// Allocate scratch space.
-		// Constructor for guard$sample101put160$global
-		{
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_t = 0;
-			
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_i$var119 = 0;
-			for(int t = (0 + 1); t < T; t += 1)
-				cv$max_i$var119 = Math.max(cv$max_i$var119, ((n_ac - 0) / 1));
-			cv$max_t = Math.max(cv$max_t, ((T - (0 + 1)) / 1));
-			
-			// Allocation of guard$sample101put160$global for multithreaded execution
-			{
-				// Get the thread count.
-				int cv$threadCount = threadCount();
-				
-				// Allocate an array to hold a copy per thread
-				guard$sample101put160$global = new boolean[cv$threadCount][][];
-				
-				// Populate the array with a copy per thread
-				for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
-					guard$sample101put160$global[cv$index] = new boolean[cv$max_t][cv$max_i$var119];
-			}
-		}
-		
-		// Constructor for guard$sample101poisson164$global
-		{
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_t = 0;
-			
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_i$var119 = 0;
-			for(int t = (0 + 1); t < T; t += 1)
-				cv$max_i$var119 = Math.max(cv$max_i$var119, ((n_ac - 0) / 1));
-			cv$max_t = Math.max(cv$max_t, ((T - (0 + 1)) / 1));
-			
-			// Allocation of guard$sample101poisson164$global for multithreaded execution
-			{
-				// Get the thread count.
-				int cv$threadCount = threadCount();
-				
-				// Allocate an array to hold a copy per thread
-				guard$sample101poisson164$global = new boolean[cv$threadCount][][];
-				
-				// Populate the array with a copy per thread
-				for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
-					guard$sample101poisson164$global[cv$index] = new boolean[cv$max_t][cv$max_i$var119];
-			}
-		}
-	}
+	public final void allocateScratch() {}
 
 	// Method to allocate space for model inputs and outputs.
 	@Override
@@ -1487,9 +1028,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 			for(int t = (0 + 1); t < T; t += 1)
 				logProbability$sample165[((t - (0 + 1)) / 1)] = new double[((((n_ac - 1) - 0) / 1) + 1)];
 		}
-		
-		// Allocate scratch space
-		allocateScratch();
 	}
 
 	// Method to execute the model code conventionally.
@@ -1562,12 +1100,12 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$18 = 0.0;
+										double reduceVar$var151$12 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 											// Set the left hand term of the reduction function to the return variable value.
-											double x = reduceVar$var151$18;
+											double x = reduceVar$var151$12;
 											
 											// Set the right hand term to a value from the array var141
 											double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1575,10 +1113,10 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// Execute the reduction function, saving the result into the return value.
 											if(!fixedFlag$sample101)
 												// Copy the result of the reduction into the variable returned by the reduction.
-												reduceVar$var151$18 = (x + y);
+												reduceVar$var151$12 = (x + y);
 										}
 										if(!fixedFlag$sample101)
-											var139[i$var119] = reduceVar$var151$18;
+											var139[i$var119] = reduceVar$var151$12;
 										var154[i$var119] = DistributionSampling.samplePoisson(RNG$2, sum_t[t][i$var119]);
 									}
 							}
@@ -1658,12 +1196,12 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$22 = 0.0;
+										double reduceVar$var151$16 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 											// Set the left hand term of the reduction function to the return variable value.
-											double x = reduceVar$var151$22;
+											double x = reduceVar$var151$16;
 											
 											// Set the right hand term to a value from the array var141
 											double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1671,9 +1209,9 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// Execute the reduction function, saving the result into the return value.
 											// 
 											// Copy the result of the reduction into the variable returned by the reduction.
-											reduceVar$var151$22 = (x + y);
+											reduceVar$var151$16 = (x + y);
 										}
-										var139[i$var119] = reduceVar$var151$22;
+										var139[i$var119] = reduceVar$var151$16;
 									}
 							}
 						);
@@ -1752,12 +1290,12 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$19 = 0.0;
+										double reduceVar$var151$13 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 											// Set the left hand term of the reduction function to the return variable value.
-											double x = reduceVar$var151$19;
+											double x = reduceVar$var151$13;
 											
 											// Set the right hand term to a value from the array var141
 											double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1765,9 +1303,9 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// Execute the reduction function, saving the result into the return value.
 											// 
 											// Copy the result of the reduction into the variable returned by the reduction.
-											reduceVar$var151$19 = (x + y);
+											reduceVar$var151$13 = (x + y);
 										}
-										var139[i$var119] = reduceVar$var151$19;
+										var139[i$var119] = reduceVar$var151$13;
 										var154[i$var119] = DistributionSampling.samplePoisson(RNG$2, sum_t[t][i$var119]);
 									}
 							}
@@ -1847,12 +1385,12 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$20 = 0.0;
+										double reduceVar$var151$14 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 											// Set the left hand term of the reduction function to the return variable value.
-											double x = reduceVar$var151$20;
+											double x = reduceVar$var151$14;
 											
 											// Set the right hand term to a value from the array var141
 											double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1860,10 +1398,10 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// Execute the reduction function, saving the result into the return value.
 											if(!fixedFlag$sample101)
 												// Copy the result of the reduction into the variable returned by the reduction.
-												reduceVar$var151$20 = (x + y);
+												reduceVar$var151$14 = (x + y);
 										}
 										if(!fixedFlag$sample101)
-											var139[i$var119] = reduceVar$var151$20;
+											var139[i$var119] = reduceVar$var151$14;
 									}
 							}
 						);
@@ -1942,12 +1480,12 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$21 = 0.0;
+										double reduceVar$var151$15 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 											// Set the left hand term of the reduction function to the return variable value.
-											double x = reduceVar$var151$21;
+											double x = reduceVar$var151$15;
 											
 											// Set the right hand term to a value from the array var141
 											double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1955,9 +1493,9 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// Execute the reduction function, saving the result into the return value.
 											// 
 											// Copy the result of the reduction into the variable returned by the reduction.
-											reduceVar$var151$21 = (x + y);
+											reduceVar$var151$15 = (x + y);
 										}
-										var139[i$var119] = reduceVar$var151$21;
+										var139[i$var119] = reduceVar$var151$15;
 									}
 							}
 						);
@@ -2158,12 +1696,12 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$23 = 0.0;
+										double reduceVar$var151$17 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 											// Set the left hand term of the reduction function to the return variable value.
-											double x = reduceVar$var151$23;
+											double x = reduceVar$var151$17;
 											
 											// Set the right hand term to a value from the array var141
 											double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -2171,9 +1709,9 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// Execute the reduction function, saving the result into the return value.
 											// 
 											// Copy the result of the reduction into the variable returned by the reduction.
-											reduceVar$var151$23 = (x + y);
+											reduceVar$var151$17 = (x + y);
 										}
-										var139[i$var119] = reduceVar$var151$23;
+										var139[i$var119] = reduceVar$var151$17;
 									}
 							}
 						);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$MultiThreadCPU_modelNoComments.java
@@ -12,8 +12,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 	private boolean fixedFlag$sample101 = false;
 	private boolean fixedProbFlag$sample101 = false;
 	private boolean fixedProbFlag$sample165 = false;
-	private boolean[][][] guard$sample101poisson164$global;
-	private boolean[][][] guard$sample101put160$global;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
 	private double logProbability$arr;
@@ -414,7 +412,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 							}
 						}
 						{
-							boolean[][] guard$sample101put160 = guard$sample101put160$global[threadID$cv$i$var80];
 							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 								if((i$var80 == i$var119)) {
 									for(int j = 0; j < time_dim; j += 1) {
@@ -424,97 +421,17 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 													if((t == index$t$3_4)) {
 														for(int index$i$3_5 = 0; index$i$3_5 < n_ac; index$i$3_5 += 1) {
 															if((i$var119 == index$i$3_5)) {
-																{
-																	guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$4_4 = (0 + 1); index$t$4_4 < T; index$t$4_4 += 1) {
-													if((t == index$t$4_4)) {
-														for(int index$i$4_5 = 0; index$i$4_5 < n_ac; index$i$4_5 += 1) {
-															if((i$var119 == index$i$4_5)) {
 																if(((0 <= j) && (j < time_dim))) {
 																	{
-																		guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$5_4 = (0 + 1); index$t$5_4 < T; index$t$5_4 += 1) {
-													if((t == index$t$5_4)) {
-														for(int index$i$5_5 = 0; index$i$5_5 < n_ac; index$i$5_5 += 1) {
-															if((i$var119 == index$i$5_5)) {
-																{
-																	if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																		guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
 																		{
-																			double[] var139 = sum_t[index$t$5_4];
-																			double reduceVar$var151$12 = 0.0;
+																			double[] var139 = sum_t[index$t$3_4];
+																			double reduceVar$var151$9 = 0.0;
 																			for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																				double x = reduceVar$var151$12;
-																				double y = time_impact[index$t$5_4][index$i$5_5][cv$reduction152Index];
-																				reduceVar$var151$12 = (x + y);
+																				double x = reduceVar$var151$9;
+																				double y = time_impact[index$t$3_4][index$i$3_5][cv$reduction152Index];
+																				reduceVar$var151$9 = (x + y);
 																			}
-																			var139[index$i$5_5] = reduceVar$var151$12;
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$6_4 = (0 + 1); index$t$6_4 < T; index$t$6_4 += 1) {
-													if((t == index$t$6_4)) {
-														for(int index$i$6_5 = 0; index$i$6_5 < n_ac; index$i$6_5 += 1) {
-															if((i$var119 == index$i$6_5)) {
-																if(((0 <= j) && (j < time_dim))) {
-																	{
-																		if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																			guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																			{
-																				double[] var139 = sum_t[index$t$6_4];
-																				double reduceVar$var151$13 = 0.0;
-																				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																					double x = reduceVar$var151$13;
-																					double y = time_impact[index$t$6_4][index$i$6_5][cv$reduction152Index];
-																					reduceVar$var151$13 = (x + y);
-																				}
-																				var139[index$i$6_5] = reduceVar$var151$13;
-																			}
+																			var139[index$i$3_5] = reduceVar$var151$9;
 																		}
 																	}
 																}
@@ -543,98 +460,39 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 					double cv$accumulatedProbabilities = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$currentValue - cv$temp$0$var83) / Math.sqrt(cv$temp$1$var84))) - (0.5 * Math.log(cv$temp$1$var84))));
 					{
 						{
-							boolean[][] guard$sample101poisson164 = guard$sample101poisson164$global[threadID$cv$i$var80];
+							double traceTempVariable$var134$4_1 = cv$currentValue;
 							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 								if((i$var80 == i$var119)) {
 									for(int j = 0; j < time_dim; j += 1) {
 										if((var95 == j)) {
 											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$7_4 = (0 + 1); index$t$7_4 < T; index$t$7_4 += 1) {
-													if((t == index$t$7_4)) {
-														for(int index$i$7_5 = 0; index$i$7_5 < n_ac; index$i$7_5 += 1) {
-															if((i$var119 == index$i$7_5)) {
-																{
-																	for(int index$t$7_6 = (0 + 1); index$t$7_6 < T; index$t$7_6 += 1) {
-																		if((index$t$7_4 == index$t$7_6)) {
-																			for(int index$i$7_7 = 0; index$i$7_7 < n_ac; index$i$7_7 += 1) {
-																				if((index$i$7_5 == index$i$7_7))
-																					guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$8_4 = (0 + 1); index$t$8_4 < T; index$t$8_4 += 1) {
-													if((t == index$t$8_4)) {
-														for(int index$i$8_5 = 0; index$i$8_5 < n_ac; index$i$8_5 += 1) {
-															if((i$var119 == index$i$8_5)) {
+												double traceTempVariable$x$4_5 = (TimeFeat[t][j] * traceTempVariable$var134$4_1);
+												for(int index$t$4_6 = (0 + 1); index$t$4_6 < T; index$t$4_6 += 1) {
+													if((t == index$t$4_6)) {
+														for(int index$i$4_7 = 0; index$i$4_7 < n_ac; index$i$4_7 += 1) {
+															if((i$var119 == index$i$4_7)) {
 																if(((0 <= j) && (j < time_dim))) {
 																	{
-																		for(int index$t$8_6 = (0 + 1); index$t$8_6 < T; index$t$8_6 += 1) {
-																			if((index$t$8_4 == index$t$8_6)) {
-																				for(int index$i$8_7 = 0; index$i$8_7 < n_ac; index$i$8_7 += 1) {
-																					if((index$i$8_5 == index$i$8_7))
-																						guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																				}
+																		if((0 < time_dim)) {
+																			double reduceVar$var151$10 = 0.0;
+																			for(int cv$reduction673Index = 0; cv$reduction673Index < j; cv$reduction673Index += 1) {
+																				double x = reduceVar$var151$10;
+																				double y = time_impact[index$t$4_6][index$i$4_7][cv$reduction673Index];
+																				reduceVar$var151$10 = (x + y);
 																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							double traceTempVariable$var134$9_1 = cv$currentValue;
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$9_5 = (0 + 1); index$t$9_5 < T; index$t$9_5 += 1) {
-													if((t == index$t$9_5)) {
-														for(int index$i$9_6 = 0; index$i$9_6 < n_ac; index$i$9_6 += 1) {
-															if((i$var119 == index$i$9_6)) {
-																{
-																	if((0 < time_dim)) {
-																		double reduceVar$var151$14 = time_impact[index$t$9_5][index$i$9_6][0];
-																		for(int cv$reduction1129Index = 0; cv$reduction1129Index < 0; cv$reduction1129Index += 1) {
-																			double x = reduceVar$var151$14;
-																			double y = time_impact[index$t$9_5][index$i$9_6][cv$reduction1129Index];
-																			reduceVar$var151$14 = (x + y);
-																		}
-																		for(int cv$reduction1129Index = (0 + 1); cv$reduction1129Index < time_dim; cv$reduction1129Index += 1) {
-																			double x = reduceVar$var151$14;
-																			double y = time_impact[index$t$9_5][index$i$9_6][cv$reduction1129Index];
-																			reduceVar$var151$14 = (x + y);
-																		}
-																		double cv$reduced152 = reduceVar$var151$14;
-																		reduceVar$var151$14 = (0.0 + cv$reduced152);
-																		double traceTempVariable$var151$9_7 = reduceVar$var151$14;
-																		double traceTempVariable$var156$9_8 = traceTempVariable$var151$9_7;
-																		for(int index$t$9_9 = (0 + 1); index$t$9_9 < T; index$t$9_9 += 1) {
-																			if((index$t$9_5 == index$t$9_9)) {
-																				for(int index$i$9_10 = 0; index$i$9_10 < n_ac; index$i$9_10 += 1) {
-																					if((index$i$9_6 == index$i$9_10)) {
-																						if(!guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																							guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
+																			for(int cv$reduction673Index = (j + 1); cv$reduction673Index < time_dim; cv$reduction673Index += 1) {
+																				double x = reduceVar$var151$10;
+																				double y = time_impact[index$t$4_6][index$i$4_7][cv$reduction673Index];
+																				reduceVar$var151$10 = (x + y);
+																			}
+																			double cv$reduced152 = reduceVar$var151$10;
+																			reduceVar$var151$10 = (traceTempVariable$x$4_5 + cv$reduced152);
+																			double traceTempVariable$var151$4_8 = reduceVar$var151$10;
+																			double traceTempVariable$var156$4_9 = traceTempVariable$var151$4_8;
+																			for(int index$t$4_10 = (0 + 1); index$t$4_10 < T; index$t$4_10 += 1) {
+																				if((index$t$4_6 == index$t$4_10)) {
+																					for(int index$i$4_11 = 0; index$i$4_11 < n_ac; index$i$4_11 += 1) {
+																						if((index$i$4_7 == index$i$4_11)) {
 																							{
 																								double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
 																								double cv$consumerDistributionProbabilityAccumulator = 1.0;
@@ -644,16 +502,16 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 																											{
 																												double cv$temp$2$var156;
 																												{
-																													double var156 = traceTempVariable$var156$9_8;
+																													double var156 = traceTempVariable$var156$4_9;
 																													cv$temp$2$var156 = var156;
 																												}
-																												if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)) < cv$accumulatedConsumerProbabilities))
-																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
 																												else {
 																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156));
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156));
 																													else
-																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)));
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)));
 																												}
 																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
 																											}
@@ -668,93 +526,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 																										cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
 																									else
 																										cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
-																								}
-																							}
-																						}
-																					}
-																				}
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							double traceTempVariable$var134$10_1 = cv$currentValue;
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												double traceTempVariable$x$10_5 = (TimeFeat[t][j] * traceTempVariable$var134$10_1);
-												for(int index$t$10_6 = (0 + 1); index$t$10_6 < T; index$t$10_6 += 1) {
-													if((t == index$t$10_6)) {
-														for(int index$i$10_7 = 0; index$i$10_7 < n_ac; index$i$10_7 += 1) {
-															if((i$var119 == index$i$10_7)) {
-																if(((0 <= j) && (j < time_dim))) {
-																	{
-																		if((0 < time_dim)) {
-																			double reduceVar$var151$15 = 0.0;
-																			for(int cv$reduction1175Index = 0; cv$reduction1175Index < j; cv$reduction1175Index += 1) {
-																				double x = reduceVar$var151$15;
-																				double y = time_impact[index$t$10_6][index$i$10_7][cv$reduction1175Index];
-																				reduceVar$var151$15 = (x + y);
-																			}
-																			for(int cv$reduction1175Index = (j + 1); cv$reduction1175Index < time_dim; cv$reduction1175Index += 1) {
-																				double x = reduceVar$var151$15;
-																				double y = time_impact[index$t$10_6][index$i$10_7][cv$reduction1175Index];
-																				reduceVar$var151$15 = (x + y);
-																			}
-																			double cv$reduced152 = reduceVar$var151$15;
-																			reduceVar$var151$15 = (traceTempVariable$x$10_5 + cv$reduced152);
-																			double traceTempVariable$var151$10_8 = reduceVar$var151$15;
-																			double traceTempVariable$var156$10_9 = traceTempVariable$var151$10_8;
-																			for(int index$t$10_10 = (0 + 1); index$t$10_10 < T; index$t$10_10 += 1) {
-																				if((index$t$10_6 == index$t$10_10)) {
-																					for(int index$i$10_11 = 0; index$i$10_11 < n_ac; index$i$10_11 += 1) {
-																						if((index$i$10_7 == index$i$10_11)) {
-																							if(!guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																								guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																								{
-																									double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
-																									double cv$consumerDistributionProbabilityAccumulator = 1.0;
-																									{
-																										{
-																											{
-																												{
-																													double cv$temp$3$var156;
-																													{
-																														double var156 = traceTempVariable$var156$10_9;
-																														cv$temp$3$var156 = var156;
-																													}
-																													if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)) < cv$accumulatedConsumerProbabilities))
-																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
-																													else {
-																														if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																															cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156));
-																														else
-																															cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)));
-																													}
-																													cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
-																												}
-																											}
-																										}
-																									}
-																									cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
-																									if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
-																										cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
-																									else {
-																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																											cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
-																										else
-																											cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
-																									}
 																								}
 																							}
 																						}
@@ -814,107 +585,26 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 					}
 				}
 				{
-					boolean[][] guard$sample101put160 = guard$sample101put160$global[threadID$cv$i$var80];
 					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 						if((i$var80 == i$var119)) {
 							for(int j = 0; j < time_dim; j += 1) {
 								if((var95 == j)) {
 									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$17_4 = (0 + 1); index$t$17_4 < T; index$t$17_4 += 1) {
-											if((t == index$t$17_4)) {
-												for(int index$i$17_5 = 0; index$i$17_5 < n_ac; index$i$17_5 += 1) {
-													if((i$var119 == index$i$17_5)) {
-														{
-															guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$18_4 = (0 + 1); index$t$18_4 < T; index$t$18_4 += 1) {
-											if((t == index$t$18_4)) {
-												for(int index$i$18_5 = 0; index$i$18_5 < n_ac; index$i$18_5 += 1) {
-													if((i$var119 == index$i$18_5)) {
+										for(int index$t$9_4 = (0 + 1); index$t$9_4 < T; index$t$9_4 += 1) {
+											if((t == index$t$9_4)) {
+												for(int index$i$9_5 = 0; index$i$9_5 < n_ac; index$i$9_5 += 1) {
+													if((i$var119 == index$i$9_5)) {
 														if(((0 <= j) && (j < time_dim))) {
 															{
-																guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$19_4 = (0 + 1); index$t$19_4 < T; index$t$19_4 += 1) {
-											if((t == index$t$19_4)) {
-												for(int index$i$19_5 = 0; index$i$19_5 < n_ac; index$i$19_5 += 1) {
-													if((i$var119 == index$i$19_5)) {
-														{
-															if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
 																{
-																	double[] var139 = sum_t[index$t$19_4];
-																	double reduceVar$var151$16 = 0.0;
+																	double[] var139 = sum_t[index$t$9_4];
+																	double reduceVar$var151$11 = 0.0;
 																	for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																		double x = reduceVar$var151$16;
-																		double y = time_impact[index$t$19_4][index$i$19_5][cv$reduction152Index];
-																		reduceVar$var151$16 = (x + y);
+																		double x = reduceVar$var151$11;
+																		double y = time_impact[index$t$9_4][index$i$9_5][cv$reduction152Index];
+																		reduceVar$var151$11 = (x + y);
 																	}
-																	var139[index$i$19_5] = reduceVar$var151$16;
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$20_4 = (0 + 1); index$t$20_4 < T; index$t$20_4 += 1) {
-											if((t == index$t$20_4)) {
-												for(int index$i$20_5 = 0; index$i$20_5 < n_ac; index$i$20_5 += 1) {
-													if((i$var119 == index$i$20_5)) {
-														if(((0 <= j) && (j < time_dim))) {
-															{
-																if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																	guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																	{
-																		double[] var139 = sum_t[index$t$20_4];
-																		double reduceVar$var151$17 = 0.0;
-																		for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																			double x = reduceVar$var151$17;
-																			double y = time_impact[index$t$20_4][index$i$20_5][cv$reduction152Index];
-																			reduceVar$var151$17 = (x + y);
-																		}
-																		var139[index$i$20_5] = reduceVar$var151$17;
-																	}
+																	var139[index$i$9_5] = reduceVar$var151$11;
 																}
 															}
 														}
@@ -933,34 +623,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 	}
 
 	@Override
-	public final void allocateScratch() {
-		{
-			int cv$max_t = 0;
-			int cv$max_i$var119 = 0;
-			for(int t = (0 + 1); t < T; t += 1)
-				cv$max_i$var119 = Math.max(cv$max_i$var119, ((n_ac - 0) / 1));
-			cv$max_t = Math.max(cv$max_t, ((T - (0 + 1)) / 1));
-			{
-				int cv$threadCount = threadCount();
-				guard$sample101put160$global = new boolean[cv$threadCount][][];
-				for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
-					guard$sample101put160$global[cv$index] = new boolean[cv$max_t][cv$max_i$var119];
-			}
-		}
-		{
-			int cv$max_t = 0;
-			int cv$max_i$var119 = 0;
-			for(int t = (0 + 1); t < T; t += 1)
-				cv$max_i$var119 = Math.max(cv$max_i$var119, ((n_ac - 0) / 1));
-			cv$max_t = Math.max(cv$max_t, ((T - (0 + 1)) / 1));
-			{
-				int cv$threadCount = threadCount();
-				guard$sample101poisson164$global = new boolean[cv$threadCount][][];
-				for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
-					guard$sample101poisson164$global[cv$index] = new boolean[cv$max_t][cv$max_i$var119];
-			}
-		}
-	}
+	public final void allocateScratch() {}
 
 	@Override
 	public final void allocator() {
@@ -1010,7 +673,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 			for(int t = (0 + 1); t < T; t += 1)
 				logProbability$sample165[((t - (0 + 1)) / 1)] = new double[((((n_ac - 1) - 0) / 1) + 1)];
 		}
-		allocateScratch();
 	}
 
 	@Override
@@ -1052,15 +714,15 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 													}
 											}
 										);
-										double reduceVar$var151$18 = 0.0;
+										double reduceVar$var151$12 = 0.0;
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-											double x = reduceVar$var151$18;
+											double x = reduceVar$var151$12;
 											double y = time_impact[t][i$var119][cv$reduction152Index];
 											if(!fixedFlag$sample101)
-												reduceVar$var151$18 = (x + y);
+												reduceVar$var151$12 = (x + y);
 										}
 										if(!fixedFlag$sample101)
-											var139[i$var119] = reduceVar$var151$18;
+											var139[i$var119] = reduceVar$var151$12;
 										var154[i$var119] = DistributionSampling.samplePoisson(RNG$2, sum_t[t][i$var119]);
 									}
 							}
@@ -1107,13 +769,13 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 													}
 											}
 										);
-										double reduceVar$var151$22 = 0.0;
+										double reduceVar$var151$16 = 0.0;
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-											double x = reduceVar$var151$22;
+											double x = reduceVar$var151$16;
 											double y = time_impact[t][i$var119][cv$reduction152Index];
-											reduceVar$var151$22 = (x + y);
+											reduceVar$var151$16 = (x + y);
 										}
-										var139[i$var119] = reduceVar$var151$22;
+										var139[i$var119] = reduceVar$var151$16;
 									}
 							}
 						);
@@ -1160,13 +822,13 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 													}
 											}
 										);
-										double reduceVar$var151$19 = 0.0;
+										double reduceVar$var151$13 = 0.0;
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-											double x = reduceVar$var151$19;
+											double x = reduceVar$var151$13;
 											double y = time_impact[t][i$var119][cv$reduction152Index];
-											reduceVar$var151$19 = (x + y);
+											reduceVar$var151$13 = (x + y);
 										}
-										var139[i$var119] = reduceVar$var151$19;
+										var139[i$var119] = reduceVar$var151$13;
 										var154[i$var119] = DistributionSampling.samplePoisson(RNG$2, sum_t[t][i$var119]);
 									}
 							}
@@ -1214,15 +876,15 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 													}
 											}
 										);
-										double reduceVar$var151$20 = 0.0;
+										double reduceVar$var151$14 = 0.0;
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-											double x = reduceVar$var151$20;
+											double x = reduceVar$var151$14;
 											double y = time_impact[t][i$var119][cv$reduction152Index];
 											if(!fixedFlag$sample101)
-												reduceVar$var151$20 = (x + y);
+												reduceVar$var151$14 = (x + y);
 										}
 										if(!fixedFlag$sample101)
-											var139[i$var119] = reduceVar$var151$20;
+											var139[i$var119] = reduceVar$var151$14;
 									}
 							}
 						);
@@ -1268,13 +930,13 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 													}
 											}
 										);
-										double reduceVar$var151$21 = 0.0;
+										double reduceVar$var151$15 = 0.0;
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-											double x = reduceVar$var151$21;
+											double x = reduceVar$var151$15;
 											double y = time_impact[t][i$var119][cv$reduction152Index];
-											reduceVar$var151$21 = (x + y);
+											reduceVar$var151$15 = (x + y);
 										}
-										var139[i$var119] = reduceVar$var151$21;
+										var139[i$var119] = reduceVar$var151$15;
 									}
 							}
 						);
@@ -1400,13 +1062,13 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 													}
 											}
 										);
-										double reduceVar$var151$23 = 0.0;
+										double reduceVar$var151$17 = 0.0;
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-											double x = reduceVar$var151$23;
+											double x = reduceVar$var151$17;
 											double y = time_impact[t][i$var119][cv$reduction152Index];
-											reduceVar$var151$23 = (x + y);
+											reduceVar$var151$17 = (x + y);
 										}
-										var139[i$var119] = reduceVar$var151$23;
+										var139[i$var119] = reduceVar$var151$17;
 									}
 							}
 						);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$MultiThreadCPU_modelSingle.java
@@ -14,8 +14,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 	private boolean fixedFlag$sample101 = false;
 	private boolean fixedProbFlag$sample101 = false;
 	private boolean fixedProbFlag$sample165 = false;
-	private boolean[][][] guard$sample101poisson164$global;
-	private boolean[][][] guard$sample101put160$global;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
 	private double logProbability$arr;
@@ -648,9 +646,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 						// 
 						// Looking for a path between Sample 101 and consumer double[][] 153.
 						{
-							// Guard to check that at most one copy of the code is executed for a given random
-							// variable instance.
-							boolean[][] guard$sample101put160 = guard$sample101put160$global[threadID$cv$i$var80];
 							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 								if((i$var80 == i$var119)) {
 									for(int j = 0; j < time_dim; j += 1) {
@@ -660,131 +655,32 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 													if((t == index$t$3_4)) {
 														for(int index$i$3_5 = 0; index$i$3_5 < n_ac; index$i$3_5 += 1) {
 															if((i$var119 == index$i$3_5)) {
-																{
-																	// Set the flags to false
-																	guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$4_4 = (0 + 1); index$t$4_4 < T; index$t$4_4 += 1) {
-													if((t == index$t$4_4)) {
-														for(int index$i$4_5 = 0; index$i$4_5 < n_ac; index$i$4_5 += 1) {
-															if((i$var119 == index$i$4_5)) {
 																if(((0 <= j) && (j < time_dim))) {
 																	{
-																		// Set the flags to false
-																		guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$5_4 = (0 + 1); index$t$5_4 < T; index$t$5_4 += 1) {
-													if((t == index$t$5_4)) {
-														for(int index$i$5_5 = 0; index$i$5_5 < n_ac; index$i$5_5 += 1) {
-															if((i$var119 == index$i$5_5)) {
-																{
-																	if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																		// The body will execute, so should not be executed again
-																		guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
 																		{
-																			double[] var139 = sum_t[index$t$5_4];
+																			double[] var139 = sum_t[index$t$3_4];
 																			
 																			// Reduction of array null
 																			// 
 																			// A generated name to prevent name collisions if the reduction is implemented more
 																			// than once in inference and probability code. Initialize the variable to the unit
 																			// value
-																			double reduceVar$var151$12 = 0.0;
+																			double reduceVar$var151$9 = 0.0;
 																			
 																			// For each index in the array to be reduced
 																			for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 																				// Set the left hand term of the reduction function to the return variable value.
-																				double x = reduceVar$var151$12;
+																				double x = reduceVar$var151$9;
 																				
 																				// Set the right hand term to a value from the array var141
-																				double y = time_impact[index$t$5_4][index$i$5_5][cv$reduction152Index];
+																				double y = time_impact[index$t$3_4][index$i$3_5][cv$reduction152Index];
 																				
 																				// Execute the reduction function, saving the result into the return value.
 																				// 
 																				// Copy the result of the reduction into the variable returned by the reduction.
-																				reduceVar$var151$12 = (x + y);
+																				reduceVar$var151$9 = (x + y);
 																			}
-																			var139[index$i$5_5] = reduceVar$var151$12;
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$6_4 = (0 + 1); index$t$6_4 < T; index$t$6_4 += 1) {
-													if((t == index$t$6_4)) {
-														for(int index$i$6_5 = 0; index$i$6_5 < n_ac; index$i$6_5 += 1) {
-															if((i$var119 == index$i$6_5)) {
-																if(((0 <= j) && (j < time_dim))) {
-																	{
-																		if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																			// The body will execute, so should not be executed again
-																			guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																			{
-																				double[] var139 = sum_t[index$t$6_4];
-																				
-																				// Reduction of array null
-																				// 
-																				// A generated name to prevent name collisions if the reduction is implemented more
-																				// than once in inference and probability code. Initialize the variable to the unit
-																				// value
-																				double reduceVar$var151$13 = 0.0;
-																				
-																				// For each index in the array to be reduced
-																				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																					// Set the left hand term of the reduction function to the return variable value.
-																					double x = reduceVar$var151$13;
-																					
-																					// Set the right hand term to a value from the array var141
-																					double y = time_impact[index$t$6_4][index$i$6_5][cv$reduction152Index];
-																					
-																					// Execute the reduction function, saving the result into the return value.
-																					// 
-																					// Copy the result of the reduction into the variable returned by the reduction.
-																					reduceVar$var151$13 = (x + y);
-																				}
-																				var139[index$i$6_5] = reduceVar$var151$13;
-																			}
+																			var139[index$i$3_5] = reduceVar$var151$9;
 																		}
 																	}
 																}
@@ -820,129 +716,64 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 					{
 						// Looking for a path between Sample 101 and consumer Poisson 157.
 						{
-							// Guard to check that at most one copy of the code is executed for a given random
-							// variable instance.
-							boolean[][] guard$sample101poisson164 = guard$sample101poisson164$global[threadID$cv$i$var80];
+							double traceTempVariable$var134$4_1 = cv$currentValue;
 							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 								if((i$var80 == i$var119)) {
 									for(int j = 0; j < time_dim; j += 1) {
 										if((var95 == j)) {
 											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$7_4 = (0 + 1); index$t$7_4 < T; index$t$7_4 += 1) {
-													if((t == index$t$7_4)) {
-														for(int index$i$7_5 = 0; index$i$7_5 < n_ac; index$i$7_5 += 1) {
-															if((i$var119 == index$i$7_5)) {
-																{
-																	for(int index$t$7_6 = (0 + 1); index$t$7_6 < T; index$t$7_6 += 1) {
-																		if((index$t$7_4 == index$t$7_6)) {
-																			for(int index$i$7_7 = 0; index$i$7_7 < n_ac; index$i$7_7 += 1) {
-																				if((index$i$7_5 == index$i$7_7))
-																					// Set the flags to false
-																					guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$8_4 = (0 + 1); index$t$8_4 < T; index$t$8_4 += 1) {
-													if((t == index$t$8_4)) {
-														for(int index$i$8_5 = 0; index$i$8_5 < n_ac; index$i$8_5 += 1) {
-															if((i$var119 == index$i$8_5)) {
+												double traceTempVariable$x$4_5 = (TimeFeat[t][j] * traceTempVariable$var134$4_1);
+												for(int index$t$4_6 = (0 + 1); index$t$4_6 < T; index$t$4_6 += 1) {
+													if((t == index$t$4_6)) {
+														for(int index$i$4_7 = 0; index$i$4_7 < n_ac; index$i$4_7 += 1) {
+															if((i$var119 == index$i$4_7)) {
 																if(((0 <= j) && (j < time_dim))) {
 																	{
-																		for(int index$t$8_6 = (0 + 1); index$t$8_6 < T; index$t$8_6 += 1) {
-																			if((index$t$8_4 == index$t$8_6)) {
-																				for(int index$i$8_7 = 0; index$i$8_7 < n_ac; index$i$8_7 += 1) {
-																					if((index$i$8_5 == index$i$8_7))
-																						// Set the flags to false
-																						guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																				}
+																		if((0 < time_dim)) {
+																			// Reduction of array null
+																			// 
+																			// A generated name to prevent name collisions if the reduction is implemented more
+																			// than once in inference and probability code. Initialize the variable to the unit
+																			// value
+																			double reduceVar$var151$10 = 0.0;
+																			
+																			// Reduce for every value except a masked value which will be skipped.
+																			for(int cv$reduction642Index = 0; cv$reduction642Index < j; cv$reduction642Index += 1) {
+																				// Set the left hand term of the reduction function to the return variable value.
+																				double x = reduceVar$var151$10;
+																				
+																				// Set the right hand term to a value from the array var141
+																				double y = time_impact[index$t$4_6][index$i$4_7][cv$reduction642Index];
+																				
+																				// Execute the reduction function, saving the result into the return value.
+																				// 
+																				// Copy the result of the reduction into the variable returned by the reduction.
+																				reduceVar$var151$10 = (x + y);
 																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							double traceTempVariable$var134$9_1 = cv$currentValue;
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$9_5 = (0 + 1); index$t$9_5 < T; index$t$9_5 += 1) {
-													if((t == index$t$9_5)) {
-														for(int index$i$9_6 = 0; index$i$9_6 < n_ac; index$i$9_6 += 1) {
-															if((i$var119 == index$i$9_6)) {
-																{
-																	if((0 < time_dim)) {
-																		// Reduction of array null
-																		// 
-																		// A generated name to prevent name collisions if the reduction is implemented more
-																		// than once in inference and probability code. Initialize the variable to the unit
-																		// value
-																		double reduceVar$var151$14 = time_impact[index$t$9_5][index$i$9_6][0];
-																		
-																		// Reduce for every value except a masked value which will be skipped.
-																		for(int cv$reduction1098Index = 0; cv$reduction1098Index < 0; cv$reduction1098Index += 1) {
-																			// Set the left hand term of the reduction function to the return variable value.
-																			double x = reduceVar$var151$14;
+																			for(int cv$reduction642Index = (j + 1); cv$reduction642Index < time_dim; cv$reduction642Index += 1) {
+																				// Set the left hand term of the reduction function to the return variable value.
+																				double x = reduceVar$var151$10;
+																				
+																				// Set the right hand term to a value from the array var141
+																				double y = time_impact[index$t$4_6][index$i$4_7][cv$reduction642Index];
+																				
+																				// Execute the reduction function, saving the result into the return value.
+																				// 
+																				// Execute the reduction function, saving the result into the return value.
+																				// 
+																				// Copy the result of the reduction into the variable returned by the reduction.
+																				reduceVar$var151$10 = (x + y);
+																			}
+																			double cv$reduced152 = reduceVar$var151$10;
 																			
-																			// Set the right hand term to a value from the array var141
-																			double y = time_impact[index$t$9_5][index$i$9_6][cv$reduction1098Index];
-																			
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
 																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$14 = (x + y);
-																		}
-																		for(int cv$reduction1098Index = (0 + 1); cv$reduction1098Index < time_dim; cv$reduction1098Index += 1) {
-																			// Set the left hand term of the reduction function to the return variable value.
-																			double x = reduceVar$var151$14;
-																			
-																			// Set the right hand term to a value from the array var141
-																			double y = time_impact[index$t$9_5][index$i$9_6][cv$reduction1098Index];
-																			
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
-																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$14 = (x + y);
-																		}
-																		double cv$reduced152 = reduceVar$var151$14;
-																		
-																		// Copy the result of the reduction into the variable returned by the reduction.
-																		reduceVar$var151$14 = (0.0 + cv$reduced152);
-																		double traceTempVariable$var151$9_7 = reduceVar$var151$14;
-																		double traceTempVariable$var156$9_8 = traceTempVariable$var151$9_7;
-																		for(int index$t$9_9 = (0 + 1); index$t$9_9 < T; index$t$9_9 += 1) {
-																			if((index$t$9_5 == index$t$9_9)) {
-																				for(int index$i$9_10 = 0; index$i$9_10 < n_ac; index$i$9_10 += 1) {
-																					if((index$i$9_6 == index$i$9_10)) {
-																						if(!guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																							// The body will execute, so should not be executed again
-																							guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																							
+																			reduceVar$var151$10 = (traceTempVariable$x$4_5 + cv$reduced152);
+																			double traceTempVariable$var151$4_8 = reduceVar$var151$10;
+																			double traceTempVariable$var156$4_9 = traceTempVariable$var151$4_8;
+																			for(int index$t$4_10 = (0 + 1); index$t$4_10 < T; index$t$4_10 += 1) {
+																				if((index$t$4_6 == index$t$4_10)) {
+																					for(int index$i$4_11 = 0; index$i$4_11 < n_ac; index$i$4_11 += 1) {
+																						if((index$i$4_7 == index$i$4_11)) {
 																							// Processing sample task 165 of consumer random variable null.
 																							{
 																								// Set an accumulator to sum the probabilities for each possible configuration of
@@ -959,19 +790,19 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 																												double cv$temp$2$var156;
 																												{
 																													// Constructing a random variable input for use later.
-																													double var156 = traceTempVariable$var156$9_8;
+																													double var156 = traceTempVariable$var156$4_9;
 																													cv$temp$2$var156 = var156;
 																												}
 																												
 																												// Record the probability of sample task 165 generating output with current configuration.
-																												if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)) < cv$accumulatedConsumerProbabilities))
-																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
 																												else {
 																													// If the second value is -infinity.
 																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156));
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156));
 																													else
-																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)));
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)));
 																												}
 																												
 																												// Recorded the probability of reaching sample task 165 with the current configuration.
@@ -995,139 +826,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 																										cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
 																									else
 																										cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
-																								}
-																							}
-																						}
-																					}
-																				}
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							double traceTempVariable$var134$10_1 = cv$currentValue;
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												double traceTempVariable$x$10_5 = (TimeFeat[t][j] * traceTempVariable$var134$10_1);
-												for(int index$t$10_6 = (0 + 1); index$t$10_6 < T; index$t$10_6 += 1) {
-													if((t == index$t$10_6)) {
-														for(int index$i$10_7 = 0; index$i$10_7 < n_ac; index$i$10_7 += 1) {
-															if((i$var119 == index$i$10_7)) {
-																if(((0 <= j) && (j < time_dim))) {
-																	{
-																		if((0 < time_dim)) {
-																			// Reduction of array null
-																			// 
-																			// A generated name to prevent name collisions if the reduction is implemented more
-																			// than once in inference and probability code. Initialize the variable to the unit
-																			// value
-																			double reduceVar$var151$15 = 0.0;
-																			
-																			// Reduce for every value except a masked value which will be skipped.
-																			for(int cv$reduction1144Index = 0; cv$reduction1144Index < j; cv$reduction1144Index += 1) {
-																				// Set the left hand term of the reduction function to the return variable value.
-																				double x = reduceVar$var151$15;
-																				
-																				// Set the right hand term to a value from the array var141
-																				double y = time_impact[index$t$10_6][index$i$10_7][cv$reduction1144Index];
-																				
-																				// Execute the reduction function, saving the result into the return value.
-																				// 
-																				// Copy the result of the reduction into the variable returned by the reduction.
-																				reduceVar$var151$15 = (x + y);
-																			}
-																			for(int cv$reduction1144Index = (j + 1); cv$reduction1144Index < time_dim; cv$reduction1144Index += 1) {
-																				// Set the left hand term of the reduction function to the return variable value.
-																				double x = reduceVar$var151$15;
-																				
-																				// Set the right hand term to a value from the array var141
-																				double y = time_impact[index$t$10_6][index$i$10_7][cv$reduction1144Index];
-																				
-																				// Execute the reduction function, saving the result into the return value.
-																				// 
-																				// Execute the reduction function, saving the result into the return value.
-																				// 
-																				// Copy the result of the reduction into the variable returned by the reduction.
-																				reduceVar$var151$15 = (x + y);
-																			}
-																			double cv$reduced152 = reduceVar$var151$15;
-																			
-																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$15 = (traceTempVariable$x$10_5 + cv$reduced152);
-																			double traceTempVariable$var151$10_8 = reduceVar$var151$15;
-																			double traceTempVariable$var156$10_9 = traceTempVariable$var151$10_8;
-																			for(int index$t$10_10 = (0 + 1); index$t$10_10 < T; index$t$10_10 += 1) {
-																				if((index$t$10_6 == index$t$10_10)) {
-																					for(int index$i$10_11 = 0; index$i$10_11 < n_ac; index$i$10_11 += 1) {
-																						if((index$i$10_7 == index$i$10_11)) {
-																							if(!guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																								// The body will execute, so should not be executed again
-																								guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																								
-																								// Processing sample task 165 of consumer random variable null.
-																								{
-																									// Set an accumulator to sum the probabilities for each possible configuration of
-																									// inputs.
-																									double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
-																									
-																									// Set an accumulator to record the consumer distributions not seen. Initially set
-																									// to 1 as seen values will be deducted from this value.
-																									double cv$consumerDistributionProbabilityAccumulator = 1.0;
-																									{
-																										{
-																											{
-																												{
-																													double cv$temp$3$var156;
-																													{
-																														// Constructing a random variable input for use later.
-																														double var156 = traceTempVariable$var156$10_9;
-																														cv$temp$3$var156 = var156;
-																													}
-																													
-																													// Record the probability of sample task 165 generating output with current configuration.
-																													if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)) < cv$accumulatedConsumerProbabilities))
-																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
-																													else {
-																														// If the second value is -infinity.
-																														if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																															cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156));
-																														else
-																															cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)));
-																													}
-																													
-																													// Recorded the probability of reaching sample task 165 with the current configuration.
-																													cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
-																												}
-																											}
-																										}
-																									}
-																									
-																									// A check to ensure rounding of floating point values can never result in a negative
-																									// value.
-																									cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
-																									
-																									// Multiply (log space add) in the probability of the sample task to the overall probability
-																									// for this configuration of the source random variable.
-																									if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
-																										cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
-																									else {
-																										// If the second value is -infinity.
-																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																											cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
-																										else
-																											cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
-																									}
 																								}
 																							}
 																						}
@@ -1216,143 +914,41 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 				// 
 				// Looking for a path between Sample 101 and consumer double[][] 153.
 				{
-					// Guard to check that at most one copy of the code is executed for a given random
-					// variable instance.
-					boolean[][] guard$sample101put160 = guard$sample101put160$global[threadID$cv$i$var80];
 					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 						if((i$var80 == i$var119)) {
 							for(int j = 0; j < time_dim; j += 1) {
 								if((var95 == j)) {
 									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$17_4 = (0 + 1); index$t$17_4 < T; index$t$17_4 += 1) {
-											if((t == index$t$17_4)) {
-												for(int index$i$17_5 = 0; index$i$17_5 < n_ac; index$i$17_5 += 1) {
-													if((i$var119 == index$i$17_5)) {
-														{
-															// Set the flags to false
-															guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$18_4 = (0 + 1); index$t$18_4 < T; index$t$18_4 += 1) {
-											if((t == index$t$18_4)) {
-												for(int index$i$18_5 = 0; index$i$18_5 < n_ac; index$i$18_5 += 1) {
-													if((i$var119 == index$i$18_5)) {
+										for(int index$t$9_4 = (0 + 1); index$t$9_4 < T; index$t$9_4 += 1) {
+											if((t == index$t$9_4)) {
+												for(int index$i$9_5 = 0; index$i$9_5 < n_ac; index$i$9_5 += 1) {
+													if((i$var119 == index$i$9_5)) {
 														if(((0 <= j) && (j < time_dim))) {
 															{
-																// Set the flags to false
-																guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$19_4 = (0 + 1); index$t$19_4 < T; index$t$19_4 += 1) {
-											if((t == index$t$19_4)) {
-												for(int index$i$19_5 = 0; index$i$19_5 < n_ac; index$i$19_5 += 1) {
-													if((i$var119 == index$i$19_5)) {
-														{
-															if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																// The body will execute, so should not be executed again
-																guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
 																{
-																	double[] var139 = sum_t[index$t$19_4];
+																	double[] var139 = sum_t[index$t$9_4];
 																	
 																	// Reduction of array null
 																	// 
 																	// A generated name to prevent name collisions if the reduction is implemented more
 																	// than once in inference and probability code. Initialize the variable to the unit
 																	// value
-																	double reduceVar$var151$16 = 0.0;
+																	double reduceVar$var151$11 = 0.0;
 																	
 																	// For each index in the array to be reduced
 																	for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 																		// Set the left hand term of the reduction function to the return variable value.
-																		double x = reduceVar$var151$16;
+																		double x = reduceVar$var151$11;
 																		
 																		// Set the right hand term to a value from the array var141
-																		double y = time_impact[index$t$19_4][index$i$19_5][cv$reduction152Index];
+																		double y = time_impact[index$t$9_4][index$i$9_5][cv$reduction152Index];
 																		
 																		// Execute the reduction function, saving the result into the return value.
 																		// 
 																		// Copy the result of the reduction into the variable returned by the reduction.
-																		reduceVar$var151$16 = (x + y);
+																		reduceVar$var151$11 = (x + y);
 																	}
-																	var139[index$i$19_5] = reduceVar$var151$16;
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$20_4 = (0 + 1); index$t$20_4 < T; index$t$20_4 += 1) {
-											if((t == index$t$20_4)) {
-												for(int index$i$20_5 = 0; index$i$20_5 < n_ac; index$i$20_5 += 1) {
-													if((i$var119 == index$i$20_5)) {
-														if(((0 <= j) && (j < time_dim))) {
-															{
-																if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																	// The body will execute, so should not be executed again
-																	guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																	{
-																		double[] var139 = sum_t[index$t$20_4];
-																		
-																		// Reduction of array null
-																		// 
-																		// A generated name to prevent name collisions if the reduction is implemented more
-																		// than once in inference and probability code. Initialize the variable to the unit
-																		// value
-																		double reduceVar$var151$17 = 0.0;
-																		
-																		// For each index in the array to be reduced
-																		for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																			// Set the left hand term of the reduction function to the return variable value.
-																			double x = reduceVar$var151$17;
-																			
-																			// Set the right hand term to a value from the array var141
-																			double y = time_impact[index$t$20_4][index$i$20_5][cv$reduction152Index];
-																			
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
-																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$17 = (x + y);
-																		}
-																		var139[index$i$20_5] = reduceVar$var151$17;
-																	}
+																	var139[index$i$9_5] = reduceVar$var151$11;
 																}
 															}
 														}
@@ -1374,62 +970,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 	// here prevents repeated allocation and deallocation, and makes the code more amenable
 	// to GPU execution.
 	@Override
-	public final void allocateScratch() {
-		// Allocate scratch space.
-		// Constructor for guard$sample101put160$global
-		{
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_t = 0;
-			
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_i$var119 = 0;
-			for(int t = (0 + 1); t < T; t += 1)
-				cv$max_i$var119 = Math.max(cv$max_i$var119, ((n_ac - 0) / 1));
-			cv$max_t = Math.max(cv$max_t, ((T - (0 + 1)) / 1));
-			
-			// Allocation of guard$sample101put160$global for multithreaded execution
-			{
-				// Get the thread count.
-				int cv$threadCount = threadCount();
-				
-				// Allocate an array to hold a copy per thread
-				guard$sample101put160$global = new boolean[cv$threadCount][][];
-				
-				// Populate the array with a copy per thread
-				for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
-					guard$sample101put160$global[cv$index] = new boolean[cv$max_t][cv$max_i$var119];
-			}
-		}
-		
-		// Constructor for guard$sample101poisson164$global
-		{
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_t = 0;
-			
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_i$var119 = 0;
-			for(int t = (0 + 1); t < T; t += 1)
-				cv$max_i$var119 = Math.max(cv$max_i$var119, ((n_ac - 0) / 1));
-			cv$max_t = Math.max(cv$max_t, ((T - (0 + 1)) / 1));
-			
-			// Allocation of guard$sample101poisson164$global for multithreaded execution
-			{
-				// Get the thread count.
-				int cv$threadCount = threadCount();
-				
-				// Allocate an array to hold a copy per thread
-				guard$sample101poisson164$global = new boolean[cv$threadCount][][];
-				
-				// Populate the array with a copy per thread
-				for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
-					guard$sample101poisson164$global[cv$index] = new boolean[cv$max_t][cv$max_i$var119];
-			}
-		}
-	}
+	public final void allocateScratch() {}
 
 	// Method to allocate space for model inputs and outputs.
 	@Override
@@ -1477,9 +1018,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 			for(int i$var80 = 0; i$var80 < n_ac; i$var80 += 1)
 				logProbability$sample101[((i$var80 - 0) / 1)] = new double[((((TimeFeat[0].length - 1) - 0) / 1) + 1)];
 		}
-		
-		// Allocate scratch space
-		allocateScratch();
 	}
 
 	// Method to execute the model code conventionally.
@@ -1552,12 +1090,12 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$18 = 0.0;
+										double reduceVar$var151$12 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 											// Set the left hand term of the reduction function to the return variable value.
-											double x = reduceVar$var151$18;
+											double x = reduceVar$var151$12;
 											
 											// Set the right hand term to a value from the array var141
 											double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1565,10 +1103,10 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// Execute the reduction function, saving the result into the return value.
 											if(!fixedFlag$sample101)
 												// Copy the result of the reduction into the variable returned by the reduction.
-												reduceVar$var151$18 = (x + y);
+												reduceVar$var151$12 = (x + y);
 										}
 										if(!fixedFlag$sample101)
-											var139[i$var119] = reduceVar$var151$18;
+											var139[i$var119] = reduceVar$var151$12;
 										var154[i$var119] = DistributionSampling.samplePoisson(RNG$2, sum_t[t][i$var119]);
 									}
 							}
@@ -1648,12 +1186,12 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$22 = 0.0;
+										double reduceVar$var151$16 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 											// Set the left hand term of the reduction function to the return variable value.
-											double x = reduceVar$var151$22;
+											double x = reduceVar$var151$16;
 											
 											// Set the right hand term to a value from the array var141
 											double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1661,9 +1199,9 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// Execute the reduction function, saving the result into the return value.
 											// 
 											// Copy the result of the reduction into the variable returned by the reduction.
-											reduceVar$var151$22 = (x + y);
+											reduceVar$var151$16 = (x + y);
 										}
-										var139[i$var119] = reduceVar$var151$22;
+										var139[i$var119] = reduceVar$var151$16;
 									}
 							}
 						);
@@ -1742,12 +1280,12 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$19 = 0.0;
+										double reduceVar$var151$13 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 											// Set the left hand term of the reduction function to the return variable value.
-											double x = reduceVar$var151$19;
+											double x = reduceVar$var151$13;
 											
 											// Set the right hand term to a value from the array var141
 											double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1755,9 +1293,9 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// Execute the reduction function, saving the result into the return value.
 											// 
 											// Copy the result of the reduction into the variable returned by the reduction.
-											reduceVar$var151$19 = (x + y);
+											reduceVar$var151$13 = (x + y);
 										}
-										var139[i$var119] = reduceVar$var151$19;
+										var139[i$var119] = reduceVar$var151$13;
 										var154[i$var119] = DistributionSampling.samplePoisson(RNG$2, sum_t[t][i$var119]);
 									}
 							}
@@ -1837,12 +1375,12 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$20 = 0.0;
+										double reduceVar$var151$14 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 											// Set the left hand term of the reduction function to the return variable value.
-											double x = reduceVar$var151$20;
+											double x = reduceVar$var151$14;
 											
 											// Set the right hand term to a value from the array var141
 											double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1850,10 +1388,10 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// Execute the reduction function, saving the result into the return value.
 											if(!fixedFlag$sample101)
 												// Copy the result of the reduction into the variable returned by the reduction.
-												reduceVar$var151$20 = (x + y);
+												reduceVar$var151$14 = (x + y);
 										}
 										if(!fixedFlag$sample101)
-											var139[i$var119] = reduceVar$var151$20;
+											var139[i$var119] = reduceVar$var151$14;
 									}
 							}
 						);
@@ -1932,12 +1470,12 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$21 = 0.0;
+										double reduceVar$var151$15 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 											// Set the left hand term of the reduction function to the return variable value.
-											double x = reduceVar$var151$21;
+											double x = reduceVar$var151$15;
 											
 											// Set the right hand term to a value from the array var141
 											double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1945,9 +1483,9 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// Execute the reduction function, saving the result into the return value.
 											// 
 											// Copy the result of the reduction into the variable returned by the reduction.
-											reduceVar$var151$21 = (x + y);
+											reduceVar$var151$15 = (x + y);
 										}
-										var139[i$var119] = reduceVar$var151$21;
+										var139[i$var119] = reduceVar$var151$15;
 									}
 							}
 						);
@@ -2140,12 +1678,12 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$23 = 0.0;
+										double reduceVar$var151$17 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 											// Set the left hand term of the reduction function to the return variable value.
-											double x = reduceVar$var151$23;
+											double x = reduceVar$var151$17;
 											
 											// Set the right hand term to a value from the array var141
 											double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -2153,9 +1691,9 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// Execute the reduction function, saving the result into the return value.
 											// 
 											// Copy the result of the reduction into the variable returned by the reduction.
-											reduceVar$var151$23 = (x + y);
+											reduceVar$var151$17 = (x + y);
 										}
-										var139[i$var119] = reduceVar$var151$23;
+										var139[i$var119] = reduceVar$var151$17;
 									}
 							}
 						);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$MultiThreadCPU_optimisedModel.java
@@ -14,8 +14,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 	private boolean fixedFlag$sample101 = false;
 	private boolean fixedProbFlag$sample101 = false;
 	private boolean fixedProbFlag$sample165 = false;
-	private boolean[][][] guard$sample101poisson164$global;
-	private boolean[][][] guard$sample101put160$global;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
 	private double logProbability$arr;
@@ -414,373 +412,26 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 		
 		// The proposed new value for the sample
 		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
-		
-		// This value is not used before it is set again, so removing the value declaration.
-		// 
-		// The probability of the random variable generating the new sample value.
-		double cv$proposedProbability;
 		{
-			// Unrolled loop
-			{
-				// An accumulator to allow the value for each distribution to be constructed before
-				// it is added to the index probabilities.
-				// 
-				// Substituted "cv$temp$1$var84" with its value "1.0".
-				// 
-				// Set the current value to the current state of the tree.
-				double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$originalValue);
-				
-				// Processing random variable 157.
-				// 
-				// Looking for a path between Sample 101 and consumer Poisson 157.
-				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				boolean[][] guard$sample101poisson164 = guard$sample101poisson164$global[threadID$cv$i$var80];
-				for(int t = 1; t < T; t += 1)
-					// Set the flags to false
-					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101poisson164[(t - 1)][i$var80] = false;
-				for(int t = 1; t < T; t += 1) {
-					// Reduction of array null
-					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					// 
-					// Substituted "index$t$9_5" with its value "t".
-					// 
-					// Substituted "index$i$9_6" with its value "i$var80".
-					double reduceVar$var151$14 = time_impact[t][i$var80][0];
-					for(int cv$reduction1129Index = 1; cv$reduction1129Index < time_dim; cv$reduction1129Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$9_5" with its value "t".
-						// 
-						// Substituted "index$i$9_6" with its value "i$var80".
-						reduceVar$var151$14 = (reduceVar$var151$14 + time_impact[t][i$var80][cv$reduction1129Index]);
-					if(!guard$sample101poisson164[(t - 1)][i$var80]) {
-						// The body will execute, so should not be executed again
-						// 
-						// Substituted "i$var119" with its value "i$var80".
-						guard$sample101poisson164[(t - 1)][i$var80] = true;
-						
-						// A check to ensure rounding of floating point values can never result in a negative
-						// value.
-						// 
-						// Recorded the probability of reaching sample task 165 with the current configuration.
-						// 
-						// Set an accumulator to record the consumer distributions not seen. Initially set
-						// to 1 as seen values will be deducted from this value.
-						// 
-						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-						// Declaration comment was:
-						// Processing sample task 165 of consumer random variable null.
-						// 
-						// Set an accumulator to sum the probabilities for each possible configuration of
-						// inputs.
-						// 
-						// Substituted "index$i$9_10" with its value "index$i$9_6".
-						// 
-						// Substituted "index$t$9_9" with its value "t".
-						// 
-						// cv$temp$2$var156's comment
-						// Variable declaration of cv$temp$2$var156 moved.
-						// 
-						// Constructing a random variable input for use later.
-						cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$14) + cv$accumulatedProbabilities);
-					}
-				}
-				for(int t = 1; t < T; t += 1) {
-					// Reduction of array null
-					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$15 = 0.0;
-					
-					// Reduce for every value except a masked value which will be skipped.
-					// 
-					// Substituted "j" with its value "var95".
-					for(int cv$reduction1175Index = 0; cv$reduction1175Index < var95; cv$reduction1175Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$10_6" with its value "t".
-						// 
-						// Substituted "index$i$10_7" with its value "i$var80".
-						reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var80][cv$reduction1175Index]);
-					
-					// Substituted "j" with its value "var95".
-					for(int cv$reduction1175Index = (var95 + 1); cv$reduction1175Index < time_dim; cv$reduction1175Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$10_6" with its value "t".
-						// 
-						// Substituted "index$i$10_7" with its value "i$var80".
-						reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var80][cv$reduction1175Index]);
-					
-					// Copy the result of the reduction into the variable returned by the reduction.
-					// 
-					// Substituted "j" with its value "var95".
-					// 
-					// Set the current value to the current state of the tree.
-					reduceVar$var151$15 = ((TimeFeat[t][var95] * cv$originalValue) + reduceVar$var151$15);
-					if(!guard$sample101poisson164[(t - 1)][i$var80]) {
-						// The body will execute, so should not be executed again
-						// 
-						// Substituted "i$var119" with its value "i$var80".
-						guard$sample101poisson164[(t - 1)][i$var80] = true;
-						
-						// A check to ensure rounding of floating point values can never result in a negative
-						// value.
-						// 
-						// Recorded the probability of reaching sample task 165 with the current configuration.
-						// 
-						// Set an accumulator to record the consumer distributions not seen. Initially set
-						// to 1 as seen values will be deducted from this value.
-						// 
-						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-						// Declaration comment was:
-						// Processing sample task 165 of consumer random variable null.
-						// 
-						// Set an accumulator to sum the probabilities for each possible configuration of
-						// inputs.
-						// 
-						// Substituted "index$i$10_11" with its value "index$i$10_7".
-						// 
-						// Substituted "index$t$10_10" with its value "t".
-						// 
-						// cv$temp$3$var156's comment
-						// Variable declaration of cv$temp$3$var156 moved.
-						// 
-						// Constructing a random variable input for use later.
-						cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$15) + cv$accumulatedProbabilities);
-					}
-				}
-				
-				// Initialize a log space accumulator to take the product of all the distribution
-				// probabilities.
-				// 
-				// Record the reached probability density.
-				// 
-				// Initialize a counter to track the reached distributions.
-				cv$originalProbability = cv$accumulatedProbabilities;
-			}
-			time_coeff[i$var80][var95] = cv$proposedValue;
-			
-			// Guards to ensure that time_impact is only updated when there is a valid path.
-			// 
-			// Looking for a path between Sample 101 and consumer double[][][] 138.
-			for(int t = 1; t < T; t += 1)
-				// Substituted "i$var119" with its value "i$var80".
-				// 
-				// Substituted "i$var119" with its value "i$var80".
-				time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
-			
-			// Guards to ensure that sum_t is only updated when there is a valid path.
-			// 
-			// Looking for a path between Sample 101 and consumer double[][] 153.
-			// 
-			// Guard to check that at most one copy of the code is executed for a given random
-			// variable instance.
-			boolean[][] guard$sample101put160 = guard$sample101put160$global[threadID$cv$i$var80];
-			for(int t = 1; t < T; t += 1)
-				// Set the flags to false
-				// 
-				// Substituted "i$var119" with its value "i$var80".
-				guard$sample101put160[(t - 1)][i$var80] = false;
-			for(int t = 1; t < T; t += 1) {
-				// Constraints moved from conditionals in inner loops/scopes/etc.
-				if(!guard$sample101put160[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
-					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101put160[(t - 1)][i$var80] = true;
-					
-					// Reduction of array null
-					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$12 = 0.0;
-					
-					// For each index in the array to be reduced
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$5_4" with its value "t".
-						// 
-						// Substituted "index$i$5_5" with its value "i$var80".
-						reduceVar$var151$12 = (reduceVar$var151$12 + time_impact[t][i$var80][cv$reduction152Index]);
-					
-					// Substituted "index$t$5_4" with its value "t".
-					sum_t[t][i$var80] = reduceVar$var151$12;
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				// Constraints moved from conditionals in inner loops/scopes/etc.
-				if(!guard$sample101put160[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
-					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101put160[(t - 1)][i$var80] = true;
-					
-					// Reduction of array null
-					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$13 = 0.0;
-					
-					// For each index in the array to be reduced
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$6_4" with its value "t".
-						// 
-						// Substituted "index$i$6_5" with its value "i$var80".
-						reduceVar$var151$13 = (reduceVar$var151$13 + time_impact[t][i$var80][cv$reduction152Index]);
-					
-					// Substituted "index$t$6_4" with its value "t".
-					sum_t[t][i$var80] = reduceVar$var151$13;
-				}
-			}
-			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
 			// Substituted "cv$temp$1$var84" with its value "1.0".
-			double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$proposedValue);
-			
-			// Processing random variable 157.
 			// 
-			// Looking for a path between Sample 101 and consumer Poisson 157.
-			// 
-			// Guard to check that at most one copy of the code is executed for a given random
-			// variable instance.
-			boolean[][] guard$sample101poisson164 = guard$sample101poisson164$global[threadID$cv$i$var80];
-			for(int t = 1; t < T; t += 1)
-				// Set the flags to false
-				// 
-				// Substituted "i$var119" with its value "i$var80".
-				guard$sample101poisson164[(t - 1)][i$var80] = false;
+			// Set the current value to the current state of the tree.
+			double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$originalValue);
 			for(int t = 1; t < T; t += 1) {
 				// Reduction of array null
 				// 
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				// 
-				// Substituted "index$t$9_5" with its value "t".
-				// 
-				// Substituted "index$i$9_6" with its value "i$var80".
-				double reduceVar$var151$14 = time_impact[t][i$var80][0];
-				for(int cv$reduction1129Index = 1; cv$reduction1129Index < time_dim; cv$reduction1129Index += 1)
-					// Execute the reduction function, saving the result into the return value.
-					// 
-					// Execute the reduction function, saving the result into the return value.
-					// 
-					// Copy the result of the reduction into the variable returned by the reduction.
-					// 
-					// x's comment
-					// Set the left hand term of the reduction function to the return variable value.
-					// 
-					// y's comment
-					// Set the right hand term to a value from the array var141
-					// 
-					// Substituted "index$t$9_5" with its value "t".
-					// 
-					// Substituted "index$i$9_6" with its value "i$var80".
-					reduceVar$var151$14 = (reduceVar$var151$14 + time_impact[t][i$var80][cv$reduction1129Index]);
-				if(!guard$sample101poisson164[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
-					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101poisson164[(t - 1)][i$var80] = true;
-					
-					// A check to ensure rounding of floating point values can never result in a negative
-					// value.
-					// 
-					// Recorded the probability of reaching sample task 165 with the current configuration.
-					// 
-					// Set an accumulator to record the consumer distributions not seen. Initially set
-					// to 1 as seen values will be deducted from this value.
-					// 
-					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-					// Declaration comment was:
-					// Processing sample task 165 of consumer random variable null.
-					// 
-					// Set an accumulator to sum the probabilities for each possible configuration of
-					// inputs.
-					// 
-					// Substituted "index$i$9_10" with its value "index$i$9_6".
-					// 
-					// Substituted "index$t$9_9" with its value "t".
-					// 
-					// cv$temp$2$var156's comment
-					// Variable declaration of cv$temp$2$var156 moved.
-					// 
-					// Constructing a random variable input for use later.
-					cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$14) + cv$accumulatedProbabilities);
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				// Reduction of array null
-				// 
-				// A generated name to prevent name collisions if the reduction is implemented more
-				// than once in inference and probability code. Initialize the variable to the unit
-				// value
-				double reduceVar$var151$15 = 0.0;
+				double reduceVar$var151$10 = 0.0;
 				
 				// Reduce for every value except a masked value which will be skipped.
 				// 
 				// Substituted "j" with its value "var95".
-				for(int cv$reduction1175Index = 0; cv$reduction1175Index < var95; cv$reduction1175Index += 1)
+				for(int cv$reduction673Index = 0; cv$reduction673Index < var95; cv$reduction673Index += 1)
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Copy the result of the reduction into the variable returned by the reduction.
@@ -791,13 +442,13 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 					// y's comment
 					// Set the right hand term to a value from the array var141
 					// 
-					// Substituted "index$t$10_6" with its value "t".
+					// Substituted "index$t$4_6" with its value "t".
 					// 
-					// Substituted "index$i$10_7" with its value "i$var80".
-					reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var80][cv$reduction1175Index]);
+					// Substituted "index$i$4_7" with its value "i$var80".
+					reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var80][cv$reduction673Index]);
 				
 				// Substituted "j" with its value "var95".
-				for(int cv$reduction1175Index = (var95 + 1); cv$reduction1175Index < time_dim; cv$reduction1175Index += 1)
+				for(int cv$reduction673Index = (var95 + 1); cv$reduction673Index < time_dim; cv$reduction673Index += 1)
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Execute the reduction function, saving the result into the return value.
@@ -810,46 +461,42 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 					// y's comment
 					// Set the right hand term to a value from the array var141
 					// 
-					// Substituted "index$t$10_6" with its value "t".
+					// Substituted "index$t$4_6" with its value "t".
 					// 
-					// Substituted "index$i$10_7" with its value "i$var80".
-					reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var80][cv$reduction1175Index]);
+					// Substituted "index$i$4_7" with its value "i$var80".
+					reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var80][cv$reduction673Index]);
 				
 				// Copy the result of the reduction into the variable returned by the reduction.
 				// 
 				// Substituted "j" with its value "var95".
-				reduceVar$var151$15 = ((TimeFeat[t][var95] * cv$proposedValue) + reduceVar$var151$15);
-				if(!guard$sample101poisson164[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
-					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101poisson164[(t - 1)][i$var80] = true;
-					
-					// A check to ensure rounding of floating point values can never result in a negative
-					// value.
-					// 
-					// Recorded the probability of reaching sample task 165 with the current configuration.
-					// 
-					// Set an accumulator to record the consumer distributions not seen. Initially set
-					// to 1 as seen values will be deducted from this value.
-					// 
-					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-					// Declaration comment was:
-					// Processing sample task 165 of consumer random variable null.
-					// 
-					// Set an accumulator to sum the probabilities for each possible configuration of
-					// inputs.
-					// 
-					// Substituted "index$i$10_11" with its value "index$i$10_7".
-					// 
-					// Substituted "index$t$10_10" with its value "t".
-					// 
-					// cv$temp$3$var156's comment
-					// Variable declaration of cv$temp$3$var156 moved.
-					// 
-					// Constructing a random variable input for use later.
-					cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$15) + cv$accumulatedProbabilities);
-				}
+				// 
+				// Set the current value to the current state of the tree.
+				reduceVar$var151$10 = ((TimeFeat[t][var95] * cv$originalValue) + reduceVar$var151$10);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 165 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Processing sample task 165 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "index$i$4_11" with its value "index$i$4_7".
+				// 
+				// Substituted "index$t$4_10" with its value "t".
+				// 
+				// cv$temp$2$var156's comment
+				// Variable declaration of cv$temp$2$var156 moved.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$10) + cv$accumulatedProbabilities);
 			}
 			
 			// Initialize a log space accumulator to take the product of all the distribution
@@ -858,7 +505,127 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 			// Record the reached probability density.
 			// 
 			// Initialize a counter to track the reached distributions.
-			cv$proposedProbability = cv$accumulatedProbabilities;
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		time_coeff[i$var80][var95] = cv$proposedValue;
+		
+		// Guards to ensure that time_impact is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 101 and consumer double[][][] 138.
+		for(int t = 1; t < T; t += 1)
+			// Substituted "i$var119" with its value "i$var80".
+			// 
+			// Substituted "i$var119" with its value "i$var80".
+			time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
+		for(int t = 1; t < T; t += 1) {
+			// Reduction of array null
+			// 
+			// A generated name to prevent name collisions if the reduction is implemented more
+			// than once in inference and probability code. Initialize the variable to the unit
+			// value
+			double reduceVar$var151$9 = 0.0;
+			
+			// For each index in the array to be reduced
+			for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
+				// Execute the reduction function, saving the result into the return value.
+				// 
+				// Copy the result of the reduction into the variable returned by the reduction.
+				// 
+				// x's comment
+				// Set the left hand term of the reduction function to the return variable value.
+				// 
+				// y's comment
+				// Set the right hand term to a value from the array var141
+				// 
+				// Substituted "index$t$3_4" with its value "t".
+				// 
+				// Substituted "index$i$3_5" with its value "i$var80".
+				reduceVar$var151$9 = (reduceVar$var151$9 + time_impact[t][i$var80][cv$reduction152Index]);
+			
+			// Substituted "index$t$3_4" with its value "t".
+			sum_t[t][i$var80] = reduceVar$var151$9;
+		}
+		
+		// An accumulator to allow the value for each distribution to be constructed before
+		// it is added to the index probabilities.
+		// 
+		// Substituted "cv$temp$1$var84" with its value "1.0".
+		double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$proposedValue);
+		for(int t = 1; t < T; t += 1) {
+			// Reduction of array null
+			// 
+			// A generated name to prevent name collisions if the reduction is implemented more
+			// than once in inference and probability code. Initialize the variable to the unit
+			// value
+			double reduceVar$var151$10 = 0.0;
+			
+			// Reduce for every value except a masked value which will be skipped.
+			// 
+			// Substituted "j" with its value "var95".
+			for(int cv$reduction673Index = 0; cv$reduction673Index < var95; cv$reduction673Index += 1)
+				// Execute the reduction function, saving the result into the return value.
+				// 
+				// Copy the result of the reduction into the variable returned by the reduction.
+				// 
+				// x's comment
+				// Set the left hand term of the reduction function to the return variable value.
+				// 
+				// y's comment
+				// Set the right hand term to a value from the array var141
+				// 
+				// Substituted "index$t$4_6" with its value "t".
+				// 
+				// Substituted "index$i$4_7" with its value "i$var80".
+				reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var80][cv$reduction673Index]);
+			
+			// Substituted "j" with its value "var95".
+			for(int cv$reduction673Index = (var95 + 1); cv$reduction673Index < time_dim; cv$reduction673Index += 1)
+				// Execute the reduction function, saving the result into the return value.
+				// 
+				// Execute the reduction function, saving the result into the return value.
+				// 
+				// Copy the result of the reduction into the variable returned by the reduction.
+				// 
+				// x's comment
+				// Set the left hand term of the reduction function to the return variable value.
+				// 
+				// y's comment
+				// Set the right hand term to a value from the array var141
+				// 
+				// Substituted "index$t$4_6" with its value "t".
+				// 
+				// Substituted "index$i$4_7" with its value "i$var80".
+				reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var80][cv$reduction673Index]);
+			
+			// Copy the result of the reduction into the variable returned by the reduction.
+			// 
+			// Substituted "j" with its value "var95".
+			reduceVar$var151$10 = ((TimeFeat[t][var95] * cv$proposedValue) + reduceVar$var151$10);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 165 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Processing sample task 165 of consumer random variable null.
+			// 
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Substituted "index$i$4_11" with its value "index$i$4_7".
+			// 
+			// Substituted "index$t$4_10" with its value "t".
+			// 
+			// cv$temp$2$var156's comment
+			// Variable declaration of cv$temp$2$var156 moved.
+			// 
+			// Constructing a random variable input for use later.
+			cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$10) + cv$accumulatedProbabilities);
 		}
 		
 		// Test if the probability of the sample is sufficient to keep the value. This needs
@@ -866,7 +633,14 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 		// the random value is 0 an impossible value will be accepted.
 		// 
 		// The probability ration for the proposed value and the current value.
-		if((((cv$proposedProbability - cv$originalProbability) <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN((cv$proposedProbability - cv$originalProbability)))) {
+		// 
+		// Initialize a log space accumulator to take the product of all the distribution
+		// probabilities.
+		// 
+		// Record the reached probability density.
+		// 
+		// Initialize a counter to track the reached distributions.
+		if((((cv$accumulatedProbabilities - cv$originalProbability) <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN((cv$accumulatedProbabilities - cv$originalProbability)))) {
 			// If it is not revert the changes.
 			// 
 			// Set the sample value
@@ -882,90 +656,33 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 				// 
 				// Substituted "i$var119" with its value "i$var80".
 				time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
-			
-			// Guards to ensure that sum_t is only updated when there is a valid path.
-			// 
-			// Looking for a path between Sample 101 and consumer double[][] 153.
-			// 
-			// Guard to check that at most one copy of the code is executed for a given random
-			// variable instance.
-			boolean[][] guard$sample101put160 = guard$sample101put160$global[threadID$cv$i$var80];
-			for(int t = 1; t < T; t += 1)
-				// Set the flags to false
+			for(int t = 1; t < T; t += 1) {
+				// Reduction of array null
 				// 
-				// Substituted "i$var119" with its value "i$var80".
-				guard$sample101put160[(t - 1)][i$var80] = false;
-			for(int t = 1; t < T; t += 1) {
-				// Constraints moved from conditionals in inner loops/scopes/etc.
-				if(!guard$sample101put160[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
+				// A generated name to prevent name collisions if the reduction is implemented more
+				// than once in inference and probability code. Initialize the variable to the unit
+				// value
+				double reduceVar$var151$11 = 0.0;
+				
+				// For each index in the array to be reduced
+				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
+					// Execute the reduction function, saving the result into the return value.
 					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101put160[(t - 1)][i$var80] = true;
-					
-					// Reduction of array null
+					// Copy the result of the reduction into the variable returned by the reduction.
 					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$16 = 0.0;
-					
-					// For each index in the array to be reduced
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$19_4" with its value "t".
-						// 
-						// Substituted "index$i$19_5" with its value "i$var80".
-						reduceVar$var151$16 = (reduceVar$var151$16 + time_impact[t][i$var80][cv$reduction152Index]);
-					
-					// Substituted "index$t$19_4" with its value "t".
-					sum_t[t][i$var80] = reduceVar$var151$16;
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				// Constraints moved from conditionals in inner loops/scopes/etc.
-				if(!guard$sample101put160[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
+					// x's comment
+					// Set the left hand term of the reduction function to the return variable value.
 					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101put160[(t - 1)][i$var80] = true;
-					
-					// Reduction of array null
+					// y's comment
+					// Set the right hand term to a value from the array var141
 					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$17 = 0.0;
-					
-					// For each index in the array to be reduced
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$20_4" with its value "t".
-						// 
-						// Substituted "index$i$20_5" with its value "i$var80".
-						reduceVar$var151$17 = (reduceVar$var151$17 + time_impact[t][i$var80][cv$reduction152Index]);
-					
-					// Substituted "index$t$20_4" with its value "t".
-					sum_t[t][i$var80] = reduceVar$var151$17;
-				}
+					// Substituted "index$t$9_4" with its value "t".
+					// 
+					// Substituted "index$i$9_5" with its value "i$var80".
+					reduceVar$var151$11 = (reduceVar$var151$11 + time_impact[t][i$var80][cv$reduction152Index]);
+				
+				// Substituted "index$t$9_4" with its value "t".
+				sum_t[t][i$var80] = reduceVar$var151$11;
 			}
 		}
 	}
@@ -974,71 +691,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 	// here prevents repeated allocation and deallocation, and makes the code more amenable
 	// to GPU execution.
 	@Override
-	public final void allocateScratch() {
-		// Allocate scratch space.
-		// Constructor for guard$sample101put160$global
-		{
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_i$var119 = 0;
-			if((1 < T))
-				// Calculate the largest index of i that is possible and allocate an array to hold
-				// the guard for each of these.
-				cv$max_i$var119 = Math.max(0, n_ac);
-			
-			// Variable declaration of cv$max_t moved.
-			// Declaration comment was:
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			// 
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_t = Math.max(0, (T - 1));
-			
-			// Allocation of guard$sample101put160$global for multithreaded execution
-			// 
-			// Get the thread count.
-			int cv$threadCount = threadCount();
-			
-			// Allocate an array to hold a copy per thread
-			guard$sample101put160$global = new boolean[cv$threadCount][][];
-			
-			// Populate the array with a copy per thread
-			for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
-				guard$sample101put160$global[cv$index] = new boolean[cv$max_t][cv$max_i$var119];
-		}
-		
-		// Calculate the largest index of i that is possible and allocate an array to hold
-		// the guard for each of these.
-		int cv$max_i$var119 = 0;
-		if((1 < T))
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			cv$max_i$var119 = Math.max(0, n_ac);
-		
-		// Variable declaration of cv$max_t moved.
-		// Declaration comment was:
-		// Constructor for guard$sample101poisson164$global
-		// 
-		// Calculate the largest index of t that is possible and allocate an array to hold
-		// the guard for each of these.
-		// 
-		// Calculate the largest index of t that is possible and allocate an array to hold
-		// the guard for each of these.
-		int cv$max_t = Math.max(0, (T - 1));
-		
-		// Allocation of guard$sample101poisson164$global for multithreaded execution
-		// 
-		// Get the thread count.
-		int cv$threadCount = threadCount();
-		
-		// Allocate an array to hold a copy per thread
-		guard$sample101poisson164$global = new boolean[cv$threadCount][][];
-		
-		// Populate the array with a copy per thread
-		for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
-			guard$sample101poisson164$global[cv$index] = new boolean[cv$max_t][cv$max_i$var119];
-	}
+	public final void allocateScratch() {}
 
 	// Method to allocate space for model inputs and outputs.
 	@Override
@@ -1089,9 +742,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$sample165 = new double[(T - 1)][];
 		for(int t = 1; t < T; t += 1)
 			logProbability$sample165[(t - 1)] = new double[n_ac];
-		
-		// Allocate scratch space
-		allocateScratch();
 	}
 
 	// Method to execute the model code conventionally.
@@ -1164,7 +814,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// A generated name to prevent name collisions if the reduction is implemented more
 											// than once in inference and probability code. Initialize the variable to the unit
 											// value
-											double reduceVar$var151$18 = 0.0;
+											double reduceVar$var151$12 = 0.0;
 											
 											// For each index in the array to be reduced
 											for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1172,8 +822,8 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 												// 
 												// y's comment
 												// Set the right hand term to a value from the array var141
-												reduceVar$var151$18 = (reduceVar$var151$18 + time_impact[t][i$var119][cv$reduction152Index]);
-											var139[i$var119] = reduceVar$var151$18;
+												reduceVar$var151$12 = (reduceVar$var151$12 + time_impact[t][i$var119][cv$reduction152Index]);
+											var139[i$var119] = reduceVar$var151$12;
 										}
 										var154[i$var119] = DistributionSampling.samplePoisson(RNG$2, sum_t[t][i$var119]);
 									}
@@ -1253,7 +903,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$22 = 0.0;
+										double reduceVar$var151$16 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1263,8 +913,8 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// 
 											// y's comment
 											// Set the right hand term to a value from the array var141
-											reduceVar$var151$22 = (reduceVar$var151$22 + time_impact[t][i$var119][cv$reduction152Index]);
-										var139[i$var119] = reduceVar$var151$22;
+											reduceVar$var151$16 = (reduceVar$var151$16 + time_impact[t][i$var119][cv$reduction152Index]);
+										var139[i$var119] = reduceVar$var151$16;
 									}
 							}
 						);
@@ -1342,7 +992,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$19 = 0.0;
+										double reduceVar$var151$13 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1352,8 +1002,8 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// 
 											// y's comment
 											// Set the right hand term to a value from the array var141
-											reduceVar$var151$19 = (reduceVar$var151$19 + time_impact[t][i$var119][cv$reduction152Index]);
-										var139[i$var119] = reduceVar$var151$19;
+											reduceVar$var151$13 = (reduceVar$var151$13 + time_impact[t][i$var119][cv$reduction152Index]);
+										var139[i$var119] = reduceVar$var151$13;
 										var154[i$var119] = DistributionSampling.samplePoisson(RNG$2, sum_t[t][i$var119]);
 									}
 							}
@@ -1430,7 +1080,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// A generated name to prevent name collisions if the reduction is implemented more
 											// than once in inference and probability code. Initialize the variable to the unit
 											// value
-											double reduceVar$var151$20 = 0.0;
+											double reduceVar$var151$14 = 0.0;
 											
 											// For each index in the array to be reduced
 											for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1438,8 +1088,8 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 												// 
 												// y's comment
 												// Set the right hand term to a value from the array var141
-												reduceVar$var151$20 = (reduceVar$var151$20 + time_impact[t][i$var119][cv$reduction152Index]);
-											var139[i$var119] = reduceVar$var151$20;
+												reduceVar$var151$14 = (reduceVar$var151$14 + time_impact[t][i$var119][cv$reduction152Index]);
+											var139[i$var119] = reduceVar$var151$14;
 										}
 								}
 							);
@@ -1518,7 +1168,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$21 = 0.0;
+										double reduceVar$var151$15 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1528,8 +1178,8 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// 
 											// y's comment
 											// Set the right hand term to a value from the array var141
-											reduceVar$var151$21 = (reduceVar$var151$21 + time_impact[t][i$var119][cv$reduction152Index]);
-										var139[i$var119] = reduceVar$var151$21;
+											reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var119][cv$reduction152Index]);
+										var139[i$var119] = reduceVar$var151$15;
 									}
 							}
 						);
@@ -1727,7 +1377,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$23 = 0.0;
+										double reduceVar$var151$17 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1737,8 +1387,8 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// 
 											// y's comment
 											// Set the right hand term to a value from the array var141
-											reduceVar$var151$23 = (reduceVar$var151$23 + time_impact[t][i$var119][cv$reduction152Index]);
-										var139[i$var119] = reduceVar$var151$23;
+											reduceVar$var151$17 = (reduceVar$var151$17 + time_impact[t][i$var119][cv$reduction152Index]);
+										var139[i$var119] = reduceVar$var151$17;
 									}
 							}
 						);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$MultiThreadCPU_optimisedModelNoComments.java
@@ -12,8 +12,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 	private boolean fixedFlag$sample101 = false;
 	private boolean fixedProbFlag$sample101 = false;
 	private boolean fixedProbFlag$sample165 = false;
-	private boolean[][][] guard$sample101poisson164$global;
-	private boolean[][][] guard$sample101put160$global;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
 	private double logProbability$arr;
@@ -230,136 +228,53 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 		if((cv$var < 0.010000000000000002))
 			cv$var = 0.010000000000000002;
 		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
-		double cv$proposedProbability;
 		{
-			{
-				double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$originalValue);
-				boolean[][] guard$sample101poisson164 = guard$sample101poisson164$global[threadID$cv$i$var80];
-				for(int t = 1; t < T; t += 1)
-					guard$sample101poisson164[(t - 1)][i$var80] = false;
-				for(int t = 1; t < T; t += 1) {
-					double reduceVar$var151$14 = time_impact[t][i$var80][0];
-					for(int cv$reduction1129Index = 1; cv$reduction1129Index < time_dim; cv$reduction1129Index += 1)
-						reduceVar$var151$14 = (reduceVar$var151$14 + time_impact[t][i$var80][cv$reduction1129Index]);
-					if(!guard$sample101poisson164[(t - 1)][i$var80]) {
-						guard$sample101poisson164[(t - 1)][i$var80] = true;
-						cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$14) + cv$accumulatedProbabilities);
-					}
-				}
-				for(int t = 1; t < T; t += 1) {
-					double reduceVar$var151$15 = 0.0;
-					for(int cv$reduction1175Index = 0; cv$reduction1175Index < var95; cv$reduction1175Index += 1)
-						reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var80][cv$reduction1175Index]);
-					for(int cv$reduction1175Index = (var95 + 1); cv$reduction1175Index < time_dim; cv$reduction1175Index += 1)
-						reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var80][cv$reduction1175Index]);
-					reduceVar$var151$15 = ((TimeFeat[t][var95] * cv$originalValue) + reduceVar$var151$15);
-					if(!guard$sample101poisson164[(t - 1)][i$var80]) {
-						guard$sample101poisson164[(t - 1)][i$var80] = true;
-						cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$15) + cv$accumulatedProbabilities);
-					}
-				}
-				cv$originalProbability = cv$accumulatedProbabilities;
-			}
-			time_coeff[i$var80][var95] = cv$proposedValue;
-			for(int t = 1; t < T; t += 1)
-				time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
-			boolean[][] guard$sample101put160 = guard$sample101put160$global[threadID$cv$i$var80];
-			for(int t = 1; t < T; t += 1)
-				guard$sample101put160[(t - 1)][i$var80] = false;
+			double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$originalValue);
 			for(int t = 1; t < T; t += 1) {
-				if(!guard$sample101put160[(t - 1)][i$var80]) {
-					guard$sample101put160[(t - 1)][i$var80] = true;
-					double reduceVar$var151$12 = 0.0;
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						reduceVar$var151$12 = (reduceVar$var151$12 + time_impact[t][i$var80][cv$reduction152Index]);
-					sum_t[t][i$var80] = reduceVar$var151$12;
-				}
+				double reduceVar$var151$10 = 0.0;
+				for(int cv$reduction673Index = 0; cv$reduction673Index < var95; cv$reduction673Index += 1)
+					reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var80][cv$reduction673Index]);
+				for(int cv$reduction673Index = (var95 + 1); cv$reduction673Index < time_dim; cv$reduction673Index += 1)
+					reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var80][cv$reduction673Index]);
+				reduceVar$var151$10 = ((TimeFeat[t][var95] * cv$originalValue) + reduceVar$var151$10);
+				cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$10) + cv$accumulatedProbabilities);
 			}
-			for(int t = 1; t < T; t += 1) {
-				if(!guard$sample101put160[(t - 1)][i$var80]) {
-					guard$sample101put160[(t - 1)][i$var80] = true;
-					double reduceVar$var151$13 = 0.0;
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						reduceVar$var151$13 = (reduceVar$var151$13 + time_impact[t][i$var80][cv$reduction152Index]);
-					sum_t[t][i$var80] = reduceVar$var151$13;
-				}
-			}
-			double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$proposedValue);
-			boolean[][] guard$sample101poisson164 = guard$sample101poisson164$global[threadID$cv$i$var80];
-			for(int t = 1; t < T; t += 1)
-				guard$sample101poisson164[(t - 1)][i$var80] = false;
-			for(int t = 1; t < T; t += 1) {
-				double reduceVar$var151$14 = time_impact[t][i$var80][0];
-				for(int cv$reduction1129Index = 1; cv$reduction1129Index < time_dim; cv$reduction1129Index += 1)
-					reduceVar$var151$14 = (reduceVar$var151$14 + time_impact[t][i$var80][cv$reduction1129Index]);
-				if(!guard$sample101poisson164[(t - 1)][i$var80]) {
-					guard$sample101poisson164[(t - 1)][i$var80] = true;
-					cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$14) + cv$accumulatedProbabilities);
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				double reduceVar$var151$15 = 0.0;
-				for(int cv$reduction1175Index = 0; cv$reduction1175Index < var95; cv$reduction1175Index += 1)
-					reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var80][cv$reduction1175Index]);
-				for(int cv$reduction1175Index = (var95 + 1); cv$reduction1175Index < time_dim; cv$reduction1175Index += 1)
-					reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var80][cv$reduction1175Index]);
-				reduceVar$var151$15 = ((TimeFeat[t][var95] * cv$proposedValue) + reduceVar$var151$15);
-				if(!guard$sample101poisson164[(t - 1)][i$var80]) {
-					guard$sample101poisson164[(t - 1)][i$var80] = true;
-					cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$15) + cv$accumulatedProbabilities);
-				}
-			}
-			cv$proposedProbability = cv$accumulatedProbabilities;
+			cv$originalProbability = cv$accumulatedProbabilities;
 		}
-		if((((cv$proposedProbability - cv$originalProbability) <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN((cv$proposedProbability - cv$originalProbability)))) {
+		time_coeff[i$var80][var95] = cv$proposedValue;
+		for(int t = 1; t < T; t += 1)
+			time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
+		for(int t = 1; t < T; t += 1) {
+			double reduceVar$var151$9 = 0.0;
+			for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
+				reduceVar$var151$9 = (reduceVar$var151$9 + time_impact[t][i$var80][cv$reduction152Index]);
+			sum_t[t][i$var80] = reduceVar$var151$9;
+		}
+		double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$proposedValue);
+		for(int t = 1; t < T; t += 1) {
+			double reduceVar$var151$10 = 0.0;
+			for(int cv$reduction673Index = 0; cv$reduction673Index < var95; cv$reduction673Index += 1)
+				reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var80][cv$reduction673Index]);
+			for(int cv$reduction673Index = (var95 + 1); cv$reduction673Index < time_dim; cv$reduction673Index += 1)
+				reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var80][cv$reduction673Index]);
+			reduceVar$var151$10 = ((TimeFeat[t][var95] * cv$proposedValue) + reduceVar$var151$10);
+			cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$10) + cv$accumulatedProbabilities);
+		}
+		if((((cv$accumulatedProbabilities - cv$originalProbability) <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN((cv$accumulatedProbabilities - cv$originalProbability)))) {
 			time_coeff[i$var80][var95] = cv$originalValue;
 			for(int t = 1; t < T; t += 1)
 				time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
-			boolean[][] guard$sample101put160 = guard$sample101put160$global[threadID$cv$i$var80];
-			for(int t = 1; t < T; t += 1)
-				guard$sample101put160[(t - 1)][i$var80] = false;
 			for(int t = 1; t < T; t += 1) {
-				if(!guard$sample101put160[(t - 1)][i$var80]) {
-					guard$sample101put160[(t - 1)][i$var80] = true;
-					double reduceVar$var151$16 = 0.0;
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						reduceVar$var151$16 = (reduceVar$var151$16 + time_impact[t][i$var80][cv$reduction152Index]);
-					sum_t[t][i$var80] = reduceVar$var151$16;
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				if(!guard$sample101put160[(t - 1)][i$var80]) {
-					guard$sample101put160[(t - 1)][i$var80] = true;
-					double reduceVar$var151$17 = 0.0;
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						reduceVar$var151$17 = (reduceVar$var151$17 + time_impact[t][i$var80][cv$reduction152Index]);
-					sum_t[t][i$var80] = reduceVar$var151$17;
-				}
+				double reduceVar$var151$11 = 0.0;
+				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
+					reduceVar$var151$11 = (reduceVar$var151$11 + time_impact[t][i$var80][cv$reduction152Index]);
+				sum_t[t][i$var80] = reduceVar$var151$11;
 			}
 		}
 	}
 
 	@Override
-	public final void allocateScratch() {
-		{
-			int cv$max_i$var119 = 0;
-			if((1 < T))
-				cv$max_i$var119 = Math.max(0, n_ac);
-			int cv$max_t = Math.max(0, (T - 1));
-			int cv$threadCount = threadCount();
-			guard$sample101put160$global = new boolean[cv$threadCount][][];
-			for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
-				guard$sample101put160$global[cv$index] = new boolean[cv$max_t][cv$max_i$var119];
-		}
-		int cv$max_i$var119 = 0;
-		if((1 < T))
-			cv$max_i$var119 = Math.max(0, n_ac);
-		int cv$max_t = Math.max(0, (T - 1));
-		int cv$threadCount = threadCount();
-		guard$sample101poisson164$global = new boolean[cv$threadCount][][];
-		for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
-			guard$sample101poisson164$global[cv$index] = new boolean[cv$max_t][cv$max_i$var119];
-	}
+	public final void allocateScratch() {}
 
 	@Override
 	public final void allocator() {
@@ -393,7 +308,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$sample165 = new double[(T - 1)][];
 		for(int t = 1; t < T; t += 1)
 			logProbability$sample165[(t - 1)] = new double[n_ac];
-		allocateScratch();
 	}
 
 	@Override
@@ -433,10 +347,10 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 															var129[i$var119][j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
 												}
 											);
-											double reduceVar$var151$18 = 0.0;
+											double reduceVar$var151$12 = 0.0;
 											for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-												reduceVar$var151$18 = (reduceVar$var151$18 + time_impact[t][i$var119][cv$reduction152Index]);
-											var139[i$var119] = reduceVar$var151$18;
+												reduceVar$var151$12 = (reduceVar$var151$12 + time_impact[t][i$var119][cv$reduction152Index]);
+											var139[i$var119] = reduceVar$var151$12;
 										}
 										var154[i$var119] = DistributionSampling.samplePoisson(RNG$2, sum_t[t][i$var119]);
 									}
@@ -482,10 +396,10 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 														var129[i$var119][j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
 											}
 										);
-										double reduceVar$var151$22 = 0.0;
+										double reduceVar$var151$16 = 0.0;
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-											reduceVar$var151$22 = (reduceVar$var151$22 + time_impact[t][i$var119][cv$reduction152Index]);
-										var139[i$var119] = reduceVar$var151$22;
+											reduceVar$var151$16 = (reduceVar$var151$16 + time_impact[t][i$var119][cv$reduction152Index]);
+										var139[i$var119] = reduceVar$var151$16;
 									}
 							}
 						);
@@ -530,10 +444,10 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 														var129[i$var119][j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
 											}
 										);
-										double reduceVar$var151$19 = 0.0;
+										double reduceVar$var151$13 = 0.0;
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-											reduceVar$var151$19 = (reduceVar$var151$19 + time_impact[t][i$var119][cv$reduction152Index]);
-										var139[i$var119] = reduceVar$var151$19;
+											reduceVar$var151$13 = (reduceVar$var151$13 + time_impact[t][i$var119][cv$reduction152Index]);
+										var139[i$var119] = reduceVar$var151$13;
 										var154[i$var119] = DistributionSampling.samplePoisson(RNG$2, sum_t[t][i$var119]);
 									}
 							}
@@ -577,10 +491,10 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 															var129[i$var119][j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
 												}
 											);
-											double reduceVar$var151$20 = 0.0;
+											double reduceVar$var151$14 = 0.0;
 											for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-												reduceVar$var151$20 = (reduceVar$var151$20 + time_impact[t][i$var119][cv$reduction152Index]);
-											var139[i$var119] = reduceVar$var151$20;
+												reduceVar$var151$14 = (reduceVar$var151$14 + time_impact[t][i$var119][cv$reduction152Index]);
+											var139[i$var119] = reduceVar$var151$14;
 										}
 								}
 							);
@@ -625,10 +539,10 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 														var129[i$var119][j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
 											}
 										);
-										double reduceVar$var151$21 = 0.0;
+										double reduceVar$var151$15 = 0.0;
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-											reduceVar$var151$21 = (reduceVar$var151$21 + time_impact[t][i$var119][cv$reduction152Index]);
-										var139[i$var119] = reduceVar$var151$21;
+											reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var119][cv$reduction152Index]);
+										var139[i$var119] = reduceVar$var151$15;
 									}
 							}
 						);
@@ -748,10 +662,10 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 														var129[i$var119][j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
 											}
 										);
-										double reduceVar$var151$23 = 0.0;
+										double reduceVar$var151$17 = 0.0;
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-											reduceVar$var151$23 = (reduceVar$var151$23 + time_impact[t][i$var119][cv$reduction152Index]);
-										var139[i$var119] = reduceVar$var151$23;
+											reduceVar$var151$17 = (reduceVar$var151$17 + time_impact[t][i$var119][cv$reduction152Index]);
+										var139[i$var119] = reduceVar$var151$17;
 									}
 							}
 						);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$MultiThreadCPU_optimisedModelSingle.java
@@ -14,8 +14,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 	private boolean fixedFlag$sample101 = false;
 	private boolean fixedProbFlag$sample101 = false;
 	private boolean fixedProbFlag$sample165 = false;
-	private boolean[][][] guard$sample101poisson164$global;
-	private boolean[][][] guard$sample101put160$global;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
 	private double logProbability$arr;
@@ -448,373 +446,26 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 		
 		// The proposed new value for the sample
 		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
-		
-		// This value is not used before it is set again, so removing the value declaration.
-		// 
-		// The probability of the random variable generating the new sample value.
-		double cv$proposedProbability;
 		{
-			// Unrolled loop
-			{
-				// An accumulator to allow the value for each distribution to be constructed before
-				// it is added to the index probabilities.
-				// 
-				// Substituted "cv$temp$1$var84" with its value "1.0".
-				// 
-				// Set the current value to the current state of the tree.
-				double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$originalValue);
-				
-				// Processing random variable 157.
-				// 
-				// Looking for a path between Sample 101 and consumer Poisson 157.
-				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				boolean[][] guard$sample101poisson164 = guard$sample101poisson164$global[threadID$cv$i$var80];
-				for(int t = 1; t < T; t += 1)
-					// Set the flags to false
-					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101poisson164[(t - 1)][i$var80] = false;
-				for(int t = 1; t < T; t += 1) {
-					// Reduction of array null
-					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					// 
-					// Substituted "index$t$9_5" with its value "t".
-					// 
-					// Substituted "index$i$9_6" with its value "i$var80".
-					double reduceVar$var151$14 = time_impact[t][i$var80][0];
-					for(int cv$reduction1098Index = 1; cv$reduction1098Index < time_dim; cv$reduction1098Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$9_5" with its value "t".
-						// 
-						// Substituted "index$i$9_6" with its value "i$var80".
-						reduceVar$var151$14 = (reduceVar$var151$14 + time_impact[t][i$var80][cv$reduction1098Index]);
-					if(!guard$sample101poisson164[(t - 1)][i$var80]) {
-						// The body will execute, so should not be executed again
-						// 
-						// Substituted "i$var119" with its value "i$var80".
-						guard$sample101poisson164[(t - 1)][i$var80] = true;
-						
-						// A check to ensure rounding of floating point values can never result in a negative
-						// value.
-						// 
-						// Recorded the probability of reaching sample task 165 with the current configuration.
-						// 
-						// Set an accumulator to record the consumer distributions not seen. Initially set
-						// to 1 as seen values will be deducted from this value.
-						// 
-						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-						// Declaration comment was:
-						// Processing sample task 165 of consumer random variable null.
-						// 
-						// Set an accumulator to sum the probabilities for each possible configuration of
-						// inputs.
-						// 
-						// Substituted "index$i$9_10" with its value "index$i$9_6".
-						// 
-						// Substituted "index$t$9_9" with its value "t".
-						// 
-						// cv$temp$2$var156's comment
-						// Variable declaration of cv$temp$2$var156 moved.
-						// 
-						// Constructing a random variable input for use later.
-						cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$14) + cv$accumulatedProbabilities);
-					}
-				}
-				for(int t = 1; t < T; t += 1) {
-					// Reduction of array null
-					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$15 = 0.0;
-					
-					// Reduce for every value except a masked value which will be skipped.
-					// 
-					// Substituted "j" with its value "var95".
-					for(int cv$reduction1144Index = 0; cv$reduction1144Index < var95; cv$reduction1144Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$10_6" with its value "t".
-						// 
-						// Substituted "index$i$10_7" with its value "i$var80".
-						reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var80][cv$reduction1144Index]);
-					
-					// Substituted "j" with its value "var95".
-					for(int cv$reduction1144Index = (var95 + 1); cv$reduction1144Index < time_dim; cv$reduction1144Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$10_6" with its value "t".
-						// 
-						// Substituted "index$i$10_7" with its value "i$var80".
-						reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var80][cv$reduction1144Index]);
-					
-					// Copy the result of the reduction into the variable returned by the reduction.
-					// 
-					// Substituted "j" with its value "var95".
-					// 
-					// Set the current value to the current state of the tree.
-					reduceVar$var151$15 = ((TimeFeat[t][var95] * cv$originalValue) + reduceVar$var151$15);
-					if(!guard$sample101poisson164[(t - 1)][i$var80]) {
-						// The body will execute, so should not be executed again
-						// 
-						// Substituted "i$var119" with its value "i$var80".
-						guard$sample101poisson164[(t - 1)][i$var80] = true;
-						
-						// A check to ensure rounding of floating point values can never result in a negative
-						// value.
-						// 
-						// Recorded the probability of reaching sample task 165 with the current configuration.
-						// 
-						// Set an accumulator to record the consumer distributions not seen. Initially set
-						// to 1 as seen values will be deducted from this value.
-						// 
-						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-						// Declaration comment was:
-						// Processing sample task 165 of consumer random variable null.
-						// 
-						// Set an accumulator to sum the probabilities for each possible configuration of
-						// inputs.
-						// 
-						// Substituted "index$i$10_11" with its value "index$i$10_7".
-						// 
-						// Substituted "index$t$10_10" with its value "t".
-						// 
-						// cv$temp$3$var156's comment
-						// Variable declaration of cv$temp$3$var156 moved.
-						// 
-						// Constructing a random variable input for use later.
-						cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$15) + cv$accumulatedProbabilities);
-					}
-				}
-				
-				// Initialize a log space accumulator to take the product of all the distribution
-				// probabilities.
-				// 
-				// Record the reached probability density.
-				// 
-				// Initialize a counter to track the reached distributions.
-				cv$originalProbability = cv$accumulatedProbabilities;
-			}
-			time_coeff[i$var80][var95] = cv$proposedValue;
-			
-			// Guards to ensure that time_impact is only updated when there is a valid path.
-			// 
-			// Looking for a path between Sample 101 and consumer double[][][] 138.
-			for(int t = 1; t < T; t += 1)
-				// Substituted "i$var119" with its value "i$var80".
-				// 
-				// Substituted "i$var119" with its value "i$var80".
-				time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
-			
-			// Guards to ensure that sum_t is only updated when there is a valid path.
-			// 
-			// Looking for a path between Sample 101 and consumer double[][] 153.
-			// 
-			// Guard to check that at most one copy of the code is executed for a given random
-			// variable instance.
-			boolean[][] guard$sample101put160 = guard$sample101put160$global[threadID$cv$i$var80];
-			for(int t = 1; t < T; t += 1)
-				// Set the flags to false
-				// 
-				// Substituted "i$var119" with its value "i$var80".
-				guard$sample101put160[(t - 1)][i$var80] = false;
-			for(int t = 1; t < T; t += 1) {
-				// Constraints moved from conditionals in inner loops/scopes/etc.
-				if(!guard$sample101put160[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
-					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101put160[(t - 1)][i$var80] = true;
-					
-					// Reduction of array null
-					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$12 = 0.0;
-					
-					// For each index in the array to be reduced
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$5_4" with its value "t".
-						// 
-						// Substituted "index$i$5_5" with its value "i$var80".
-						reduceVar$var151$12 = (reduceVar$var151$12 + time_impact[t][i$var80][cv$reduction152Index]);
-					
-					// Substituted "index$t$5_4" with its value "t".
-					sum_t[t][i$var80] = reduceVar$var151$12;
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				// Constraints moved from conditionals in inner loops/scopes/etc.
-				if(!guard$sample101put160[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
-					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101put160[(t - 1)][i$var80] = true;
-					
-					// Reduction of array null
-					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$13 = 0.0;
-					
-					// For each index in the array to be reduced
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$6_4" with its value "t".
-						// 
-						// Substituted "index$i$6_5" with its value "i$var80".
-						reduceVar$var151$13 = (reduceVar$var151$13 + time_impact[t][i$var80][cv$reduction152Index]);
-					
-					// Substituted "index$t$6_4" with its value "t".
-					sum_t[t][i$var80] = reduceVar$var151$13;
-				}
-			}
-			
 			// An accumulator to allow the value for each distribution to be constructed before
 			// it is added to the index probabilities.
 			// 
 			// Substituted "cv$temp$1$var84" with its value "1.0".
-			double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$proposedValue);
-			
-			// Processing random variable 157.
 			// 
-			// Looking for a path between Sample 101 and consumer Poisson 157.
-			// 
-			// Guard to check that at most one copy of the code is executed for a given random
-			// variable instance.
-			boolean[][] guard$sample101poisson164 = guard$sample101poisson164$global[threadID$cv$i$var80];
-			for(int t = 1; t < T; t += 1)
-				// Set the flags to false
-				// 
-				// Substituted "i$var119" with its value "i$var80".
-				guard$sample101poisson164[(t - 1)][i$var80] = false;
+			// Set the current value to the current state of the tree.
+			double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$originalValue);
 			for(int t = 1; t < T; t += 1) {
 				// Reduction of array null
 				// 
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				// 
-				// Substituted "index$t$9_5" with its value "t".
-				// 
-				// Substituted "index$i$9_6" with its value "i$var80".
-				double reduceVar$var151$14 = time_impact[t][i$var80][0];
-				for(int cv$reduction1098Index = 1; cv$reduction1098Index < time_dim; cv$reduction1098Index += 1)
-					// Execute the reduction function, saving the result into the return value.
-					// 
-					// Execute the reduction function, saving the result into the return value.
-					// 
-					// Copy the result of the reduction into the variable returned by the reduction.
-					// 
-					// x's comment
-					// Set the left hand term of the reduction function to the return variable value.
-					// 
-					// y's comment
-					// Set the right hand term to a value from the array var141
-					// 
-					// Substituted "index$t$9_5" with its value "t".
-					// 
-					// Substituted "index$i$9_6" with its value "i$var80".
-					reduceVar$var151$14 = (reduceVar$var151$14 + time_impact[t][i$var80][cv$reduction1098Index]);
-				if(!guard$sample101poisson164[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
-					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101poisson164[(t - 1)][i$var80] = true;
-					
-					// A check to ensure rounding of floating point values can never result in a negative
-					// value.
-					// 
-					// Recorded the probability of reaching sample task 165 with the current configuration.
-					// 
-					// Set an accumulator to record the consumer distributions not seen. Initially set
-					// to 1 as seen values will be deducted from this value.
-					// 
-					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-					// Declaration comment was:
-					// Processing sample task 165 of consumer random variable null.
-					// 
-					// Set an accumulator to sum the probabilities for each possible configuration of
-					// inputs.
-					// 
-					// Substituted "index$i$9_10" with its value "index$i$9_6".
-					// 
-					// Substituted "index$t$9_9" with its value "t".
-					// 
-					// cv$temp$2$var156's comment
-					// Variable declaration of cv$temp$2$var156 moved.
-					// 
-					// Constructing a random variable input for use later.
-					cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$14) + cv$accumulatedProbabilities);
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				// Reduction of array null
-				// 
-				// A generated name to prevent name collisions if the reduction is implemented more
-				// than once in inference and probability code. Initialize the variable to the unit
-				// value
-				double reduceVar$var151$15 = 0.0;
+				double reduceVar$var151$10 = 0.0;
 				
 				// Reduce for every value except a masked value which will be skipped.
 				// 
 				// Substituted "j" with its value "var95".
-				for(int cv$reduction1144Index = 0; cv$reduction1144Index < var95; cv$reduction1144Index += 1)
+				for(int cv$reduction642Index = 0; cv$reduction642Index < var95; cv$reduction642Index += 1)
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Copy the result of the reduction into the variable returned by the reduction.
@@ -825,13 +476,13 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 					// y's comment
 					// Set the right hand term to a value from the array var141
 					// 
-					// Substituted "index$t$10_6" with its value "t".
+					// Substituted "index$t$4_6" with its value "t".
 					// 
-					// Substituted "index$i$10_7" with its value "i$var80".
-					reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var80][cv$reduction1144Index]);
+					// Substituted "index$i$4_7" with its value "i$var80".
+					reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var80][cv$reduction642Index]);
 				
 				// Substituted "j" with its value "var95".
-				for(int cv$reduction1144Index = (var95 + 1); cv$reduction1144Index < time_dim; cv$reduction1144Index += 1)
+				for(int cv$reduction642Index = (var95 + 1); cv$reduction642Index < time_dim; cv$reduction642Index += 1)
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Execute the reduction function, saving the result into the return value.
@@ -844,46 +495,42 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 					// y's comment
 					// Set the right hand term to a value from the array var141
 					// 
-					// Substituted "index$t$10_6" with its value "t".
+					// Substituted "index$t$4_6" with its value "t".
 					// 
-					// Substituted "index$i$10_7" with its value "i$var80".
-					reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var80][cv$reduction1144Index]);
+					// Substituted "index$i$4_7" with its value "i$var80".
+					reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var80][cv$reduction642Index]);
 				
 				// Copy the result of the reduction into the variable returned by the reduction.
 				// 
 				// Substituted "j" with its value "var95".
-				reduceVar$var151$15 = ((TimeFeat[t][var95] * cv$proposedValue) + reduceVar$var151$15);
-				if(!guard$sample101poisson164[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
-					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101poisson164[(t - 1)][i$var80] = true;
-					
-					// A check to ensure rounding of floating point values can never result in a negative
-					// value.
-					// 
-					// Recorded the probability of reaching sample task 165 with the current configuration.
-					// 
-					// Set an accumulator to record the consumer distributions not seen. Initially set
-					// to 1 as seen values will be deducted from this value.
-					// 
-					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-					// Declaration comment was:
-					// Processing sample task 165 of consumer random variable null.
-					// 
-					// Set an accumulator to sum the probabilities for each possible configuration of
-					// inputs.
-					// 
-					// Substituted "index$i$10_11" with its value "index$i$10_7".
-					// 
-					// Substituted "index$t$10_10" with its value "t".
-					// 
-					// cv$temp$3$var156's comment
-					// Variable declaration of cv$temp$3$var156 moved.
-					// 
-					// Constructing a random variable input for use later.
-					cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$15) + cv$accumulatedProbabilities);
-				}
+				// 
+				// Set the current value to the current state of the tree.
+				reduceVar$var151$10 = ((TimeFeat[t][var95] * cv$originalValue) + reduceVar$var151$10);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 165 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Processing sample task 165 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "index$i$4_11" with its value "index$i$4_7".
+				// 
+				// Substituted "index$t$4_10" with its value "t".
+				// 
+				// cv$temp$2$var156's comment
+				// Variable declaration of cv$temp$2$var156 moved.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$10) + cv$accumulatedProbabilities);
 			}
 			
 			// Initialize a log space accumulator to take the product of all the distribution
@@ -892,7 +539,127 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 			// Record the reached probability density.
 			// 
 			// Initialize a counter to track the reached distributions.
-			cv$proposedProbability = cv$accumulatedProbabilities;
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		time_coeff[i$var80][var95] = cv$proposedValue;
+		
+		// Guards to ensure that time_impact is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 101 and consumer double[][][] 138.
+		for(int t = 1; t < T; t += 1)
+			// Substituted "i$var119" with its value "i$var80".
+			// 
+			// Substituted "i$var119" with its value "i$var80".
+			time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
+		for(int t = 1; t < T; t += 1) {
+			// Reduction of array null
+			// 
+			// A generated name to prevent name collisions if the reduction is implemented more
+			// than once in inference and probability code. Initialize the variable to the unit
+			// value
+			double reduceVar$var151$9 = 0.0;
+			
+			// For each index in the array to be reduced
+			for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
+				// Execute the reduction function, saving the result into the return value.
+				// 
+				// Copy the result of the reduction into the variable returned by the reduction.
+				// 
+				// x's comment
+				// Set the left hand term of the reduction function to the return variable value.
+				// 
+				// y's comment
+				// Set the right hand term to a value from the array var141
+				// 
+				// Substituted "index$t$3_4" with its value "t".
+				// 
+				// Substituted "index$i$3_5" with its value "i$var80".
+				reduceVar$var151$9 = (reduceVar$var151$9 + time_impact[t][i$var80][cv$reduction152Index]);
+			
+			// Substituted "index$t$3_4" with its value "t".
+			sum_t[t][i$var80] = reduceVar$var151$9;
+		}
+		
+		// An accumulator to allow the value for each distribution to be constructed before
+		// it is added to the index probabilities.
+		// 
+		// Substituted "cv$temp$1$var84" with its value "1.0".
+		double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$proposedValue);
+		for(int t = 1; t < T; t += 1) {
+			// Reduction of array null
+			// 
+			// A generated name to prevent name collisions if the reduction is implemented more
+			// than once in inference and probability code. Initialize the variable to the unit
+			// value
+			double reduceVar$var151$10 = 0.0;
+			
+			// Reduce for every value except a masked value which will be skipped.
+			// 
+			// Substituted "j" with its value "var95".
+			for(int cv$reduction642Index = 0; cv$reduction642Index < var95; cv$reduction642Index += 1)
+				// Execute the reduction function, saving the result into the return value.
+				// 
+				// Copy the result of the reduction into the variable returned by the reduction.
+				// 
+				// x's comment
+				// Set the left hand term of the reduction function to the return variable value.
+				// 
+				// y's comment
+				// Set the right hand term to a value from the array var141
+				// 
+				// Substituted "index$t$4_6" with its value "t".
+				// 
+				// Substituted "index$i$4_7" with its value "i$var80".
+				reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var80][cv$reduction642Index]);
+			
+			// Substituted "j" with its value "var95".
+			for(int cv$reduction642Index = (var95 + 1); cv$reduction642Index < time_dim; cv$reduction642Index += 1)
+				// Execute the reduction function, saving the result into the return value.
+				// 
+				// Execute the reduction function, saving the result into the return value.
+				// 
+				// Copy the result of the reduction into the variable returned by the reduction.
+				// 
+				// x's comment
+				// Set the left hand term of the reduction function to the return variable value.
+				// 
+				// y's comment
+				// Set the right hand term to a value from the array var141
+				// 
+				// Substituted "index$t$4_6" with its value "t".
+				// 
+				// Substituted "index$i$4_7" with its value "i$var80".
+				reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var80][cv$reduction642Index]);
+			
+			// Copy the result of the reduction into the variable returned by the reduction.
+			// 
+			// Substituted "j" with its value "var95".
+			reduceVar$var151$10 = ((TimeFeat[t][var95] * cv$proposedValue) + reduceVar$var151$10);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 165 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Processing sample task 165 of consumer random variable null.
+			// 
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Substituted "index$i$4_11" with its value "index$i$4_7".
+			// 
+			// Substituted "index$t$4_10" with its value "t".
+			// 
+			// cv$temp$2$var156's comment
+			// Variable declaration of cv$temp$2$var156 moved.
+			// 
+			// Constructing a random variable input for use later.
+			cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$10) + cv$accumulatedProbabilities);
 		}
 		
 		// Test if the probability of the sample is sufficient to keep the value. This needs
@@ -900,7 +667,14 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 		// the random value is 0 an impossible value will be accepted.
 		// 
 		// The probability ration for the proposed value and the current value.
-		if((((cv$proposedProbability - cv$originalProbability) <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN((cv$proposedProbability - cv$originalProbability)))) {
+		// 
+		// Initialize a log space accumulator to take the product of all the distribution
+		// probabilities.
+		// 
+		// Record the reached probability density.
+		// 
+		// Initialize a counter to track the reached distributions.
+		if((((cv$accumulatedProbabilities - cv$originalProbability) <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN((cv$accumulatedProbabilities - cv$originalProbability)))) {
 			// If it is not revert the changes.
 			// 
 			// Set the sample value
@@ -916,90 +690,33 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 				// 
 				// Substituted "i$var119" with its value "i$var80".
 				time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
-			
-			// Guards to ensure that sum_t is only updated when there is a valid path.
-			// 
-			// Looking for a path between Sample 101 and consumer double[][] 153.
-			// 
-			// Guard to check that at most one copy of the code is executed for a given random
-			// variable instance.
-			boolean[][] guard$sample101put160 = guard$sample101put160$global[threadID$cv$i$var80];
-			for(int t = 1; t < T; t += 1)
-				// Set the flags to false
+			for(int t = 1; t < T; t += 1) {
+				// Reduction of array null
 				// 
-				// Substituted "i$var119" with its value "i$var80".
-				guard$sample101put160[(t - 1)][i$var80] = false;
-			for(int t = 1; t < T; t += 1) {
-				// Constraints moved from conditionals in inner loops/scopes/etc.
-				if(!guard$sample101put160[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
+				// A generated name to prevent name collisions if the reduction is implemented more
+				// than once in inference and probability code. Initialize the variable to the unit
+				// value
+				double reduceVar$var151$11 = 0.0;
+				
+				// For each index in the array to be reduced
+				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
+					// Execute the reduction function, saving the result into the return value.
 					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101put160[(t - 1)][i$var80] = true;
-					
-					// Reduction of array null
+					// Copy the result of the reduction into the variable returned by the reduction.
 					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$16 = 0.0;
-					
-					// For each index in the array to be reduced
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$19_4" with its value "t".
-						// 
-						// Substituted "index$i$19_5" with its value "i$var80".
-						reduceVar$var151$16 = (reduceVar$var151$16 + time_impact[t][i$var80][cv$reduction152Index]);
-					
-					// Substituted "index$t$19_4" with its value "t".
-					sum_t[t][i$var80] = reduceVar$var151$16;
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				// Constraints moved from conditionals in inner loops/scopes/etc.
-				if(!guard$sample101put160[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
+					// x's comment
+					// Set the left hand term of the reduction function to the return variable value.
 					// 
-					// Substituted "i$var119" with its value "i$var80".
-					guard$sample101put160[(t - 1)][i$var80] = true;
-					
-					// Reduction of array null
+					// y's comment
+					// Set the right hand term to a value from the array var141
 					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$17 = 0.0;
-					
-					// For each index in the array to be reduced
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$20_4" with its value "t".
-						// 
-						// Substituted "index$i$20_5" with its value "i$var80".
-						reduceVar$var151$17 = (reduceVar$var151$17 + time_impact[t][i$var80][cv$reduction152Index]);
-					
-					// Substituted "index$t$20_4" with its value "t".
-					sum_t[t][i$var80] = reduceVar$var151$17;
-				}
+					// Substituted "index$t$9_4" with its value "t".
+					// 
+					// Substituted "index$i$9_5" with its value "i$var80".
+					reduceVar$var151$11 = (reduceVar$var151$11 + time_impact[t][i$var80][cv$reduction152Index]);
+				
+				// Substituted "index$t$9_4" with its value "t".
+				sum_t[t][i$var80] = reduceVar$var151$11;
 			}
 		}
 	}
@@ -1008,71 +725,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 	// here prevents repeated allocation and deallocation, and makes the code more amenable
 	// to GPU execution.
 	@Override
-	public final void allocateScratch() {
-		// Allocate scratch space.
-		// Constructor for guard$sample101put160$global
-		{
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_i$var119 = 0;
-			if((1 < T))
-				// Calculate the largest index of i that is possible and allocate an array to hold
-				// the guard for each of these.
-				cv$max_i$var119 = Math.max(0, n_ac);
-			
-			// Variable declaration of cv$max_t moved.
-			// Declaration comment was:
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			// 
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_t = Math.max(0, (T - 1));
-			
-			// Allocation of guard$sample101put160$global for multithreaded execution
-			// 
-			// Get the thread count.
-			int cv$threadCount = threadCount();
-			
-			// Allocate an array to hold a copy per thread
-			guard$sample101put160$global = new boolean[cv$threadCount][][];
-			
-			// Populate the array with a copy per thread
-			for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
-				guard$sample101put160$global[cv$index] = new boolean[cv$max_t][cv$max_i$var119];
-		}
-		
-		// Calculate the largest index of i that is possible and allocate an array to hold
-		// the guard for each of these.
-		int cv$max_i$var119 = 0;
-		if((1 < T))
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			cv$max_i$var119 = Math.max(0, n_ac);
-		
-		// Variable declaration of cv$max_t moved.
-		// Declaration comment was:
-		// Constructor for guard$sample101poisson164$global
-		// 
-		// Calculate the largest index of t that is possible and allocate an array to hold
-		// the guard for each of these.
-		// 
-		// Calculate the largest index of t that is possible and allocate an array to hold
-		// the guard for each of these.
-		int cv$max_t = Math.max(0, (T - 1));
-		
-		// Allocation of guard$sample101poisson164$global for multithreaded execution
-		// 
-		// Get the thread count.
-		int cv$threadCount = threadCount();
-		
-		// Allocate an array to hold a copy per thread
-		guard$sample101poisson164$global = new boolean[cv$threadCount][][];
-		
-		// Populate the array with a copy per thread
-		for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
-			guard$sample101poisson164$global[cv$index] = new boolean[cv$max_t][cv$max_i$var119];
-	}
+	public final void allocateScratch() {}
 
 	// Method to allocate space for model inputs and outputs.
 	@Override
@@ -1110,9 +763,6 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 		logProbability$sample101 = new double[n_ac][];
 		for(int i$var80 = 0; i$var80 < n_ac; i$var80 += 1)
 			logProbability$sample101[i$var80] = new double[TimeFeat[0].length];
-		
-		// Allocate scratch space
-		allocateScratch();
 	}
 
 	// Method to execute the model code conventionally.
@@ -1185,7 +835,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// A generated name to prevent name collisions if the reduction is implemented more
 											// than once in inference and probability code. Initialize the variable to the unit
 											// value
-											double reduceVar$var151$18 = 0.0;
+											double reduceVar$var151$12 = 0.0;
 											
 											// For each index in the array to be reduced
 											for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1193,8 +843,8 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 												// 
 												// y's comment
 												// Set the right hand term to a value from the array var141
-												reduceVar$var151$18 = (reduceVar$var151$18 + time_impact[t][i$var119][cv$reduction152Index]);
-											var139[i$var119] = reduceVar$var151$18;
+												reduceVar$var151$12 = (reduceVar$var151$12 + time_impact[t][i$var119][cv$reduction152Index]);
+											var139[i$var119] = reduceVar$var151$12;
 										}
 										var154[i$var119] = DistributionSampling.samplePoisson(RNG$2, sum_t[t][i$var119]);
 									}
@@ -1274,7 +924,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$22 = 0.0;
+										double reduceVar$var151$16 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1284,8 +934,8 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// 
 											// y's comment
 											// Set the right hand term to a value from the array var141
-											reduceVar$var151$22 = (reduceVar$var151$22 + time_impact[t][i$var119][cv$reduction152Index]);
-										var139[i$var119] = reduceVar$var151$22;
+											reduceVar$var151$16 = (reduceVar$var151$16 + time_impact[t][i$var119][cv$reduction152Index]);
+										var139[i$var119] = reduceVar$var151$16;
 									}
 							}
 						);
@@ -1363,7 +1013,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$19 = 0.0;
+										double reduceVar$var151$13 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1373,8 +1023,8 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// 
 											// y's comment
 											// Set the right hand term to a value from the array var141
-											reduceVar$var151$19 = (reduceVar$var151$19 + time_impact[t][i$var119][cv$reduction152Index]);
-										var139[i$var119] = reduceVar$var151$19;
+											reduceVar$var151$13 = (reduceVar$var151$13 + time_impact[t][i$var119][cv$reduction152Index]);
+										var139[i$var119] = reduceVar$var151$13;
 										var154[i$var119] = DistributionSampling.samplePoisson(RNG$2, sum_t[t][i$var119]);
 									}
 							}
@@ -1451,7 +1101,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// A generated name to prevent name collisions if the reduction is implemented more
 											// than once in inference and probability code. Initialize the variable to the unit
 											// value
-											double reduceVar$var151$20 = 0.0;
+											double reduceVar$var151$14 = 0.0;
 											
 											// For each index in the array to be reduced
 											for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1459,8 +1109,8 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 												// 
 												// y's comment
 												// Set the right hand term to a value from the array var141
-												reduceVar$var151$20 = (reduceVar$var151$20 + time_impact[t][i$var119][cv$reduction152Index]);
-											var139[i$var119] = reduceVar$var151$20;
+												reduceVar$var151$14 = (reduceVar$var151$14 + time_impact[t][i$var119][cv$reduction152Index]);
+											var139[i$var119] = reduceVar$var151$14;
 										}
 								}
 							);
@@ -1539,7 +1189,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$21 = 0.0;
+										double reduceVar$var151$15 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1549,8 +1199,8 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// 
 											// y's comment
 											// Set the right hand term to a value from the array var141
-											reduceVar$var151$21 = (reduceVar$var151$21 + time_impact[t][i$var119][cv$reduction152Index]);
-										var139[i$var119] = reduceVar$var151$21;
+											reduceVar$var151$15 = (reduceVar$var151$15 + time_impact[t][i$var119][cv$reduction152Index]);
+										var139[i$var119] = reduceVar$var151$15;
 									}
 							}
 						);
@@ -1740,7 +1390,7 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 										// A generated name to prevent name collisions if the reduction is implemented more
 										// than once in inference and probability code. Initialize the variable to the unit
 										// value
-										double reduceVar$var151$23 = 0.0;
+										double reduceVar$var151$17 = 0.0;
 										
 										// For each index in the array to be reduced
 										for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1750,8 +1400,8 @@ class ReductionTest1$MultiThreadCPU extends org.sandwood.runtime.internal.model.
 											// 
 											// y's comment
 											// Set the right hand term to a value from the array var141
-											reduceVar$var151$23 = (reduceVar$var151$23 + time_impact[t][i$var119][cv$reduction152Index]);
-										var139[i$var119] = reduceVar$var151$23;
+											reduceVar$var151$17 = (reduceVar$var151$17 + time_impact[t][i$var119][cv$reduction152Index]);
+										var139[i$var119] = reduceVar$var151$17;
 									}
 							}
 						);

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$SingleThreadCPU_model.java
@@ -13,8 +13,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 	private boolean fixedFlag$sample101 = false;
 	private boolean fixedProbFlag$sample101 = false;
 	private boolean fixedProbFlag$sample165 = false;
-	private boolean[][] guard$sample101poisson164$global;
-	private boolean[][] guard$sample101put160$global;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
 	private double logProbability$arr;
@@ -638,9 +636,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 						// 
 						// Looking for a path between Sample 101 and consumer double[][] 153.
 						{
-							// Guard to check that at most one copy of the code is executed for a given random
-							// variable instance.
-							boolean[][] guard$sample101put160 = guard$sample101put160$global;
 							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 								if((i$var80 == i$var119)) {
 									for(int j = 0; j < time_dim; j += 1) {
@@ -650,58 +645,10 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 													if((t == index$t$3_4)) {
 														for(int index$i$3_5 = 0; index$i$3_5 < n_ac; index$i$3_5 += 1) {
 															if((i$var119 == index$i$3_5)) {
-																{
-																	// Set the flags to false
-																	guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$4_4 = (0 + 1); index$t$4_4 < T; index$t$4_4 += 1) {
-													if((t == index$t$4_4)) {
-														for(int index$i$4_5 = 0; index$i$4_5 < n_ac; index$i$4_5 += 1) {
-															if((i$var119 == index$i$4_5)) {
 																if(((0 <= j) && (j < time_dim))) {
 																	{
-																		// Set the flags to false
-																		guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$5_4 = (0 + 1); index$t$5_4 < T; index$t$5_4 += 1) {
-													if((t == index$t$5_4)) {
-														for(int index$i$5_5 = 0; index$i$5_5 < n_ac; index$i$5_5 += 1) {
-															if((i$var119 == index$i$5_5)) {
-																{
-																	if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																		// The body will execute, so should not be executed again
-																		guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
 																		{
-																			double[] var139 = sum_t[index$t$5_4];
+																			double[] var139 = sum_t[index$t$3_4];
 																			
 																			// Reduction of array null
 																			// 
@@ -716,65 +663,14 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 																				double x = reduceVar$var151$0;
 																				
 																				// Set the right hand term to a value from the array var141
-																				double y = time_impact[index$t$5_4][index$i$5_5][cv$reduction152Index];
+																				double y = time_impact[index$t$3_4][index$i$3_5][cv$reduction152Index];
 																				
 																				// Execute the reduction function, saving the result into the return value.
 																				// 
 																				// Copy the result of the reduction into the variable returned by the reduction.
 																				reduceVar$var151$0 = (x + y);
 																			}
-																			var139[index$i$5_5] = reduceVar$var151$0;
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$6_4 = (0 + 1); index$t$6_4 < T; index$t$6_4 += 1) {
-													if((t == index$t$6_4)) {
-														for(int index$i$6_5 = 0; index$i$6_5 < n_ac; index$i$6_5 += 1) {
-															if((i$var119 == index$i$6_5)) {
-																if(((0 <= j) && (j < time_dim))) {
-																	{
-																		if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																			// The body will execute, so should not be executed again
-																			guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																			{
-																				double[] var139 = sum_t[index$t$6_4];
-																				
-																				// Reduction of array null
-																				// 
-																				// A generated name to prevent name collisions if the reduction is implemented more
-																				// than once in inference and probability code. Initialize the variable to the unit
-																				// value
-																				double reduceVar$var151$1 = 0.0;
-																				
-																				// For each index in the array to be reduced
-																				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																					// Set the left hand term of the reduction function to the return variable value.
-																					double x = reduceVar$var151$1;
-																					
-																					// Set the right hand term to a value from the array var141
-																					double y = time_impact[index$t$6_4][index$i$6_5][cv$reduction152Index];
-																					
-																					// Execute the reduction function, saving the result into the return value.
-																					// 
-																					// Copy the result of the reduction into the variable returned by the reduction.
-																					reduceVar$var151$1 = (x + y);
-																				}
-																				var139[index$i$6_5] = reduceVar$var151$1;
-																			}
+																			var139[index$i$3_5] = reduceVar$var151$0;
 																		}
 																	}
 																}
@@ -810,129 +706,64 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					{
 						// Looking for a path between Sample 101 and consumer Poisson 157.
 						{
-							// Guard to check that at most one copy of the code is executed for a given random
-							// variable instance.
-							boolean[][] guard$sample101poisson164 = guard$sample101poisson164$global;
+							double traceTempVariable$var134$4_1 = cv$currentValue;
 							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 								if((i$var80 == i$var119)) {
 									for(int j = 0; j < time_dim; j += 1) {
 										if((var95 == j)) {
 											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$7_4 = (0 + 1); index$t$7_4 < T; index$t$7_4 += 1) {
-													if((t == index$t$7_4)) {
-														for(int index$i$7_5 = 0; index$i$7_5 < n_ac; index$i$7_5 += 1) {
-															if((i$var119 == index$i$7_5)) {
-																{
-																	for(int index$t$7_6 = (0 + 1); index$t$7_6 < T; index$t$7_6 += 1) {
-																		if((index$t$7_4 == index$t$7_6)) {
-																			for(int index$i$7_7 = 0; index$i$7_7 < n_ac; index$i$7_7 += 1) {
-																				if((index$i$7_5 == index$i$7_7))
-																					// Set the flags to false
-																					guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$8_4 = (0 + 1); index$t$8_4 < T; index$t$8_4 += 1) {
-													if((t == index$t$8_4)) {
-														for(int index$i$8_5 = 0; index$i$8_5 < n_ac; index$i$8_5 += 1) {
-															if((i$var119 == index$i$8_5)) {
+												double traceTempVariable$x$4_5 = (TimeFeat[t][j] * traceTempVariable$var134$4_1);
+												for(int index$t$4_6 = (0 + 1); index$t$4_6 < T; index$t$4_6 += 1) {
+													if((t == index$t$4_6)) {
+														for(int index$i$4_7 = 0; index$i$4_7 < n_ac; index$i$4_7 += 1) {
+															if((i$var119 == index$i$4_7)) {
 																if(((0 <= j) && (j < time_dim))) {
 																	{
-																		for(int index$t$8_6 = (0 + 1); index$t$8_6 < T; index$t$8_6 += 1) {
-																			if((index$t$8_4 == index$t$8_6)) {
-																				for(int index$i$8_7 = 0; index$i$8_7 < n_ac; index$i$8_7 += 1) {
-																					if((index$i$8_5 == index$i$8_7))
-																						// Set the flags to false
-																						guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																				}
+																		if((0 < time_dim)) {
+																			// Reduction of array null
+																			// 
+																			// A generated name to prevent name collisions if the reduction is implemented more
+																			// than once in inference and probability code. Initialize the variable to the unit
+																			// value
+																			double reduceVar$var151$1 = 0.0;
+																			
+																			// Reduce for every value except a masked value which will be skipped.
+																			for(int cv$reduction326Index = 0; cv$reduction326Index < j; cv$reduction326Index += 1) {
+																				// Set the left hand term of the reduction function to the return variable value.
+																				double x = reduceVar$var151$1;
+																				
+																				// Set the right hand term to a value from the array var141
+																				double y = time_impact[index$t$4_6][index$i$4_7][cv$reduction326Index];
+																				
+																				// Execute the reduction function, saving the result into the return value.
+																				// 
+																				// Copy the result of the reduction into the variable returned by the reduction.
+																				reduceVar$var151$1 = (x + y);
 																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							double traceTempVariable$var134$9_1 = cv$currentValue;
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$9_5 = (0 + 1); index$t$9_5 < T; index$t$9_5 += 1) {
-													if((t == index$t$9_5)) {
-														for(int index$i$9_6 = 0; index$i$9_6 < n_ac; index$i$9_6 += 1) {
-															if((i$var119 == index$i$9_6)) {
-																{
-																	if((0 < time_dim)) {
-																		// Reduction of array null
-																		// 
-																		// A generated name to prevent name collisions if the reduction is implemented more
-																		// than once in inference and probability code. Initialize the variable to the unit
-																		// value
-																		double reduceVar$var151$2 = time_impact[index$t$9_5][index$i$9_6][0];
-																		
-																		// Reduce for every value except a masked value which will be skipped.
-																		for(int cv$reduction480Index = 0; cv$reduction480Index < 0; cv$reduction480Index += 1) {
-																			// Set the left hand term of the reduction function to the return variable value.
-																			double x = reduceVar$var151$2;
+																			for(int cv$reduction326Index = (j + 1); cv$reduction326Index < time_dim; cv$reduction326Index += 1) {
+																				// Set the left hand term of the reduction function to the return variable value.
+																				double x = reduceVar$var151$1;
+																				
+																				// Set the right hand term to a value from the array var141
+																				double y = time_impact[index$t$4_6][index$i$4_7][cv$reduction326Index];
+																				
+																				// Execute the reduction function, saving the result into the return value.
+																				// 
+																				// Execute the reduction function, saving the result into the return value.
+																				// 
+																				// Copy the result of the reduction into the variable returned by the reduction.
+																				reduceVar$var151$1 = (x + y);
+																			}
+																			double cv$reduced152 = reduceVar$var151$1;
 																			
-																			// Set the right hand term to a value from the array var141
-																			double y = time_impact[index$t$9_5][index$i$9_6][cv$reduction480Index];
-																			
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
 																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$2 = (x + y);
-																		}
-																		for(int cv$reduction480Index = (0 + 1); cv$reduction480Index < time_dim; cv$reduction480Index += 1) {
-																			// Set the left hand term of the reduction function to the return variable value.
-																			double x = reduceVar$var151$2;
-																			
-																			// Set the right hand term to a value from the array var141
-																			double y = time_impact[index$t$9_5][index$i$9_6][cv$reduction480Index];
-																			
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
-																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$2 = (x + y);
-																		}
-																		double cv$reduced152 = reduceVar$var151$2;
-																		
-																		// Copy the result of the reduction into the variable returned by the reduction.
-																		reduceVar$var151$2 = (0.0 + cv$reduced152);
-																		double traceTempVariable$var151$9_7 = reduceVar$var151$2;
-																		double traceTempVariable$var156$9_8 = traceTempVariable$var151$9_7;
-																		for(int index$t$9_9 = (0 + 1); index$t$9_9 < T; index$t$9_9 += 1) {
-																			if((index$t$9_5 == index$t$9_9)) {
-																				for(int index$i$9_10 = 0; index$i$9_10 < n_ac; index$i$9_10 += 1) {
-																					if((index$i$9_6 == index$i$9_10)) {
-																						if(!guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																							// The body will execute, so should not be executed again
-																							guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																							
+																			reduceVar$var151$1 = (traceTempVariable$x$4_5 + cv$reduced152);
+																			double traceTempVariable$var151$4_8 = reduceVar$var151$1;
+																			double traceTempVariable$var156$4_9 = traceTempVariable$var151$4_8;
+																			for(int index$t$4_10 = (0 + 1); index$t$4_10 < T; index$t$4_10 += 1) {
+																				if((index$t$4_6 == index$t$4_10)) {
+																					for(int index$i$4_11 = 0; index$i$4_11 < n_ac; index$i$4_11 += 1) {
+																						if((index$i$4_7 == index$i$4_11)) {
 																							// Processing sample task 165 of consumer random variable null.
 																							{
 																								// Set an accumulator to sum the probabilities for each possible configuration of
@@ -949,19 +780,19 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 																												double cv$temp$2$var156;
 																												{
 																													// Constructing a random variable input for use later.
-																													double var156 = traceTempVariable$var156$9_8;
+																													double var156 = traceTempVariable$var156$4_9;
 																													cv$temp$2$var156 = var156;
 																												}
 																												
 																												// Record the probability of sample task 165 generating output with current configuration.
-																												if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)) < cv$accumulatedConsumerProbabilities))
-																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
 																												else {
 																													// If the second value is -infinity.
 																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156));
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156));
 																													else
-																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)));
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)));
 																												}
 																												
 																												// Recorded the probability of reaching sample task 165 with the current configuration.
@@ -985,139 +816,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 																										cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
 																									else
 																										cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
-																								}
-																							}
-																						}
-																					}
-																				}
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							double traceTempVariable$var134$10_1 = cv$currentValue;
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												double traceTempVariable$x$10_5 = (TimeFeat[t][j] * traceTempVariable$var134$10_1);
-												for(int index$t$10_6 = (0 + 1); index$t$10_6 < T; index$t$10_6 += 1) {
-													if((t == index$t$10_6)) {
-														for(int index$i$10_7 = 0; index$i$10_7 < n_ac; index$i$10_7 += 1) {
-															if((i$var119 == index$i$10_7)) {
-																if(((0 <= j) && (j < time_dim))) {
-																	{
-																		if((0 < time_dim)) {
-																			// Reduction of array null
-																			// 
-																			// A generated name to prevent name collisions if the reduction is implemented more
-																			// than once in inference and probability code. Initialize the variable to the unit
-																			// value
-																			double reduceVar$var151$3 = 0.0;
-																			
-																			// Reduce for every value except a masked value which will be skipped.
-																			for(int cv$reduction526Index = 0; cv$reduction526Index < j; cv$reduction526Index += 1) {
-																				// Set the left hand term of the reduction function to the return variable value.
-																				double x = reduceVar$var151$3;
-																				
-																				// Set the right hand term to a value from the array var141
-																				double y = time_impact[index$t$10_6][index$i$10_7][cv$reduction526Index];
-																				
-																				// Execute the reduction function, saving the result into the return value.
-																				// 
-																				// Copy the result of the reduction into the variable returned by the reduction.
-																				reduceVar$var151$3 = (x + y);
-																			}
-																			for(int cv$reduction526Index = (j + 1); cv$reduction526Index < time_dim; cv$reduction526Index += 1) {
-																				// Set the left hand term of the reduction function to the return variable value.
-																				double x = reduceVar$var151$3;
-																				
-																				// Set the right hand term to a value from the array var141
-																				double y = time_impact[index$t$10_6][index$i$10_7][cv$reduction526Index];
-																				
-																				// Execute the reduction function, saving the result into the return value.
-																				// 
-																				// Execute the reduction function, saving the result into the return value.
-																				// 
-																				// Copy the result of the reduction into the variable returned by the reduction.
-																				reduceVar$var151$3 = (x + y);
-																			}
-																			double cv$reduced152 = reduceVar$var151$3;
-																			
-																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$3 = (traceTempVariable$x$10_5 + cv$reduced152);
-																			double traceTempVariable$var151$10_8 = reduceVar$var151$3;
-																			double traceTempVariable$var156$10_9 = traceTempVariable$var151$10_8;
-																			for(int index$t$10_10 = (0 + 1); index$t$10_10 < T; index$t$10_10 += 1) {
-																				if((index$t$10_6 == index$t$10_10)) {
-																					for(int index$i$10_11 = 0; index$i$10_11 < n_ac; index$i$10_11 += 1) {
-																						if((index$i$10_7 == index$i$10_11)) {
-																							if(!guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																								// The body will execute, so should not be executed again
-																								guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																								
-																								// Processing sample task 165 of consumer random variable null.
-																								{
-																									// Set an accumulator to sum the probabilities for each possible configuration of
-																									// inputs.
-																									double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
-																									
-																									// Set an accumulator to record the consumer distributions not seen. Initially set
-																									// to 1 as seen values will be deducted from this value.
-																									double cv$consumerDistributionProbabilityAccumulator = 1.0;
-																									{
-																										{
-																											{
-																												{
-																													double cv$temp$3$var156;
-																													{
-																														// Constructing a random variable input for use later.
-																														double var156 = traceTempVariable$var156$10_9;
-																														cv$temp$3$var156 = var156;
-																													}
-																													
-																													// Record the probability of sample task 165 generating output with current configuration.
-																													if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)) < cv$accumulatedConsumerProbabilities))
-																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
-																													else {
-																														// If the second value is -infinity.
-																														if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																															cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156));
-																														else
-																															cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)));
-																													}
-																													
-																													// Recorded the probability of reaching sample task 165 with the current configuration.
-																													cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
-																												}
-																											}
-																										}
-																									}
-																									
-																									// A check to ensure rounding of floating point values can never result in a negative
-																									// value.
-																									cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
-																									
-																									// Multiply (log space add) in the probability of the sample task to the overall probability
-																									// for this configuration of the source random variable.
-																									if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
-																										cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
-																									else {
-																										// If the second value is -infinity.
-																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																											cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
-																										else
-																											cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
-																									}
 																								}
 																							}
 																						}
@@ -1206,143 +904,41 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// 
 				// Looking for a path between Sample 101 and consumer double[][] 153.
 				{
-					// Guard to check that at most one copy of the code is executed for a given random
-					// variable instance.
-					boolean[][] guard$sample101put160 = guard$sample101put160$global;
 					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 						if((i$var80 == i$var119)) {
 							for(int j = 0; j < time_dim; j += 1) {
 								if((var95 == j)) {
 									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$17_4 = (0 + 1); index$t$17_4 < T; index$t$17_4 += 1) {
-											if((t == index$t$17_4)) {
-												for(int index$i$17_5 = 0; index$i$17_5 < n_ac; index$i$17_5 += 1) {
-													if((i$var119 == index$i$17_5)) {
-														{
-															// Set the flags to false
-															guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$18_4 = (0 + 1); index$t$18_4 < T; index$t$18_4 += 1) {
-											if((t == index$t$18_4)) {
-												for(int index$i$18_5 = 0; index$i$18_5 < n_ac; index$i$18_5 += 1) {
-													if((i$var119 == index$i$18_5)) {
+										for(int index$t$9_4 = (0 + 1); index$t$9_4 < T; index$t$9_4 += 1) {
+											if((t == index$t$9_4)) {
+												for(int index$i$9_5 = 0; index$i$9_5 < n_ac; index$i$9_5 += 1) {
+													if((i$var119 == index$i$9_5)) {
 														if(((0 <= j) && (j < time_dim))) {
 															{
-																// Set the flags to false
-																guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$19_4 = (0 + 1); index$t$19_4 < T; index$t$19_4 += 1) {
-											if((t == index$t$19_4)) {
-												for(int index$i$19_5 = 0; index$i$19_5 < n_ac; index$i$19_5 += 1) {
-													if((i$var119 == index$i$19_5)) {
-														{
-															if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																// The body will execute, so should not be executed again
-																guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
 																{
-																	double[] var139 = sum_t[index$t$19_4];
+																	double[] var139 = sum_t[index$t$9_4];
 																	
 																	// Reduction of array null
 																	// 
 																	// A generated name to prevent name collisions if the reduction is implemented more
 																	// than once in inference and probability code. Initialize the variable to the unit
 																	// value
-																	double reduceVar$var151$4 = 0.0;
+																	double reduceVar$var151$2 = 0.0;
 																	
 																	// For each index in the array to be reduced
 																	for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 																		// Set the left hand term of the reduction function to the return variable value.
-																		double x = reduceVar$var151$4;
+																		double x = reduceVar$var151$2;
 																		
 																		// Set the right hand term to a value from the array var141
-																		double y = time_impact[index$t$19_4][index$i$19_5][cv$reduction152Index];
+																		double y = time_impact[index$t$9_4][index$i$9_5][cv$reduction152Index];
 																		
 																		// Execute the reduction function, saving the result into the return value.
 																		// 
 																		// Copy the result of the reduction into the variable returned by the reduction.
-																		reduceVar$var151$4 = (x + y);
+																		reduceVar$var151$2 = (x + y);
 																	}
-																	var139[index$i$19_5] = reduceVar$var151$4;
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$20_4 = (0 + 1); index$t$20_4 < T; index$t$20_4 += 1) {
-											if((t == index$t$20_4)) {
-												for(int index$i$20_5 = 0; index$i$20_5 < n_ac; index$i$20_5 += 1) {
-													if((i$var119 == index$i$20_5)) {
-														if(((0 <= j) && (j < time_dim))) {
-															{
-																if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																	// The body will execute, so should not be executed again
-																	guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																	{
-																		double[] var139 = sum_t[index$t$20_4];
-																		
-																		// Reduction of array null
-																		// 
-																		// A generated name to prevent name collisions if the reduction is implemented more
-																		// than once in inference and probability code. Initialize the variable to the unit
-																		// value
-																		double reduceVar$var151$5 = 0.0;
-																		
-																		// For each index in the array to be reduced
-																		for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																			// Set the left hand term of the reduction function to the return variable value.
-																			double x = reduceVar$var151$5;
-																			
-																			// Set the right hand term to a value from the array var141
-																			double y = time_impact[index$t$20_4][index$i$20_5][cv$reduction152Index];
-																			
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
-																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$5 = (x + y);
-																		}
-																		var139[index$i$20_5] = reduceVar$var151$5;
-																	}
+																	var139[index$i$9_5] = reduceVar$var151$2;
 																}
 															}
 														}
@@ -1364,42 +960,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 	// here prevents repeated allocation and deallocation, and makes the code more amenable
 	// to GPU execution.
 	@Override
-	public final void allocateScratch() {
-		// Allocate scratch space.
-		// Constructor for guard$sample101put160$global
-		{
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_t = 0;
-			
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_i$var119 = 0;
-			for(int t = (0 + 1); t < T; t += 1)
-				cv$max_i$var119 = Math.max(cv$max_i$var119, ((n_ac - 0) / 1));
-			cv$max_t = Math.max(cv$max_t, ((T - (0 + 1)) / 1));
-			
-			// Allocation of guard$sample101put160$global for single threaded execution
-			guard$sample101put160$global = new boolean[cv$max_t][cv$max_i$var119];
-		}
-		
-		// Constructor for guard$sample101poisson164$global
-		{
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_t = 0;
-			
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_i$var119 = 0;
-			for(int t = (0 + 1); t < T; t += 1)
-				cv$max_i$var119 = Math.max(cv$max_i$var119, ((n_ac - 0) / 1));
-			cv$max_t = Math.max(cv$max_t, ((T - (0 + 1)) / 1));
-			
-			// Allocation of guard$sample101poisson164$global for single threaded execution
-			guard$sample101poisson164$global = new boolean[cv$max_t][cv$max_i$var119];
-		}
-	}
+	public final void allocateScratch() {}
 
 	// Method to allocate space for model inputs and outputs.
 	@Override
@@ -1466,9 +1027,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 			for(int t = (0 + 1); t < T; t += 1)
 				logProbability$sample165[((t - (0 + 1)) / 1)] = new double[((((n_ac - 1) - 0) / 1) + 1)];
 		}
-		
-		// Allocate scratch space
-		allocateScratch();
 	}
 
 	// Method to execute the model code conventionally.
@@ -1497,12 +1055,12 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$6 = 0.0;
+				double reduceVar$var151$3 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 					// Set the left hand term of the reduction function to the return variable value.
-					double x = reduceVar$var151$6;
+					double x = reduceVar$var151$3;
 					
 					// Set the right hand term to a value from the array var141
 					double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1510,10 +1068,10 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// Execute the reduction function, saving the result into the return value.
 					if(!fixedFlag$sample101)
 						// Copy the result of the reduction into the variable returned by the reduction.
-						reduceVar$var151$6 = (x + y);
+						reduceVar$var151$3 = (x + y);
 				}
 				if(!fixedFlag$sample101)
-					var139[i$var119] = reduceVar$var151$6;
+					var139[i$var119] = reduceVar$var151$3;
 				var154[i$var119] = DistributionSampling.samplePoisson(RNG$, sum_t[t][i$var119]);
 			}
 		}
@@ -1545,12 +1103,12 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$10 = 0.0;
+				double reduceVar$var151$7 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 					// Set the left hand term of the reduction function to the return variable value.
-					double x = reduceVar$var151$10;
+					double x = reduceVar$var151$7;
 					
 					// Set the right hand term to a value from the array var141
 					double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1558,9 +1116,9 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Copy the result of the reduction into the variable returned by the reduction.
-					reduceVar$var151$10 = (x + y);
+					reduceVar$var151$7 = (x + y);
 				}
-				var139[i$var119] = reduceVar$var151$10;
+				var139[i$var119] = reduceVar$var151$7;
 			}
 		}
 	}
@@ -1591,12 +1149,12 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$7 = 0.0;
+				double reduceVar$var151$4 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 					// Set the left hand term of the reduction function to the return variable value.
-					double x = reduceVar$var151$7;
+					double x = reduceVar$var151$4;
 					
 					// Set the right hand term to a value from the array var141
 					double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1604,9 +1162,9 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Copy the result of the reduction into the variable returned by the reduction.
-					reduceVar$var151$7 = (x + y);
+					reduceVar$var151$4 = (x + y);
 				}
-				var139[i$var119] = reduceVar$var151$7;
+				var139[i$var119] = reduceVar$var151$4;
 				var154[i$var119] = DistributionSampling.samplePoisson(RNG$, sum_t[t][i$var119]);
 			}
 		}
@@ -1638,12 +1196,12 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$8 = 0.0;
+				double reduceVar$var151$5 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 					// Set the left hand term of the reduction function to the return variable value.
-					double x = reduceVar$var151$8;
+					double x = reduceVar$var151$5;
 					
 					// Set the right hand term to a value from the array var141
 					double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1651,10 +1209,10 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// Execute the reduction function, saving the result into the return value.
 					if(!fixedFlag$sample101)
 						// Copy the result of the reduction into the variable returned by the reduction.
-						reduceVar$var151$8 = (x + y);
+						reduceVar$var151$5 = (x + y);
 				}
 				if(!fixedFlag$sample101)
-					var139[i$var119] = reduceVar$var151$8;
+					var139[i$var119] = reduceVar$var151$5;
 			}
 		}
 	}
@@ -1685,12 +1243,12 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$9 = 0.0;
+				double reduceVar$var151$6 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 					// Set the left hand term of the reduction function to the return variable value.
-					double x = reduceVar$var151$9;
+					double x = reduceVar$var151$6;
 					
 					// Set the right hand term to a value from the array var141
 					double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1698,9 +1256,9 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Copy the result of the reduction into the variable returned by the reduction.
-					reduceVar$var151$9 = (x + y);
+					reduceVar$var151$6 = (x + y);
 				}
-				var139[i$var119] = reduceVar$var151$9;
+				var139[i$var119] = reduceVar$var151$6;
 			}
 		}
 	}
@@ -1857,12 +1415,12 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$11 = 0.0;
+				double reduceVar$var151$8 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 					// Set the left hand term of the reduction function to the return variable value.
-					double x = reduceVar$var151$11;
+					double x = reduceVar$var151$8;
 					
 					// Set the right hand term to a value from the array var141
 					double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1870,9 +1428,9 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Copy the result of the reduction into the variable returned by the reduction.
-					reduceVar$var151$11 = (x + y);
+					reduceVar$var151$8 = (x + y);
 				}
-				var139[i$var119] = reduceVar$var151$11;
+				var139[i$var119] = reduceVar$var151$8;
 			}
 		}
 	}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$SingleThreadCPU_modelNoComments.java
@@ -11,8 +11,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 	private boolean fixedFlag$sample101 = false;
 	private boolean fixedProbFlag$sample101 = false;
 	private boolean fixedProbFlag$sample165 = false;
-	private boolean[][] guard$sample101poisson164$global;
-	private boolean[][] guard$sample101put160$global;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
 	private double logProbability$arr;
@@ -413,7 +411,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 							}
 						}
 						{
-							boolean[][] guard$sample101put160 = guard$sample101put160$global;
 							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 								if((i$var80 == i$var119)) {
 									for(int j = 0; j < time_dim; j += 1) {
@@ -423,97 +420,17 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 													if((t == index$t$3_4)) {
 														for(int index$i$3_5 = 0; index$i$3_5 < n_ac; index$i$3_5 += 1) {
 															if((i$var119 == index$i$3_5)) {
-																{
-																	guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$4_4 = (0 + 1); index$t$4_4 < T; index$t$4_4 += 1) {
-													if((t == index$t$4_4)) {
-														for(int index$i$4_5 = 0; index$i$4_5 < n_ac; index$i$4_5 += 1) {
-															if((i$var119 == index$i$4_5)) {
 																if(((0 <= j) && (j < time_dim))) {
 																	{
-																		guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$5_4 = (0 + 1); index$t$5_4 < T; index$t$5_4 += 1) {
-													if((t == index$t$5_4)) {
-														for(int index$i$5_5 = 0; index$i$5_5 < n_ac; index$i$5_5 += 1) {
-															if((i$var119 == index$i$5_5)) {
-																{
-																	if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																		guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
 																		{
-																			double[] var139 = sum_t[index$t$5_4];
+																			double[] var139 = sum_t[index$t$3_4];
 																			double reduceVar$var151$0 = 0.0;
 																			for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 																				double x = reduceVar$var151$0;
-																				double y = time_impact[index$t$5_4][index$i$5_5][cv$reduction152Index];
+																				double y = time_impact[index$t$3_4][index$i$3_5][cv$reduction152Index];
 																				reduceVar$var151$0 = (x + y);
 																			}
-																			var139[index$i$5_5] = reduceVar$var151$0;
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$6_4 = (0 + 1); index$t$6_4 < T; index$t$6_4 += 1) {
-													if((t == index$t$6_4)) {
-														for(int index$i$6_5 = 0; index$i$6_5 < n_ac; index$i$6_5 += 1) {
-															if((i$var119 == index$i$6_5)) {
-																if(((0 <= j) && (j < time_dim))) {
-																	{
-																		if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																			guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																			{
-																				double[] var139 = sum_t[index$t$6_4];
-																				double reduceVar$var151$1 = 0.0;
-																				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																					double x = reduceVar$var151$1;
-																					double y = time_impact[index$t$6_4][index$i$6_5][cv$reduction152Index];
-																					reduceVar$var151$1 = (x + y);
-																				}
-																				var139[index$i$6_5] = reduceVar$var151$1;
-																			}
+																			var139[index$i$3_5] = reduceVar$var151$0;
 																		}
 																	}
 																}
@@ -542,98 +459,39 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					double cv$accumulatedProbabilities = (Math.log(1.0) + (DistributionSampling.logProbabilityGaussian(((cv$currentValue - cv$temp$0$var83) / Math.sqrt(cv$temp$1$var84))) - (0.5 * Math.log(cv$temp$1$var84))));
 					{
 						{
-							boolean[][] guard$sample101poisson164 = guard$sample101poisson164$global;
+							double traceTempVariable$var134$4_1 = cv$currentValue;
 							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 								if((i$var80 == i$var119)) {
 									for(int j = 0; j < time_dim; j += 1) {
 										if((var95 == j)) {
 											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$7_4 = (0 + 1); index$t$7_4 < T; index$t$7_4 += 1) {
-													if((t == index$t$7_4)) {
-														for(int index$i$7_5 = 0; index$i$7_5 < n_ac; index$i$7_5 += 1) {
-															if((i$var119 == index$i$7_5)) {
-																{
-																	for(int index$t$7_6 = (0 + 1); index$t$7_6 < T; index$t$7_6 += 1) {
-																		if((index$t$7_4 == index$t$7_6)) {
-																			for(int index$i$7_7 = 0; index$i$7_7 < n_ac; index$i$7_7 += 1) {
-																				if((index$i$7_5 == index$i$7_7))
-																					guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$8_4 = (0 + 1); index$t$8_4 < T; index$t$8_4 += 1) {
-													if((t == index$t$8_4)) {
-														for(int index$i$8_5 = 0; index$i$8_5 < n_ac; index$i$8_5 += 1) {
-															if((i$var119 == index$i$8_5)) {
+												double traceTempVariable$x$4_5 = (TimeFeat[t][j] * traceTempVariable$var134$4_1);
+												for(int index$t$4_6 = (0 + 1); index$t$4_6 < T; index$t$4_6 += 1) {
+													if((t == index$t$4_6)) {
+														for(int index$i$4_7 = 0; index$i$4_7 < n_ac; index$i$4_7 += 1) {
+															if((i$var119 == index$i$4_7)) {
 																if(((0 <= j) && (j < time_dim))) {
 																	{
-																		for(int index$t$8_6 = (0 + 1); index$t$8_6 < T; index$t$8_6 += 1) {
-																			if((index$t$8_4 == index$t$8_6)) {
-																				for(int index$i$8_7 = 0; index$i$8_7 < n_ac; index$i$8_7 += 1) {
-																					if((index$i$8_5 == index$i$8_7))
-																						guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																				}
+																		if((0 < time_dim)) {
+																			double reduceVar$var151$1 = 0.0;
+																			for(int cv$reduction326Index = 0; cv$reduction326Index < j; cv$reduction326Index += 1) {
+																				double x = reduceVar$var151$1;
+																				double y = time_impact[index$t$4_6][index$i$4_7][cv$reduction326Index];
+																				reduceVar$var151$1 = (x + y);
 																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							double traceTempVariable$var134$9_1 = cv$currentValue;
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$9_5 = (0 + 1); index$t$9_5 < T; index$t$9_5 += 1) {
-													if((t == index$t$9_5)) {
-														for(int index$i$9_6 = 0; index$i$9_6 < n_ac; index$i$9_6 += 1) {
-															if((i$var119 == index$i$9_6)) {
-																{
-																	if((0 < time_dim)) {
-																		double reduceVar$var151$2 = time_impact[index$t$9_5][index$i$9_6][0];
-																		for(int cv$reduction480Index = 0; cv$reduction480Index < 0; cv$reduction480Index += 1) {
-																			double x = reduceVar$var151$2;
-																			double y = time_impact[index$t$9_5][index$i$9_6][cv$reduction480Index];
-																			reduceVar$var151$2 = (x + y);
-																		}
-																		for(int cv$reduction480Index = (0 + 1); cv$reduction480Index < time_dim; cv$reduction480Index += 1) {
-																			double x = reduceVar$var151$2;
-																			double y = time_impact[index$t$9_5][index$i$9_6][cv$reduction480Index];
-																			reduceVar$var151$2 = (x + y);
-																		}
-																		double cv$reduced152 = reduceVar$var151$2;
-																		reduceVar$var151$2 = (0.0 + cv$reduced152);
-																		double traceTempVariable$var151$9_7 = reduceVar$var151$2;
-																		double traceTempVariable$var156$9_8 = traceTempVariable$var151$9_7;
-																		for(int index$t$9_9 = (0 + 1); index$t$9_9 < T; index$t$9_9 += 1) {
-																			if((index$t$9_5 == index$t$9_9)) {
-																				for(int index$i$9_10 = 0; index$i$9_10 < n_ac; index$i$9_10 += 1) {
-																					if((index$i$9_6 == index$i$9_10)) {
-																						if(!guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																							guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
+																			for(int cv$reduction326Index = (j + 1); cv$reduction326Index < time_dim; cv$reduction326Index += 1) {
+																				double x = reduceVar$var151$1;
+																				double y = time_impact[index$t$4_6][index$i$4_7][cv$reduction326Index];
+																				reduceVar$var151$1 = (x + y);
+																			}
+																			double cv$reduced152 = reduceVar$var151$1;
+																			reduceVar$var151$1 = (traceTempVariable$x$4_5 + cv$reduced152);
+																			double traceTempVariable$var151$4_8 = reduceVar$var151$1;
+																			double traceTempVariable$var156$4_9 = traceTempVariable$var151$4_8;
+																			for(int index$t$4_10 = (0 + 1); index$t$4_10 < T; index$t$4_10 += 1) {
+																				if((index$t$4_6 == index$t$4_10)) {
+																					for(int index$i$4_11 = 0; index$i$4_11 < n_ac; index$i$4_11 += 1) {
+																						if((index$i$4_7 == index$i$4_11)) {
 																							{
 																								double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
 																								double cv$consumerDistributionProbabilityAccumulator = 1.0;
@@ -643,16 +501,16 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 																											{
 																												double cv$temp$2$var156;
 																												{
-																													double var156 = traceTempVariable$var156$9_8;
+																													double var156 = traceTempVariable$var156$4_9;
 																													cv$temp$2$var156 = var156;
 																												}
-																												if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)) < cv$accumulatedConsumerProbabilities))
-																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
 																												else {
 																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156));
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156));
 																													else
-																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)));
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)));
 																												}
 																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
 																											}
@@ -667,93 +525,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 																										cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
 																									else
 																										cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
-																								}
-																							}
-																						}
-																					}
-																				}
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							double traceTempVariable$var134$10_1 = cv$currentValue;
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												double traceTempVariable$x$10_5 = (TimeFeat[t][j] * traceTempVariable$var134$10_1);
-												for(int index$t$10_6 = (0 + 1); index$t$10_6 < T; index$t$10_6 += 1) {
-													if((t == index$t$10_6)) {
-														for(int index$i$10_7 = 0; index$i$10_7 < n_ac; index$i$10_7 += 1) {
-															if((i$var119 == index$i$10_7)) {
-																if(((0 <= j) && (j < time_dim))) {
-																	{
-																		if((0 < time_dim)) {
-																			double reduceVar$var151$3 = 0.0;
-																			for(int cv$reduction526Index = 0; cv$reduction526Index < j; cv$reduction526Index += 1) {
-																				double x = reduceVar$var151$3;
-																				double y = time_impact[index$t$10_6][index$i$10_7][cv$reduction526Index];
-																				reduceVar$var151$3 = (x + y);
-																			}
-																			for(int cv$reduction526Index = (j + 1); cv$reduction526Index < time_dim; cv$reduction526Index += 1) {
-																				double x = reduceVar$var151$3;
-																				double y = time_impact[index$t$10_6][index$i$10_7][cv$reduction526Index];
-																				reduceVar$var151$3 = (x + y);
-																			}
-																			double cv$reduced152 = reduceVar$var151$3;
-																			reduceVar$var151$3 = (traceTempVariable$x$10_5 + cv$reduced152);
-																			double traceTempVariable$var151$10_8 = reduceVar$var151$3;
-																			double traceTempVariable$var156$10_9 = traceTempVariable$var151$10_8;
-																			for(int index$t$10_10 = (0 + 1); index$t$10_10 < T; index$t$10_10 += 1) {
-																				if((index$t$10_6 == index$t$10_10)) {
-																					for(int index$i$10_11 = 0; index$i$10_11 < n_ac; index$i$10_11 += 1) {
-																						if((index$i$10_7 == index$i$10_11)) {
-																							if(!guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																								guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																								{
-																									double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
-																									double cv$consumerDistributionProbabilityAccumulator = 1.0;
-																									{
-																										{
-																											{
-																												{
-																													double cv$temp$3$var156;
-																													{
-																														double var156 = traceTempVariable$var156$10_9;
-																														cv$temp$3$var156 = var156;
-																													}
-																													if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)) < cv$accumulatedConsumerProbabilities))
-																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
-																													else {
-																														if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																															cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156));
-																														else
-																															cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)));
-																													}
-																													cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
-																												}
-																											}
-																										}
-																									}
-																									cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
-																									if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
-																										cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
-																									else {
-																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																											cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
-																										else
-																											cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
-																									}
 																								}
 																							}
 																						}
@@ -813,107 +584,26 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					}
 				}
 				{
-					boolean[][] guard$sample101put160 = guard$sample101put160$global;
 					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 						if((i$var80 == i$var119)) {
 							for(int j = 0; j < time_dim; j += 1) {
 								if((var95 == j)) {
 									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$17_4 = (0 + 1); index$t$17_4 < T; index$t$17_4 += 1) {
-											if((t == index$t$17_4)) {
-												for(int index$i$17_5 = 0; index$i$17_5 < n_ac; index$i$17_5 += 1) {
-													if((i$var119 == index$i$17_5)) {
-														{
-															guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$18_4 = (0 + 1); index$t$18_4 < T; index$t$18_4 += 1) {
-											if((t == index$t$18_4)) {
-												for(int index$i$18_5 = 0; index$i$18_5 < n_ac; index$i$18_5 += 1) {
-													if((i$var119 == index$i$18_5)) {
+										for(int index$t$9_4 = (0 + 1); index$t$9_4 < T; index$t$9_4 += 1) {
+											if((t == index$t$9_4)) {
+												for(int index$i$9_5 = 0; index$i$9_5 < n_ac; index$i$9_5 += 1) {
+													if((i$var119 == index$i$9_5)) {
 														if(((0 <= j) && (j < time_dim))) {
 															{
-																guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$19_4 = (0 + 1); index$t$19_4 < T; index$t$19_4 += 1) {
-											if((t == index$t$19_4)) {
-												for(int index$i$19_5 = 0; index$i$19_5 < n_ac; index$i$19_5 += 1) {
-													if((i$var119 == index$i$19_5)) {
-														{
-															if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
 																{
-																	double[] var139 = sum_t[index$t$19_4];
-																	double reduceVar$var151$4 = 0.0;
+																	double[] var139 = sum_t[index$t$9_4];
+																	double reduceVar$var151$2 = 0.0;
 																	for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																		double x = reduceVar$var151$4;
-																		double y = time_impact[index$t$19_4][index$i$19_5][cv$reduction152Index];
-																		reduceVar$var151$4 = (x + y);
+																		double x = reduceVar$var151$2;
+																		double y = time_impact[index$t$9_4][index$i$9_5][cv$reduction152Index];
+																		reduceVar$var151$2 = (x + y);
 																	}
-																	var139[index$i$19_5] = reduceVar$var151$4;
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$20_4 = (0 + 1); index$t$20_4 < T; index$t$20_4 += 1) {
-											if((t == index$t$20_4)) {
-												for(int index$i$20_5 = 0; index$i$20_5 < n_ac; index$i$20_5 += 1) {
-													if((i$var119 == index$i$20_5)) {
-														if(((0 <= j) && (j < time_dim))) {
-															{
-																if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																	guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																	{
-																		double[] var139 = sum_t[index$t$20_4];
-																		double reduceVar$var151$5 = 0.0;
-																		for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																			double x = reduceVar$var151$5;
-																			double y = time_impact[index$t$20_4][index$i$20_5][cv$reduction152Index];
-																			reduceVar$var151$5 = (x + y);
-																		}
-																		var139[index$i$20_5] = reduceVar$var151$5;
-																	}
+																	var139[index$i$9_5] = reduceVar$var151$2;
 																}
 															}
 														}
@@ -932,24 +622,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 	}
 
 	@Override
-	public final void allocateScratch() {
-		{
-			int cv$max_t = 0;
-			int cv$max_i$var119 = 0;
-			for(int t = (0 + 1); t < T; t += 1)
-				cv$max_i$var119 = Math.max(cv$max_i$var119, ((n_ac - 0) / 1));
-			cv$max_t = Math.max(cv$max_t, ((T - (0 + 1)) / 1));
-			guard$sample101put160$global = new boolean[cv$max_t][cv$max_i$var119];
-		}
-		{
-			int cv$max_t = 0;
-			int cv$max_i$var119 = 0;
-			for(int t = (0 + 1); t < T; t += 1)
-				cv$max_i$var119 = Math.max(cv$max_i$var119, ((n_ac - 0) / 1));
-			cv$max_t = Math.max(cv$max_t, ((T - (0 + 1)) / 1));
-			guard$sample101poisson164$global = new boolean[cv$max_t][cv$max_i$var119];
-		}
-	}
+	public final void allocateScratch() {}
 
 	@Override
 	public final void allocator() {
@@ -999,7 +672,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 			for(int t = (0 + 1); t < T; t += 1)
 				logProbability$sample165[((t - (0 + 1)) / 1)] = new double[((((n_ac - 1) - 0) / 1) + 1)];
 		}
-		allocateScratch();
 	}
 
 	@Override
@@ -1021,15 +693,15 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					if(!fixedFlag$sample101)
 						var130[j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
 				}
-				double reduceVar$var151$6 = 0.0;
+				double reduceVar$var151$3 = 0.0;
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-					double x = reduceVar$var151$6;
+					double x = reduceVar$var151$3;
 					double y = time_impact[t][i$var119][cv$reduction152Index];
 					if(!fixedFlag$sample101)
-						reduceVar$var151$6 = (x + y);
+						reduceVar$var151$3 = (x + y);
 				}
 				if(!fixedFlag$sample101)
-					var139[i$var119] = reduceVar$var151$6;
+					var139[i$var119] = reduceVar$var151$3;
 				var154[i$var119] = DistributionSampling.samplePoisson(RNG$, sum_t[t][i$var119]);
 			}
 		}
@@ -1052,13 +724,13 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					double[] var130 = var129[i$var119];
 					var130[j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
 				}
-				double reduceVar$var151$10 = 0.0;
+				double reduceVar$var151$7 = 0.0;
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-					double x = reduceVar$var151$10;
+					double x = reduceVar$var151$7;
 					double y = time_impact[t][i$var119][cv$reduction152Index];
-					reduceVar$var151$10 = (x + y);
+					reduceVar$var151$7 = (x + y);
 				}
-				var139[i$var119] = reduceVar$var151$10;
+				var139[i$var119] = reduceVar$var151$7;
 			}
 		}
 	}
@@ -1081,13 +753,13 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					double[] var130 = var129[i$var119];
 					var130[j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
 				}
-				double reduceVar$var151$7 = 0.0;
+				double reduceVar$var151$4 = 0.0;
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-					double x = reduceVar$var151$7;
+					double x = reduceVar$var151$4;
 					double y = time_impact[t][i$var119][cv$reduction152Index];
-					reduceVar$var151$7 = (x + y);
+					reduceVar$var151$4 = (x + y);
 				}
-				var139[i$var119] = reduceVar$var151$7;
+				var139[i$var119] = reduceVar$var151$4;
 				var154[i$var119] = DistributionSampling.samplePoisson(RNG$, sum_t[t][i$var119]);
 			}
 		}
@@ -1111,15 +783,15 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					if(!fixedFlag$sample101)
 						var130[j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
 				}
-				double reduceVar$var151$8 = 0.0;
+				double reduceVar$var151$5 = 0.0;
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-					double x = reduceVar$var151$8;
+					double x = reduceVar$var151$5;
 					double y = time_impact[t][i$var119][cv$reduction152Index];
 					if(!fixedFlag$sample101)
-						reduceVar$var151$8 = (x + y);
+						reduceVar$var151$5 = (x + y);
 				}
 				if(!fixedFlag$sample101)
-					var139[i$var119] = reduceVar$var151$8;
+					var139[i$var119] = reduceVar$var151$5;
 			}
 		}
 	}
@@ -1141,13 +813,13 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					double[] var130 = var129[i$var119];
 					var130[j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
 				}
-				double reduceVar$var151$9 = 0.0;
+				double reduceVar$var151$6 = 0.0;
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-					double x = reduceVar$var151$9;
+					double x = reduceVar$var151$6;
 					double y = time_impact[t][i$var119][cv$reduction152Index];
-					reduceVar$var151$9 = (x + y);
+					reduceVar$var151$6 = (x + y);
 				}
-				var139[i$var119] = reduceVar$var151$9;
+				var139[i$var119] = reduceVar$var151$6;
 			}
 		}
 	}
@@ -1250,13 +922,13 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					double[] var130 = var129[i$var119];
 					var130[j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
 				}
-				double reduceVar$var151$11 = 0.0;
+				double reduceVar$var151$8 = 0.0;
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-					double x = reduceVar$var151$11;
+					double x = reduceVar$var151$8;
 					double y = time_impact[t][i$var119][cv$reduction152Index];
-					reduceVar$var151$11 = (x + y);
+					reduceVar$var151$8 = (x + y);
 				}
-				var139[i$var119] = reduceVar$var151$11;
+				var139[i$var119] = reduceVar$var151$8;
 			}
 		}
 	}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$SingleThreadCPU_modelSingle.java
@@ -13,8 +13,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 	private boolean fixedFlag$sample101 = false;
 	private boolean fixedProbFlag$sample101 = false;
 	private boolean fixedProbFlag$sample165 = false;
-	private boolean[][] guard$sample101poisson164$global;
-	private boolean[][] guard$sample101put160$global;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
 	private double logProbability$arr;
@@ -647,9 +645,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 						// 
 						// Looking for a path between Sample 101 and consumer double[][] 153.
 						{
-							// Guard to check that at most one copy of the code is executed for a given random
-							// variable instance.
-							boolean[][] guard$sample101put160 = guard$sample101put160$global;
 							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 								if((i$var80 == i$var119)) {
 									for(int j = 0; j < time_dim; j += 1) {
@@ -659,58 +654,10 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 													if((t == index$t$3_4)) {
 														for(int index$i$3_5 = 0; index$i$3_5 < n_ac; index$i$3_5 += 1) {
 															if((i$var119 == index$i$3_5)) {
-																{
-																	// Set the flags to false
-																	guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$4_4 = (0 + 1); index$t$4_4 < T; index$t$4_4 += 1) {
-													if((t == index$t$4_4)) {
-														for(int index$i$4_5 = 0; index$i$4_5 < n_ac; index$i$4_5 += 1) {
-															if((i$var119 == index$i$4_5)) {
 																if(((0 <= j) && (j < time_dim))) {
 																	{
-																		// Set the flags to false
-																		guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$5_4 = (0 + 1); index$t$5_4 < T; index$t$5_4 += 1) {
-													if((t == index$t$5_4)) {
-														for(int index$i$5_5 = 0; index$i$5_5 < n_ac; index$i$5_5 += 1) {
-															if((i$var119 == index$i$5_5)) {
-																{
-																	if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																		// The body will execute, so should not be executed again
-																		guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
 																		{
-																			double[] var139 = sum_t[index$t$5_4];
+																			double[] var139 = sum_t[index$t$3_4];
 																			
 																			// Reduction of array null
 																			// 
@@ -725,65 +672,14 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 																				double x = reduceVar$var151$0;
 																				
 																				// Set the right hand term to a value from the array var141
-																				double y = time_impact[index$t$5_4][index$i$5_5][cv$reduction152Index];
+																				double y = time_impact[index$t$3_4][index$i$3_5][cv$reduction152Index];
 																				
 																				// Execute the reduction function, saving the result into the return value.
 																				// 
 																				// Copy the result of the reduction into the variable returned by the reduction.
 																				reduceVar$var151$0 = (x + y);
 																			}
-																			var139[index$i$5_5] = reduceVar$var151$0;
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$6_4 = (0 + 1); index$t$6_4 < T; index$t$6_4 += 1) {
-													if((t == index$t$6_4)) {
-														for(int index$i$6_5 = 0; index$i$6_5 < n_ac; index$i$6_5 += 1) {
-															if((i$var119 == index$i$6_5)) {
-																if(((0 <= j) && (j < time_dim))) {
-																	{
-																		if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																			// The body will execute, so should not be executed again
-																			guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																			{
-																				double[] var139 = sum_t[index$t$6_4];
-																				
-																				// Reduction of array null
-																				// 
-																				// A generated name to prevent name collisions if the reduction is implemented more
-																				// than once in inference and probability code. Initialize the variable to the unit
-																				// value
-																				double reduceVar$var151$1 = 0.0;
-																				
-																				// For each index in the array to be reduced
-																				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																					// Set the left hand term of the reduction function to the return variable value.
-																					double x = reduceVar$var151$1;
-																					
-																					// Set the right hand term to a value from the array var141
-																					double y = time_impact[index$t$6_4][index$i$6_5][cv$reduction152Index];
-																					
-																					// Execute the reduction function, saving the result into the return value.
-																					// 
-																					// Copy the result of the reduction into the variable returned by the reduction.
-																					reduceVar$var151$1 = (x + y);
-																				}
-																				var139[index$i$6_5] = reduceVar$var151$1;
-																			}
+																			var139[index$i$3_5] = reduceVar$var151$0;
 																		}
 																	}
 																}
@@ -819,129 +715,64 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					{
 						// Looking for a path between Sample 101 and consumer Poisson 157.
 						{
-							// Guard to check that at most one copy of the code is executed for a given random
-							// variable instance.
-							boolean[][] guard$sample101poisson164 = guard$sample101poisson164$global;
+							double traceTempVariable$var134$4_1 = cv$currentValue;
 							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 								if((i$var80 == i$var119)) {
 									for(int j = 0; j < time_dim; j += 1) {
 										if((var95 == j)) {
 											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$7_4 = (0 + 1); index$t$7_4 < T; index$t$7_4 += 1) {
-													if((t == index$t$7_4)) {
-														for(int index$i$7_5 = 0; index$i$7_5 < n_ac; index$i$7_5 += 1) {
-															if((i$var119 == index$i$7_5)) {
-																{
-																	for(int index$t$7_6 = (0 + 1); index$t$7_6 < T; index$t$7_6 += 1) {
-																		if((index$t$7_4 == index$t$7_6)) {
-																			for(int index$i$7_7 = 0; index$i$7_7 < n_ac; index$i$7_7 += 1) {
-																				if((index$i$7_5 == index$i$7_7))
-																					// Set the flags to false
-																					guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$8_4 = (0 + 1); index$t$8_4 < T; index$t$8_4 += 1) {
-													if((t == index$t$8_4)) {
-														for(int index$i$8_5 = 0; index$i$8_5 < n_ac; index$i$8_5 += 1) {
-															if((i$var119 == index$i$8_5)) {
+												double traceTempVariable$x$4_5 = (TimeFeat[t][j] * traceTempVariable$var134$4_1);
+												for(int index$t$4_6 = (0 + 1); index$t$4_6 < T; index$t$4_6 += 1) {
+													if((t == index$t$4_6)) {
+														for(int index$i$4_7 = 0; index$i$4_7 < n_ac; index$i$4_7 += 1) {
+															if((i$var119 == index$i$4_7)) {
 																if(((0 <= j) && (j < time_dim))) {
 																	{
-																		for(int index$t$8_6 = (0 + 1); index$t$8_6 < T; index$t$8_6 += 1) {
-																			if((index$t$8_4 == index$t$8_6)) {
-																				for(int index$i$8_7 = 0; index$i$8_7 < n_ac; index$i$8_7 += 1) {
-																					if((index$i$8_5 == index$i$8_7))
-																						// Set the flags to false
-																						guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-																				}
+																		if((0 < time_dim)) {
+																			// Reduction of array null
+																			// 
+																			// A generated name to prevent name collisions if the reduction is implemented more
+																			// than once in inference and probability code. Initialize the variable to the unit
+																			// value
+																			double reduceVar$var151$1 = 0.0;
+																			
+																			// Reduce for every value except a masked value which will be skipped.
+																			for(int cv$reduction326Index = 0; cv$reduction326Index < j; cv$reduction326Index += 1) {
+																				// Set the left hand term of the reduction function to the return variable value.
+																				double x = reduceVar$var151$1;
+																				
+																				// Set the right hand term to a value from the array var141
+																				double y = time_impact[index$t$4_6][index$i$4_7][cv$reduction326Index];
+																				
+																				// Execute the reduction function, saving the result into the return value.
+																				// 
+																				// Copy the result of the reduction into the variable returned by the reduction.
+																				reduceVar$var151$1 = (x + y);
 																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							double traceTempVariable$var134$9_1 = cv$currentValue;
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												for(int index$t$9_5 = (0 + 1); index$t$9_5 < T; index$t$9_5 += 1) {
-													if((t == index$t$9_5)) {
-														for(int index$i$9_6 = 0; index$i$9_6 < n_ac; index$i$9_6 += 1) {
-															if((i$var119 == index$i$9_6)) {
-																{
-																	if((0 < time_dim)) {
-																		// Reduction of array null
-																		// 
-																		// A generated name to prevent name collisions if the reduction is implemented more
-																		// than once in inference and probability code. Initialize the variable to the unit
-																		// value
-																		double reduceVar$var151$2 = time_impact[index$t$9_5][index$i$9_6][0];
-																		
-																		// Reduce for every value except a masked value which will be skipped.
-																		for(int cv$reduction480Index = 0; cv$reduction480Index < 0; cv$reduction480Index += 1) {
-																			// Set the left hand term of the reduction function to the return variable value.
-																			double x = reduceVar$var151$2;
+																			for(int cv$reduction326Index = (j + 1); cv$reduction326Index < time_dim; cv$reduction326Index += 1) {
+																				// Set the left hand term of the reduction function to the return variable value.
+																				double x = reduceVar$var151$1;
+																				
+																				// Set the right hand term to a value from the array var141
+																				double y = time_impact[index$t$4_6][index$i$4_7][cv$reduction326Index];
+																				
+																				// Execute the reduction function, saving the result into the return value.
+																				// 
+																				// Execute the reduction function, saving the result into the return value.
+																				// 
+																				// Copy the result of the reduction into the variable returned by the reduction.
+																				reduceVar$var151$1 = (x + y);
+																			}
+																			double cv$reduced152 = reduceVar$var151$1;
 																			
-																			// Set the right hand term to a value from the array var141
-																			double y = time_impact[index$t$9_5][index$i$9_6][cv$reduction480Index];
-																			
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
 																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$2 = (x + y);
-																		}
-																		for(int cv$reduction480Index = (0 + 1); cv$reduction480Index < time_dim; cv$reduction480Index += 1) {
-																			// Set the left hand term of the reduction function to the return variable value.
-																			double x = reduceVar$var151$2;
-																			
-																			// Set the right hand term to a value from the array var141
-																			double y = time_impact[index$t$9_5][index$i$9_6][cv$reduction480Index];
-																			
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
-																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$2 = (x + y);
-																		}
-																		double cv$reduced152 = reduceVar$var151$2;
-																		
-																		// Copy the result of the reduction into the variable returned by the reduction.
-																		reduceVar$var151$2 = (0.0 + cv$reduced152);
-																		double traceTempVariable$var151$9_7 = reduceVar$var151$2;
-																		double traceTempVariable$var156$9_8 = traceTempVariable$var151$9_7;
-																		for(int index$t$9_9 = (0 + 1); index$t$9_9 < T; index$t$9_9 += 1) {
-																			if((index$t$9_5 == index$t$9_9)) {
-																				for(int index$i$9_10 = 0; index$i$9_10 < n_ac; index$i$9_10 += 1) {
-																					if((index$i$9_6 == index$i$9_10)) {
-																						if(!guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																							// The body will execute, so should not be executed again
-																							guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																							
+																			reduceVar$var151$1 = (traceTempVariable$x$4_5 + cv$reduced152);
+																			double traceTempVariable$var151$4_8 = reduceVar$var151$1;
+																			double traceTempVariable$var156$4_9 = traceTempVariable$var151$4_8;
+																			for(int index$t$4_10 = (0 + 1); index$t$4_10 < T; index$t$4_10 += 1) {
+																				if((index$t$4_6 == index$t$4_10)) {
+																					for(int index$i$4_11 = 0; index$i$4_11 < n_ac; index$i$4_11 += 1) {
+																						if((index$i$4_7 == index$i$4_11)) {
 																							// Processing sample task 165 of consumer random variable null.
 																							{
 																								// Set an accumulator to sum the probabilities for each possible configuration of
@@ -958,19 +789,19 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 																												double cv$temp$2$var156;
 																												{
 																													// Constructing a random variable input for use later.
-																													double var156 = traceTempVariable$var156$9_8;
+																													double var156 = traceTempVariable$var156$4_9;
 																													cv$temp$2$var156 = var156;
 																												}
 																												
 																												// Record the probability of sample task 165 generating output with current configuration.
-																												if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)) < cv$accumulatedConsumerProbabilities))
-																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
 																												else {
 																													// If the second value is -infinity.
 																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156));
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156));
 																													else
-																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$9_9][index$i$9_10], cv$temp$2$var156)));
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$4_10][index$i$4_11], cv$temp$2$var156)));
 																												}
 																												
 																												// Recorded the probability of reaching sample task 165 with the current configuration.
@@ -994,139 +825,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 																										cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
 																									else
 																										cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
-																								}
-																							}
-																						}
-																					}
-																				}
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							double traceTempVariable$var134$10_1 = cv$currentValue;
-							for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-								if((i$var80 == i$var119)) {
-									for(int j = 0; j < time_dim; j += 1) {
-										if((var95 == j)) {
-											for(int t = (0 + 1); t < T; t += 1) {
-												double traceTempVariable$x$10_5 = (TimeFeat[t][j] * traceTempVariable$var134$10_1);
-												for(int index$t$10_6 = (0 + 1); index$t$10_6 < T; index$t$10_6 += 1) {
-													if((t == index$t$10_6)) {
-														for(int index$i$10_7 = 0; index$i$10_7 < n_ac; index$i$10_7 += 1) {
-															if((i$var119 == index$i$10_7)) {
-																if(((0 <= j) && (j < time_dim))) {
-																	{
-																		if((0 < time_dim)) {
-																			// Reduction of array null
-																			// 
-																			// A generated name to prevent name collisions if the reduction is implemented more
-																			// than once in inference and probability code. Initialize the variable to the unit
-																			// value
-																			double reduceVar$var151$3 = 0.0;
-																			
-																			// Reduce for every value except a masked value which will be skipped.
-																			for(int cv$reduction526Index = 0; cv$reduction526Index < j; cv$reduction526Index += 1) {
-																				// Set the left hand term of the reduction function to the return variable value.
-																				double x = reduceVar$var151$3;
-																				
-																				// Set the right hand term to a value from the array var141
-																				double y = time_impact[index$t$10_6][index$i$10_7][cv$reduction526Index];
-																				
-																				// Execute the reduction function, saving the result into the return value.
-																				// 
-																				// Copy the result of the reduction into the variable returned by the reduction.
-																				reduceVar$var151$3 = (x + y);
-																			}
-																			for(int cv$reduction526Index = (j + 1); cv$reduction526Index < time_dim; cv$reduction526Index += 1) {
-																				// Set the left hand term of the reduction function to the return variable value.
-																				double x = reduceVar$var151$3;
-																				
-																				// Set the right hand term to a value from the array var141
-																				double y = time_impact[index$t$10_6][index$i$10_7][cv$reduction526Index];
-																				
-																				// Execute the reduction function, saving the result into the return value.
-																				// 
-																				// Execute the reduction function, saving the result into the return value.
-																				// 
-																				// Copy the result of the reduction into the variable returned by the reduction.
-																				reduceVar$var151$3 = (x + y);
-																			}
-																			double cv$reduced152 = reduceVar$var151$3;
-																			
-																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$3 = (traceTempVariable$x$10_5 + cv$reduced152);
-																			double traceTempVariable$var151$10_8 = reduceVar$var151$3;
-																			double traceTempVariable$var156$10_9 = traceTempVariable$var151$10_8;
-																			for(int index$t$10_10 = (0 + 1); index$t$10_10 < T; index$t$10_10 += 1) {
-																				if((index$t$10_6 == index$t$10_10)) {
-																					for(int index$i$10_11 = 0; index$i$10_11 < n_ac; index$i$10_11 += 1) {
-																						if((index$i$10_7 == index$i$10_11)) {
-																							if(!guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																								// The body will execute, so should not be executed again
-																								guard$sample101poisson164[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																								
-																								// Processing sample task 165 of consumer random variable null.
-																								{
-																									// Set an accumulator to sum the probabilities for each possible configuration of
-																									// inputs.
-																									double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
-																									
-																									// Set an accumulator to record the consumer distributions not seen. Initially set
-																									// to 1 as seen values will be deducted from this value.
-																									double cv$consumerDistributionProbabilityAccumulator = 1.0;
-																									{
-																										{
-																											{
-																												{
-																													double cv$temp$3$var156;
-																													{
-																														// Constructing a random variable input for use later.
-																														double var156 = traceTempVariable$var156$10_9;
-																														cv$temp$3$var156 = var156;
-																													}
-																													
-																													// Record the probability of sample task 165 generating output with current configuration.
-																													if(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)) < cv$accumulatedConsumerProbabilities))
-																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
-																													else {
-																														// If the second value is -infinity.
-																														if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																															cv$accumulatedConsumerProbabilities = (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156));
-																														else
-																															cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)))) + 1)) + (Math.log(1.0) + DistributionSampling.logProbabilityPoisson(arr[index$t$10_10][index$i$10_11], cv$temp$3$var156)));
-																													}
-																													
-																													// Recorded the probability of reaching sample task 165 with the current configuration.
-																													cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
-																												}
-																											}
-																										}
-																									}
-																									
-																									// A check to ensure rounding of floating point values can never result in a negative
-																									// value.
-																									cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
-																									
-																									// Multiply (log space add) in the probability of the sample task to the overall probability
-																									// for this configuration of the source random variable.
-																									if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
-																										cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
-																									else {
-																										// If the second value is -infinity.
-																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
-																											cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
-																										else
-																											cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
-																									}
 																								}
 																							}
 																						}
@@ -1215,143 +913,41 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// 
 				// Looking for a path between Sample 101 and consumer double[][] 153.
 				{
-					// Guard to check that at most one copy of the code is executed for a given random
-					// variable instance.
-					boolean[][] guard$sample101put160 = guard$sample101put160$global;
 					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 						if((i$var80 == i$var119)) {
 							for(int j = 0; j < time_dim; j += 1) {
 								if((var95 == j)) {
 									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$17_4 = (0 + 1); index$t$17_4 < T; index$t$17_4 += 1) {
-											if((t == index$t$17_4)) {
-												for(int index$i$17_5 = 0; index$i$17_5 < n_ac; index$i$17_5 += 1) {
-													if((i$var119 == index$i$17_5)) {
-														{
-															// Set the flags to false
-															guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$18_4 = (0 + 1); index$t$18_4 < T; index$t$18_4 += 1) {
-											if((t == index$t$18_4)) {
-												for(int index$i$18_5 = 0; index$i$18_5 < n_ac; index$i$18_5 += 1) {
-													if((i$var119 == index$i$18_5)) {
+										for(int index$t$9_4 = (0 + 1); index$t$9_4 < T; index$t$9_4 += 1) {
+											if((t == index$t$9_4)) {
+												for(int index$i$9_5 = 0; index$i$9_5 < n_ac; index$i$9_5 += 1) {
+													if((i$var119 == index$i$9_5)) {
 														if(((0 <= j) && (j < time_dim))) {
 															{
-																// Set the flags to false
-																guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = false;
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$19_4 = (0 + 1); index$t$19_4 < T; index$t$19_4 += 1) {
-											if((t == index$t$19_4)) {
-												for(int index$i$19_5 = 0; index$i$19_5 < n_ac; index$i$19_5 += 1) {
-													if((i$var119 == index$i$19_5)) {
-														{
-															if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																// The body will execute, so should not be executed again
-																guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
 																{
-																	double[] var139 = sum_t[index$t$19_4];
+																	double[] var139 = sum_t[index$t$9_4];
 																	
 																	// Reduction of array null
 																	// 
 																	// A generated name to prevent name collisions if the reduction is implemented more
 																	// than once in inference and probability code. Initialize the variable to the unit
 																	// value
-																	double reduceVar$var151$4 = 0.0;
+																	double reduceVar$var151$2 = 0.0;
 																	
 																	// For each index in the array to be reduced
 																	for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 																		// Set the left hand term of the reduction function to the return variable value.
-																		double x = reduceVar$var151$4;
+																		double x = reduceVar$var151$2;
 																		
 																		// Set the right hand term to a value from the array var141
-																		double y = time_impact[index$t$19_4][index$i$19_5][cv$reduction152Index];
+																		double y = time_impact[index$t$9_4][index$i$9_5][cv$reduction152Index];
 																		
 																		// Execute the reduction function, saving the result into the return value.
 																		// 
 																		// Copy the result of the reduction into the variable returned by the reduction.
-																		reduceVar$var151$4 = (x + y);
+																		reduceVar$var151$2 = (x + y);
 																	}
-																	var139[index$i$19_5] = reduceVar$var151$4;
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
-						if((i$var80 == i$var119)) {
-							for(int j = 0; j < time_dim; j += 1) {
-								if((var95 == j)) {
-									for(int t = (0 + 1); t < T; t += 1) {
-										for(int index$t$20_4 = (0 + 1); index$t$20_4 < T; index$t$20_4 += 1) {
-											if((t == index$t$20_4)) {
-												for(int index$i$20_5 = 0; index$i$20_5 < n_ac; index$i$20_5 += 1) {
-													if((i$var119 == index$i$20_5)) {
-														if(((0 <= j) && (j < time_dim))) {
-															{
-																if(!guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)]) {
-																	// The body will execute, so should not be executed again
-																	guard$sample101put160[((t - (0 + 1)) / 1)][((i$var119 - 0) / 1)] = true;
-																	{
-																		double[] var139 = sum_t[index$t$20_4];
-																		
-																		// Reduction of array null
-																		// 
-																		// A generated name to prevent name collisions if the reduction is implemented more
-																		// than once in inference and probability code. Initialize the variable to the unit
-																		// value
-																		double reduceVar$var151$5 = 0.0;
-																		
-																		// For each index in the array to be reduced
-																		for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
-																			// Set the left hand term of the reduction function to the return variable value.
-																			double x = reduceVar$var151$5;
-																			
-																			// Set the right hand term to a value from the array var141
-																			double y = time_impact[index$t$20_4][index$i$20_5][cv$reduction152Index];
-																			
-																			// Execute the reduction function, saving the result into the return value.
-																			// 
-																			// Copy the result of the reduction into the variable returned by the reduction.
-																			reduceVar$var151$5 = (x + y);
-																		}
-																		var139[index$i$20_5] = reduceVar$var151$5;
-																	}
+																	var139[index$i$9_5] = reduceVar$var151$2;
 																}
 															}
 														}
@@ -1373,42 +969,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 	// here prevents repeated allocation and deallocation, and makes the code more amenable
 	// to GPU execution.
 	@Override
-	public final void allocateScratch() {
-		// Allocate scratch space.
-		// Constructor for guard$sample101put160$global
-		{
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_t = 0;
-			
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_i$var119 = 0;
-			for(int t = (0 + 1); t < T; t += 1)
-				cv$max_i$var119 = Math.max(cv$max_i$var119, ((n_ac - 0) / 1));
-			cv$max_t = Math.max(cv$max_t, ((T - (0 + 1)) / 1));
-			
-			// Allocation of guard$sample101put160$global for single threaded execution
-			guard$sample101put160$global = new boolean[cv$max_t][cv$max_i$var119];
-		}
-		
-		// Constructor for guard$sample101poisson164$global
-		{
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_t = 0;
-			
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_i$var119 = 0;
-			for(int t = (0 + 1); t < T; t += 1)
-				cv$max_i$var119 = Math.max(cv$max_i$var119, ((n_ac - 0) / 1));
-			cv$max_t = Math.max(cv$max_t, ((T - (0 + 1)) / 1));
-			
-			// Allocation of guard$sample101poisson164$global for single threaded execution
-			guard$sample101poisson164$global = new boolean[cv$max_t][cv$max_i$var119];
-		}
-	}
+	public final void allocateScratch() {}
 
 	// Method to allocate space for model inputs and outputs.
 	@Override
@@ -1456,9 +1017,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 			for(int i$var80 = 0; i$var80 < n_ac; i$var80 += 1)
 				logProbability$sample101[((i$var80 - 0) / 1)] = new double[((((TimeFeat[0].length - 1) - 0) / 1) + 1)];
 		}
-		
-		// Allocate scratch space
-		allocateScratch();
 	}
 
 	// Method to execute the model code conventionally.
@@ -1487,12 +1045,12 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$6 = 0.0;
+				double reduceVar$var151$3 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 					// Set the left hand term of the reduction function to the return variable value.
-					double x = reduceVar$var151$6;
+					double x = reduceVar$var151$3;
 					
 					// Set the right hand term to a value from the array var141
 					double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1500,10 +1058,10 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// Execute the reduction function, saving the result into the return value.
 					if(!fixedFlag$sample101)
 						// Copy the result of the reduction into the variable returned by the reduction.
-						reduceVar$var151$6 = (x + y);
+						reduceVar$var151$3 = (x + y);
 				}
 				if(!fixedFlag$sample101)
-					var139[i$var119] = reduceVar$var151$6;
+					var139[i$var119] = reduceVar$var151$3;
 				var154[i$var119] = DistributionSampling.samplePoisson(RNG$, sum_t[t][i$var119]);
 			}
 		}
@@ -1535,12 +1093,12 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$10 = 0.0;
+				double reduceVar$var151$7 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 					// Set the left hand term of the reduction function to the return variable value.
-					double x = reduceVar$var151$10;
+					double x = reduceVar$var151$7;
 					
 					// Set the right hand term to a value from the array var141
 					double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1548,9 +1106,9 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Copy the result of the reduction into the variable returned by the reduction.
-					reduceVar$var151$10 = (x + y);
+					reduceVar$var151$7 = (x + y);
 				}
-				var139[i$var119] = reduceVar$var151$10;
+				var139[i$var119] = reduceVar$var151$7;
 			}
 		}
 	}
@@ -1581,12 +1139,12 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$7 = 0.0;
+				double reduceVar$var151$4 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 					// Set the left hand term of the reduction function to the return variable value.
-					double x = reduceVar$var151$7;
+					double x = reduceVar$var151$4;
 					
 					// Set the right hand term to a value from the array var141
 					double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1594,9 +1152,9 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Copy the result of the reduction into the variable returned by the reduction.
-					reduceVar$var151$7 = (x + y);
+					reduceVar$var151$4 = (x + y);
 				}
-				var139[i$var119] = reduceVar$var151$7;
+				var139[i$var119] = reduceVar$var151$4;
 				var154[i$var119] = DistributionSampling.samplePoisson(RNG$, sum_t[t][i$var119]);
 			}
 		}
@@ -1628,12 +1186,12 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$8 = 0.0;
+				double reduceVar$var151$5 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 					// Set the left hand term of the reduction function to the return variable value.
-					double x = reduceVar$var151$8;
+					double x = reduceVar$var151$5;
 					
 					// Set the right hand term to a value from the array var141
 					double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1641,10 +1199,10 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// Execute the reduction function, saving the result into the return value.
 					if(!fixedFlag$sample101)
 						// Copy the result of the reduction into the variable returned by the reduction.
-						reduceVar$var151$8 = (x + y);
+						reduceVar$var151$5 = (x + y);
 				}
 				if(!fixedFlag$sample101)
-					var139[i$var119] = reduceVar$var151$8;
+					var139[i$var119] = reduceVar$var151$5;
 			}
 		}
 	}
@@ -1675,12 +1233,12 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$9 = 0.0;
+				double reduceVar$var151$6 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 					// Set the left hand term of the reduction function to the return variable value.
-					double x = reduceVar$var151$9;
+					double x = reduceVar$var151$6;
 					
 					// Set the right hand term to a value from the array var141
 					double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1688,9 +1246,9 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Copy the result of the reduction into the variable returned by the reduction.
-					reduceVar$var151$9 = (x + y);
+					reduceVar$var151$6 = (x + y);
 				}
-				var139[i$var119] = reduceVar$var151$9;
+				var139[i$var119] = reduceVar$var151$6;
 			}
 		}
 	}
@@ -1839,12 +1397,12 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$11 = 0.0;
+				double reduceVar$var151$8 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1) {
 					// Set the left hand term of the reduction function to the return variable value.
-					double x = reduceVar$var151$11;
+					double x = reduceVar$var151$8;
 					
 					// Set the right hand term to a value from the array var141
 					double y = time_impact[t][i$var119][cv$reduction152Index];
@@ -1852,9 +1410,9 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Copy the result of the reduction into the variable returned by the reduction.
-					reduceVar$var151$11 = (x + y);
+					reduceVar$var151$8 = (x + y);
 				}
-				var139[i$var119] = reduceVar$var151$11;
+				var139[i$var119] = reduceVar$var151$8;
 			}
 		}
 	}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$SingleThreadCPU_optimisedModel.java
@@ -13,8 +13,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 	private boolean fixedFlag$sample101 = false;
 	private boolean fixedProbFlag$sample101 = false;
 	private boolean fixedProbFlag$sample165 = false;
-	private boolean[][] guard$sample101poisson164$global;
-	private boolean[][] guard$sample101put160$global;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
 	private double logProbability$arr;
@@ -421,85 +419,18 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 			// 
 			// Set the current value to the current state of the tree.
 			double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$originalValue);
-			for(int t = 1; t < T; t += 1)
-				// Set the flags to false
-				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				guard$sample101poisson164$global[(t - 1)][i$var80] = false;
 			for(int t = 1; t < T; t += 1) {
 				// Reduction of array null
 				// 
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				// 
-				// Substituted "index$t$9_5" with its value "t".
-				// 
-				// Substituted "index$i$9_6" with its value "i$var80".
-				double reduceVar$var151$2 = time_impact[t][i$var80][0];
-				for(int cv$reduction480Index = 1; cv$reduction480Index < time_dim; cv$reduction480Index += 1)
-					// Execute the reduction function, saving the result into the return value.
-					// 
-					// Execute the reduction function, saving the result into the return value.
-					// 
-					// Copy the result of the reduction into the variable returned by the reduction.
-					// 
-					// x's comment
-					// Set the left hand term of the reduction function to the return variable value.
-					// 
-					// y's comment
-					// Set the right hand term to a value from the array var141
-					// 
-					// Substituted "index$t$9_5" with its value "t".
-					// 
-					// Substituted "index$i$9_6" with its value "i$var80".
-					reduceVar$var151$2 = (reduceVar$var151$2 + time_impact[t][i$var80][cv$reduction480Index]);
-				if(!guard$sample101poisson164$global[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
-					// 
-					// Guard to check that at most one copy of the code is executed for a given random
-					// variable instance.
-					guard$sample101poisson164$global[(t - 1)][i$var80] = true;
-					
-					// A check to ensure rounding of floating point values can never result in a negative
-					// value.
-					// 
-					// Recorded the probability of reaching sample task 165 with the current configuration.
-					// 
-					// Set an accumulator to record the consumer distributions not seen. Initially set
-					// to 1 as seen values will be deducted from this value.
-					// 
-					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-					// Declaration comment was:
-					// Processing sample task 165 of consumer random variable null.
-					// 
-					// Set an accumulator to sum the probabilities for each possible configuration of
-					// inputs.
-					// 
-					// Substituted "index$i$9_10" with its value "index$i$9_6".
-					// 
-					// Substituted "index$t$9_9" with its value "t".
-					// 
-					// cv$temp$2$var156's comment
-					// Variable declaration of cv$temp$2$var156 moved.
-					// 
-					// Constructing a random variable input for use later.
-					cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$2) + cv$accumulatedProbabilities);
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				// Reduction of array null
-				// 
-				// A generated name to prevent name collisions if the reduction is implemented more
-				// than once in inference and probability code. Initialize the variable to the unit
-				// value
-				double reduceVar$var151$3 = 0.0;
+				double reduceVar$var151$1 = 0.0;
 				
 				// Reduce for every value except a masked value which will be skipped.
 				// 
 				// Substituted "j" with its value "var95".
-				for(int cv$reduction526Index = 0; cv$reduction526Index < var95; cv$reduction526Index += 1)
+				for(int cv$reduction326Index = 0; cv$reduction326Index < var95; cv$reduction326Index += 1)
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Copy the result of the reduction into the variable returned by the reduction.
@@ -510,13 +441,13 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// y's comment
 					// Set the right hand term to a value from the array var141
 					// 
-					// Substituted "index$t$10_6" with its value "t".
+					// Substituted "index$t$4_6" with its value "t".
 					// 
-					// Substituted "index$i$10_7" with its value "i$var80".
-					reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var80][cv$reduction526Index]);
+					// Substituted "index$i$4_7" with its value "i$var80".
+					reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction326Index]);
 				
 				// Substituted "j" with its value "var95".
-				for(int cv$reduction526Index = (var95 + 1); cv$reduction526Index < time_dim; cv$reduction526Index += 1)
+				for(int cv$reduction326Index = (var95 + 1); cv$reduction326Index < time_dim; cv$reduction326Index += 1)
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Execute the reduction function, saving the result into the return value.
@@ -529,42 +460,42 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// y's comment
 					// Set the right hand term to a value from the array var141
 					// 
-					// Substituted "index$t$10_6" with its value "t".
+					// Substituted "index$t$4_6" with its value "t".
 					// 
-					// Substituted "index$i$10_7" with its value "i$var80".
-					reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var80][cv$reduction526Index]);
+					// Substituted "index$i$4_7" with its value "i$var80".
+					reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction326Index]);
 				
 				// Copy the result of the reduction into the variable returned by the reduction.
 				// 
 				// Substituted "j" with its value "var95".
 				// 
 				// Set the current value to the current state of the tree.
-				reduceVar$var151$3 = ((TimeFeat[t][var95] * cv$originalValue) + reduceVar$var151$3);
-				if(!guard$sample101poisson164$global[(t - 1)][i$var80])
-					// A check to ensure rounding of floating point values can never result in a negative
-					// value.
-					// 
-					// Recorded the probability of reaching sample task 165 with the current configuration.
-					// 
-					// Set an accumulator to record the consumer distributions not seen. Initially set
-					// to 1 as seen values will be deducted from this value.
-					// 
-					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-					// Declaration comment was:
-					// Processing sample task 165 of consumer random variable null.
-					// 
-					// Set an accumulator to sum the probabilities for each possible configuration of
-					// inputs.
-					// 
-					// Substituted "index$i$10_11" with its value "index$i$10_7".
-					// 
-					// Substituted "index$t$10_10" with its value "t".
-					// 
-					// cv$temp$3$var156's comment
-					// Variable declaration of cv$temp$3$var156 moved.
-					// 
-					// Constructing a random variable input for use later.
-					cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$3) + cv$accumulatedProbabilities);
+				reduceVar$var151$1 = ((TimeFeat[t][var95] * cv$originalValue) + reduceVar$var151$1);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 165 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Processing sample task 165 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "index$i$4_11" with its value "index$i$4_7".
+				// 
+				// Substituted "index$t$4_10" with its value "t".
+				// 
+				// cv$temp$2$var156's comment
+				// Variable declaration of cv$temp$2$var156 moved.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$1) + cv$accumulatedProbabilities);
 			}
 			
 			// Initialize a log space accumulator to take the product of all the distribution
@@ -585,85 +516,33 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 			// 
 			// Substituted "i$var119" with its value "i$var80".
 			time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
-		for(int t = 1; t < T; t += 1)
-			// Set the flags to false
+		for(int t = 1; t < T; t += 1) {
+			// Reduction of array null
 			// 
-			// Guard to check that at most one copy of the code is executed for a given random
-			// variable instance.
-			guard$sample101put160$global[(t - 1)][i$var80] = false;
-		for(int t = 1; t < T; t += 1) {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!guard$sample101put160$global[(t - 1)][i$var80]) {
-				// The body will execute, so should not be executed again
+			// A generated name to prevent name collisions if the reduction is implemented more
+			// than once in inference and probability code. Initialize the variable to the unit
+			// value
+			double reduceVar$var151$0 = 0.0;
+			
+			// For each index in the array to be reduced
+			for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
+				// Execute the reduction function, saving the result into the return value.
 				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				guard$sample101put160$global[(t - 1)][i$var80] = true;
-				
-				// Reduction of array null
+				// Copy the result of the reduction into the variable returned by the reduction.
 				// 
-				// A generated name to prevent name collisions if the reduction is implemented more
-				// than once in inference and probability code. Initialize the variable to the unit
-				// value
-				double reduceVar$var151$0 = 0.0;
-				
-				// For each index in the array to be reduced
-				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-					// Execute the reduction function, saving the result into the return value.
-					// 
-					// Copy the result of the reduction into the variable returned by the reduction.
-					// 
-					// x's comment
-					// Set the left hand term of the reduction function to the return variable value.
-					// 
-					// y's comment
-					// Set the right hand term to a value from the array var141
-					// 
-					// Substituted "index$t$5_4" with its value "t".
-					// 
-					// Substituted "index$i$5_5" with its value "i$var80".
-					reduceVar$var151$0 = (reduceVar$var151$0 + time_impact[t][i$var80][cv$reduction152Index]);
-				
-				// Substituted "index$t$5_4" with its value "t".
-				sum_t[t][i$var80] = reduceVar$var151$0;
-			}
-		}
-		for(int t = 1; t < T; t += 1) {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!guard$sample101put160$global[(t - 1)][i$var80]) {
-				// The body will execute, so should not be executed again
+				// x's comment
+				// Set the left hand term of the reduction function to the return variable value.
 				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				guard$sample101put160$global[(t - 1)][i$var80] = true;
-				
-				// Reduction of array null
+				// y's comment
+				// Set the right hand term to a value from the array var141
 				// 
-				// A generated name to prevent name collisions if the reduction is implemented more
-				// than once in inference and probability code. Initialize the variable to the unit
-				// value
-				double reduceVar$var151$1 = 0.0;
-				
-				// For each index in the array to be reduced
-				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-					// Execute the reduction function, saving the result into the return value.
-					// 
-					// Copy the result of the reduction into the variable returned by the reduction.
-					// 
-					// x's comment
-					// Set the left hand term of the reduction function to the return variable value.
-					// 
-					// y's comment
-					// Set the right hand term to a value from the array var141
-					// 
-					// Substituted "index$t$6_4" with its value "t".
-					// 
-					// Substituted "index$i$6_5" with its value "i$var80".
-					reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction152Index]);
-				
-				// Substituted "index$t$6_4" with its value "t".
-				sum_t[t][i$var80] = reduceVar$var151$1;
-			}
+				// Substituted "index$t$3_4" with its value "t".
+				// 
+				// Substituted "index$i$3_5" with its value "i$var80".
+				reduceVar$var151$0 = (reduceVar$var151$0 + time_impact[t][i$var80][cv$reduction152Index]);
+			
+			// Substituted "index$t$3_4" with its value "t".
+			sum_t[t][i$var80] = reduceVar$var151$0;
 		}
 		
 		// An accumulator to allow the value for each distribution to be constructed before
@@ -671,85 +550,18 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 		// 
 		// Substituted "cv$temp$1$var84" with its value "1.0".
 		double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$proposedValue);
-		for(int t = 1; t < T; t += 1)
-			// Set the flags to false
-			// 
-			// Guard to check that at most one copy of the code is executed for a given random
-			// variable instance.
-			guard$sample101poisson164$global[(t - 1)][i$var80] = false;
 		for(int t = 1; t < T; t += 1) {
 			// Reduction of array null
 			// 
 			// A generated name to prevent name collisions if the reduction is implemented more
 			// than once in inference and probability code. Initialize the variable to the unit
 			// value
-			// 
-			// Substituted "index$t$9_5" with its value "t".
-			// 
-			// Substituted "index$i$9_6" with its value "i$var80".
-			double reduceVar$var151$2 = time_impact[t][i$var80][0];
-			for(int cv$reduction480Index = 1; cv$reduction480Index < time_dim; cv$reduction480Index += 1)
-				// Execute the reduction function, saving the result into the return value.
-				// 
-				// Execute the reduction function, saving the result into the return value.
-				// 
-				// Copy the result of the reduction into the variable returned by the reduction.
-				// 
-				// x's comment
-				// Set the left hand term of the reduction function to the return variable value.
-				// 
-				// y's comment
-				// Set the right hand term to a value from the array var141
-				// 
-				// Substituted "index$t$9_5" with its value "t".
-				// 
-				// Substituted "index$i$9_6" with its value "i$var80".
-				reduceVar$var151$2 = (reduceVar$var151$2 + time_impact[t][i$var80][cv$reduction480Index]);
-			if(!guard$sample101poisson164$global[(t - 1)][i$var80]) {
-				// The body will execute, so should not be executed again
-				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				guard$sample101poisson164$global[(t - 1)][i$var80] = true;
-				
-				// A check to ensure rounding of floating point values can never result in a negative
-				// value.
-				// 
-				// Recorded the probability of reaching sample task 165 with the current configuration.
-				// 
-				// Set an accumulator to record the consumer distributions not seen. Initially set
-				// to 1 as seen values will be deducted from this value.
-				// 
-				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-				// Declaration comment was:
-				// Processing sample task 165 of consumer random variable null.
-				// 
-				// Set an accumulator to sum the probabilities for each possible configuration of
-				// inputs.
-				// 
-				// Substituted "index$i$9_10" with its value "index$i$9_6".
-				// 
-				// Substituted "index$t$9_9" with its value "t".
-				// 
-				// cv$temp$2$var156's comment
-				// Variable declaration of cv$temp$2$var156 moved.
-				// 
-				// Constructing a random variable input for use later.
-				cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$2) + cv$accumulatedProbabilities);
-			}
-		}
-		for(int t = 1; t < T; t += 1) {
-			// Reduction of array null
-			// 
-			// A generated name to prevent name collisions if the reduction is implemented more
-			// than once in inference and probability code. Initialize the variable to the unit
-			// value
-			double reduceVar$var151$3 = 0.0;
+			double reduceVar$var151$1 = 0.0;
 			
 			// Reduce for every value except a masked value which will be skipped.
 			// 
 			// Substituted "j" with its value "var95".
-			for(int cv$reduction526Index = 0; cv$reduction526Index < var95; cv$reduction526Index += 1)
+			for(int cv$reduction326Index = 0; cv$reduction326Index < var95; cv$reduction326Index += 1)
 				// Execute the reduction function, saving the result into the return value.
 				// 
 				// Copy the result of the reduction into the variable returned by the reduction.
@@ -760,13 +572,13 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// y's comment
 				// Set the right hand term to a value from the array var141
 				// 
-				// Substituted "index$t$10_6" with its value "t".
+				// Substituted "index$t$4_6" with its value "t".
 				// 
-				// Substituted "index$i$10_7" with its value "i$var80".
-				reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var80][cv$reduction526Index]);
+				// Substituted "index$i$4_7" with its value "i$var80".
+				reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction326Index]);
 			
 			// Substituted "j" with its value "var95".
-			for(int cv$reduction526Index = (var95 + 1); cv$reduction526Index < time_dim; cv$reduction526Index += 1)
+			for(int cv$reduction326Index = (var95 + 1); cv$reduction326Index < time_dim; cv$reduction326Index += 1)
 				// Execute the reduction function, saving the result into the return value.
 				// 
 				// Execute the reduction function, saving the result into the return value.
@@ -779,47 +591,40 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// y's comment
 				// Set the right hand term to a value from the array var141
 				// 
-				// Substituted "index$t$10_6" with its value "t".
+				// Substituted "index$t$4_6" with its value "t".
 				// 
-				// Substituted "index$i$10_7" with its value "i$var80".
-				reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var80][cv$reduction526Index]);
+				// Substituted "index$i$4_7" with its value "i$var80".
+				reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction326Index]);
 			
 			// Copy the result of the reduction into the variable returned by the reduction.
 			// 
 			// Substituted "j" with its value "var95".
-			reduceVar$var151$3 = ((TimeFeat[t][var95] * cv$proposedValue) + reduceVar$var151$3);
-			if(!guard$sample101poisson164$global[(t - 1)][i$var80]) {
-				// The body will execute, so should not be executed again
-				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				guard$sample101poisson164$global[(t - 1)][i$var80] = true;
-				
-				// A check to ensure rounding of floating point values can never result in a negative
-				// value.
-				// 
-				// Recorded the probability of reaching sample task 165 with the current configuration.
-				// 
-				// Set an accumulator to record the consumer distributions not seen. Initially set
-				// to 1 as seen values will be deducted from this value.
-				// 
-				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-				// Declaration comment was:
-				// Processing sample task 165 of consumer random variable null.
-				// 
-				// Set an accumulator to sum the probabilities for each possible configuration of
-				// inputs.
-				// 
-				// Substituted "index$i$10_11" with its value "index$i$10_7".
-				// 
-				// Substituted "index$t$10_10" with its value "t".
-				// 
-				// cv$temp$3$var156's comment
-				// Variable declaration of cv$temp$3$var156 moved.
-				// 
-				// Constructing a random variable input for use later.
-				cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$3) + cv$accumulatedProbabilities);
-			}
+			reduceVar$var151$1 = ((TimeFeat[t][var95] * cv$proposedValue) + reduceVar$var151$1);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 165 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Processing sample task 165 of consumer random variable null.
+			// 
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Substituted "index$i$4_11" with its value "index$i$4_7".
+			// 
+			// Substituted "index$t$4_10" with its value "t".
+			// 
+			// cv$temp$2$var156's comment
+			// Variable declaration of cv$temp$2$var156 moved.
+			// 
+			// Constructing a random variable input for use later.
+			cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$1) + cv$accumulatedProbabilities);
 		}
 		
 		// Test if the probability of the sample is sufficient to keep the value. This needs
@@ -850,85 +655,33 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// 
 				// Substituted "i$var119" with its value "i$var80".
 				time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
-			for(int t = 1; t < T; t += 1)
-				// Set the flags to false
+			for(int t = 1; t < T; t += 1) {
+				// Reduction of array null
 				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				guard$sample101put160$global[(t - 1)][i$var80] = false;
-			for(int t = 1; t < T; t += 1) {
-				// Constraints moved from conditionals in inner loops/scopes/etc.
-				if(!guard$sample101put160$global[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
+				// A generated name to prevent name collisions if the reduction is implemented more
+				// than once in inference and probability code. Initialize the variable to the unit
+				// value
+				double reduceVar$var151$2 = 0.0;
+				
+				// For each index in the array to be reduced
+				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
+					// Execute the reduction function, saving the result into the return value.
 					// 
-					// Guard to check that at most one copy of the code is executed for a given random
-					// variable instance.
-					guard$sample101put160$global[(t - 1)][i$var80] = true;
-					
-					// Reduction of array null
+					// Copy the result of the reduction into the variable returned by the reduction.
 					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$4 = 0.0;
-					
-					// For each index in the array to be reduced
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$19_4" with its value "t".
-						// 
-						// Substituted "index$i$19_5" with its value "i$var80".
-						reduceVar$var151$4 = (reduceVar$var151$4 + time_impact[t][i$var80][cv$reduction152Index]);
-					
-					// Substituted "index$t$19_4" with its value "t".
-					sum_t[t][i$var80] = reduceVar$var151$4;
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				// Constraints moved from conditionals in inner loops/scopes/etc.
-				if(!guard$sample101put160$global[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
+					// x's comment
+					// Set the left hand term of the reduction function to the return variable value.
 					// 
-					// Guard to check that at most one copy of the code is executed for a given random
-					// variable instance.
-					guard$sample101put160$global[(t - 1)][i$var80] = true;
-					
-					// Reduction of array null
+					// y's comment
+					// Set the right hand term to a value from the array var141
 					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$5 = 0.0;
-					
-					// For each index in the array to be reduced
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$20_4" with its value "t".
-						// 
-						// Substituted "index$i$20_5" with its value "i$var80".
-						reduceVar$var151$5 = (reduceVar$var151$5 + time_impact[t][i$var80][cv$reduction152Index]);
-					
-					// Substituted "index$t$20_4" with its value "t".
-					sum_t[t][i$var80] = reduceVar$var151$5;
-				}
+					// Substituted "index$t$9_4" with its value "t".
+					// 
+					// Substituted "index$i$9_5" with its value "i$var80".
+					reduceVar$var151$2 = (reduceVar$var151$2 + time_impact[t][i$var80][cv$reduction152Index]);
+				
+				// Substituted "index$t$9_4" with its value "t".
+				sum_t[t][i$var80] = reduceVar$var151$2;
 			}
 		}
 	}
@@ -937,39 +690,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 	// here prevents repeated allocation and deallocation, and makes the code more amenable
 	// to GPU execution.
 	@Override
-	public final void allocateScratch() {
-		// Allocate scratch space.
-		// Constructor for guard$sample101put160$global
-		{
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_i$var119 = 0;
-			if((1 < T))
-				// Calculate the largest index of i that is possible and allocate an array to hold
-				// the guard for each of these.
-				cv$max_i$var119 = Math.max(0, n_ac);
-			
-			// Allocation of guard$sample101put160$global for single threaded execution
-			// 
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			guard$sample101put160$global = new boolean[Math.max(0, (T - 1))][cv$max_i$var119];
-		}
-		
-		// Calculate the largest index of i that is possible and allocate an array to hold
-		// the guard for each of these.
-		int cv$max_i$var119 = 0;
-		if((1 < T))
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			cv$max_i$var119 = Math.max(0, n_ac);
-		
-		// Allocation of guard$sample101poisson164$global for single threaded execution
-		// 
-		// Calculate the largest index of t that is possible and allocate an array to hold
-		// the guard for each of these.
-		guard$sample101poisson164$global = new boolean[Math.max(0, (T - 1))][cv$max_i$var119];
-	}
+	public final void allocateScratch() {}
 
 	// Method to allocate space for model inputs and outputs.
 	@Override
@@ -1020,9 +741,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 		logProbability$sample165 = new double[(T - 1)][];
 		for(int t = 1; t < T; t += 1)
 			logProbability$sample165[(t - 1)] = new double[n_ac];
-		
-		// Allocate scratch space
-		allocateScratch();
 	}
 
 	// Method to execute the model code conventionally.
@@ -1051,7 +769,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// A generated name to prevent name collisions if the reduction is implemented more
 					// than once in inference and probability code. Initialize the variable to the unit
 					// value
-					double reduceVar$var151$6 = 0.0;
+					double reduceVar$var151$3 = 0.0;
 					
 					// For each index in the array to be reduced
 					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1059,8 +777,8 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 						// 
 						// y's comment
 						// Set the right hand term to a value from the array var141
-						reduceVar$var151$6 = (reduceVar$var151$6 + time_impact[t][i$var119][cv$reduction152Index]);
-					var139[i$var119] = reduceVar$var151$6;
+						reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var119][cv$reduction152Index]);
+					var139[i$var119] = reduceVar$var151$3;
 				}
 				var154[i$var119] = DistributionSampling.samplePoisson(RNG$, sum_t[t][i$var119]);
 			}
@@ -1092,7 +810,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$10 = 0.0;
+				double reduceVar$var151$7 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1102,8 +820,8 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// 
 					// y's comment
 					// Set the right hand term to a value from the array var141
-					reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var119][cv$reduction152Index]);
-				var139[i$var119] = reduceVar$var151$10;
+					reduceVar$var151$7 = (reduceVar$var151$7 + time_impact[t][i$var119][cv$reduction152Index]);
+				var139[i$var119] = reduceVar$var151$7;
 			}
 		}
 	}
@@ -1133,7 +851,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$7 = 0.0;
+				double reduceVar$var151$4 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1143,8 +861,8 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// 
 					// y's comment
 					// Set the right hand term to a value from the array var141
-					reduceVar$var151$7 = (reduceVar$var151$7 + time_impact[t][i$var119][cv$reduction152Index]);
-				var139[i$var119] = reduceVar$var151$7;
+					reduceVar$var151$4 = (reduceVar$var151$4 + time_impact[t][i$var119][cv$reduction152Index]);
+				var139[i$var119] = reduceVar$var151$4;
 				var154[i$var119] = DistributionSampling.samplePoisson(RNG$, sum_t[t][i$var119]);
 			}
 		}
@@ -1173,7 +891,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// A generated name to prevent name collisions if the reduction is implemented more
 					// than once in inference and probability code. Initialize the variable to the unit
 					// value
-					double reduceVar$var151$8 = 0.0;
+					double reduceVar$var151$5 = 0.0;
 					
 					// For each index in the array to be reduced
 					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1181,8 +899,8 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 						// 
 						// y's comment
 						// Set the right hand term to a value from the array var141
-						reduceVar$var151$8 = (reduceVar$var151$8 + time_impact[t][i$var119][cv$reduction152Index]);
-					var139[i$var119] = reduceVar$var151$8;
+						reduceVar$var151$5 = (reduceVar$var151$5 + time_impact[t][i$var119][cv$reduction152Index]);
+					var139[i$var119] = reduceVar$var151$5;
 				}
 			}
 		}
@@ -1213,7 +931,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$9 = 0.0;
+				double reduceVar$var151$6 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1223,8 +941,8 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// 
 					// y's comment
 					// Set the right hand term to a value from the array var141
-					reduceVar$var151$9 = (reduceVar$var151$9 + time_impact[t][i$var119][cv$reduction152Index]);
-				var139[i$var119] = reduceVar$var151$9;
+					reduceVar$var151$6 = (reduceVar$var151$6 + time_impact[t][i$var119][cv$reduction152Index]);
+				var139[i$var119] = reduceVar$var151$6;
 			}
 		}
 	}
@@ -1378,7 +1096,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$11 = 0.0;
+				double reduceVar$var151$8 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1388,8 +1106,8 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// 
 					// y's comment
 					// Set the right hand term to a value from the array var141
-					reduceVar$var151$11 = (reduceVar$var151$11 + time_impact[t][i$var119][cv$reduction152Index]);
-				var139[i$var119] = reduceVar$var151$11;
+					reduceVar$var151$8 = (reduceVar$var151$8 + time_impact[t][i$var119][cv$reduction152Index]);
+				var139[i$var119] = reduceVar$var151$8;
 			}
 		}
 	}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$SingleThreadCPU_optimisedModelNoComments.java
@@ -11,8 +11,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 	private boolean fixedFlag$sample101 = false;
 	private boolean fixedProbFlag$sample101 = false;
 	private boolean fixedProbFlag$sample165 = false;
-	private boolean[][] guard$sample101poisson164$global;
-	private boolean[][] guard$sample101put160$global;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
 	private double logProbability$arr;
@@ -231,116 +229,51 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
 		{
 			double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$originalValue);
-			for(int t = 1; t < T; t += 1)
-				guard$sample101poisson164$global[(t - 1)][i$var80] = false;
 			for(int t = 1; t < T; t += 1) {
-				double reduceVar$var151$2 = time_impact[t][i$var80][0];
-				for(int cv$reduction480Index = 1; cv$reduction480Index < time_dim; cv$reduction480Index += 1)
-					reduceVar$var151$2 = (reduceVar$var151$2 + time_impact[t][i$var80][cv$reduction480Index]);
-				if(!guard$sample101poisson164$global[(t - 1)][i$var80]) {
-					guard$sample101poisson164$global[(t - 1)][i$var80] = true;
-					cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$2) + cv$accumulatedProbabilities);
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				double reduceVar$var151$3 = 0.0;
-				for(int cv$reduction526Index = 0; cv$reduction526Index < var95; cv$reduction526Index += 1)
-					reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var80][cv$reduction526Index]);
-				for(int cv$reduction526Index = (var95 + 1); cv$reduction526Index < time_dim; cv$reduction526Index += 1)
-					reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var80][cv$reduction526Index]);
-				reduceVar$var151$3 = ((TimeFeat[t][var95] * cv$originalValue) + reduceVar$var151$3);
-				if(!guard$sample101poisson164$global[(t - 1)][i$var80])
-					cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$3) + cv$accumulatedProbabilities);
+				double reduceVar$var151$1 = 0.0;
+				for(int cv$reduction326Index = 0; cv$reduction326Index < var95; cv$reduction326Index += 1)
+					reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction326Index]);
+				for(int cv$reduction326Index = (var95 + 1); cv$reduction326Index < time_dim; cv$reduction326Index += 1)
+					reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction326Index]);
+				reduceVar$var151$1 = ((TimeFeat[t][var95] * cv$originalValue) + reduceVar$var151$1);
+				cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$1) + cv$accumulatedProbabilities);
 			}
 			cv$originalProbability = cv$accumulatedProbabilities;
 		}
 		time_coeff[i$var80][var95] = cv$proposedValue;
 		for(int t = 1; t < T; t += 1)
 			time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
-		for(int t = 1; t < T; t += 1)
-			guard$sample101put160$global[(t - 1)][i$var80] = false;
 		for(int t = 1; t < T; t += 1) {
-			if(!guard$sample101put160$global[(t - 1)][i$var80]) {
-				guard$sample101put160$global[(t - 1)][i$var80] = true;
-				double reduceVar$var151$0 = 0.0;
-				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-					reduceVar$var151$0 = (reduceVar$var151$0 + time_impact[t][i$var80][cv$reduction152Index]);
-				sum_t[t][i$var80] = reduceVar$var151$0;
-			}
-		}
-		for(int t = 1; t < T; t += 1) {
-			if(!guard$sample101put160$global[(t - 1)][i$var80]) {
-				guard$sample101put160$global[(t - 1)][i$var80] = true;
-				double reduceVar$var151$1 = 0.0;
-				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-					reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction152Index]);
-				sum_t[t][i$var80] = reduceVar$var151$1;
-			}
+			double reduceVar$var151$0 = 0.0;
+			for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
+				reduceVar$var151$0 = (reduceVar$var151$0 + time_impact[t][i$var80][cv$reduction152Index]);
+			sum_t[t][i$var80] = reduceVar$var151$0;
 		}
 		double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$proposedValue);
-		for(int t = 1; t < T; t += 1)
-			guard$sample101poisson164$global[(t - 1)][i$var80] = false;
 		for(int t = 1; t < T; t += 1) {
-			double reduceVar$var151$2 = time_impact[t][i$var80][0];
-			for(int cv$reduction480Index = 1; cv$reduction480Index < time_dim; cv$reduction480Index += 1)
-				reduceVar$var151$2 = (reduceVar$var151$2 + time_impact[t][i$var80][cv$reduction480Index]);
-			if(!guard$sample101poisson164$global[(t - 1)][i$var80]) {
-				guard$sample101poisson164$global[(t - 1)][i$var80] = true;
-				cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$2) + cv$accumulatedProbabilities);
-			}
-		}
-		for(int t = 1; t < T; t += 1) {
-			double reduceVar$var151$3 = 0.0;
-			for(int cv$reduction526Index = 0; cv$reduction526Index < var95; cv$reduction526Index += 1)
-				reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var80][cv$reduction526Index]);
-			for(int cv$reduction526Index = (var95 + 1); cv$reduction526Index < time_dim; cv$reduction526Index += 1)
-				reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var80][cv$reduction526Index]);
-			reduceVar$var151$3 = ((TimeFeat[t][var95] * cv$proposedValue) + reduceVar$var151$3);
-			if(!guard$sample101poisson164$global[(t - 1)][i$var80]) {
-				guard$sample101poisson164$global[(t - 1)][i$var80] = true;
-				cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$3) + cv$accumulatedProbabilities);
-			}
+			double reduceVar$var151$1 = 0.0;
+			for(int cv$reduction326Index = 0; cv$reduction326Index < var95; cv$reduction326Index += 1)
+				reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction326Index]);
+			for(int cv$reduction326Index = (var95 + 1); cv$reduction326Index < time_dim; cv$reduction326Index += 1)
+				reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction326Index]);
+			reduceVar$var151$1 = ((TimeFeat[t][var95] * cv$proposedValue) + reduceVar$var151$1);
+			cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$1) + cv$accumulatedProbabilities);
 		}
 		if((((cv$accumulatedProbabilities - cv$originalProbability) <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN((cv$accumulatedProbabilities - cv$originalProbability)))) {
 			time_coeff[i$var80][var95] = cv$originalValue;
 			for(int t = 1; t < T; t += 1)
 				time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
-			for(int t = 1; t < T; t += 1)
-				guard$sample101put160$global[(t - 1)][i$var80] = false;
 			for(int t = 1; t < T; t += 1) {
-				if(!guard$sample101put160$global[(t - 1)][i$var80]) {
-					guard$sample101put160$global[(t - 1)][i$var80] = true;
-					double reduceVar$var151$4 = 0.0;
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						reduceVar$var151$4 = (reduceVar$var151$4 + time_impact[t][i$var80][cv$reduction152Index]);
-					sum_t[t][i$var80] = reduceVar$var151$4;
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				if(!guard$sample101put160$global[(t - 1)][i$var80]) {
-					guard$sample101put160$global[(t - 1)][i$var80] = true;
-					double reduceVar$var151$5 = 0.0;
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						reduceVar$var151$5 = (reduceVar$var151$5 + time_impact[t][i$var80][cv$reduction152Index]);
-					sum_t[t][i$var80] = reduceVar$var151$5;
-				}
+				double reduceVar$var151$2 = 0.0;
+				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
+					reduceVar$var151$2 = (reduceVar$var151$2 + time_impact[t][i$var80][cv$reduction152Index]);
+				sum_t[t][i$var80] = reduceVar$var151$2;
 			}
 		}
 	}
 
 	@Override
-	public final void allocateScratch() {
-		{
-			int cv$max_i$var119 = 0;
-			if((1 < T))
-				cv$max_i$var119 = Math.max(0, n_ac);
-			guard$sample101put160$global = new boolean[Math.max(0, (T - 1))][cv$max_i$var119];
-		}
-		int cv$max_i$var119 = 0;
-		if((1 < T))
-			cv$max_i$var119 = Math.max(0, n_ac);
-		guard$sample101poisson164$global = new boolean[Math.max(0, (T - 1))][cv$max_i$var119];
-	}
+	public final void allocateScratch() {}
 
 	@Override
 	public final void allocator() {
@@ -374,7 +307,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 		logProbability$sample165 = new double[(T - 1)][];
 		for(int t = 1; t < T; t += 1)
 			logProbability$sample165[(t - 1)] = new double[n_ac];
-		allocateScratch();
 	}
 
 	@Override
@@ -394,10 +326,10 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				if(!fixedFlag$sample101) {
 					for(int j = 0; j < time_dim; j += 1)
 						var129[i$var119][j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
-					double reduceVar$var151$6 = 0.0;
+					double reduceVar$var151$3 = 0.0;
 					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						reduceVar$var151$6 = (reduceVar$var151$6 + time_impact[t][i$var119][cv$reduction152Index]);
-					var139[i$var119] = reduceVar$var151$6;
+						reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var119][cv$reduction152Index]);
+					var139[i$var119] = reduceVar$var151$3;
 				}
 				var154[i$var119] = DistributionSampling.samplePoisson(RNG$, sum_t[t][i$var119]);
 			}
@@ -419,10 +351,10 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 			for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 				for(int j = 0; j < time_dim; j += 1)
 					var129[i$var119][j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
-				double reduceVar$var151$10 = 0.0;
+				double reduceVar$var151$7 = 0.0;
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-					reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var119][cv$reduction152Index]);
-				var139[i$var119] = reduceVar$var151$10;
+					reduceVar$var151$7 = (reduceVar$var151$7 + time_impact[t][i$var119][cv$reduction152Index]);
+				var139[i$var119] = reduceVar$var151$7;
 			}
 		}
 	}
@@ -443,10 +375,10 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 			for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 				for(int j = 0; j < time_dim; j += 1)
 					var129[i$var119][j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
-				double reduceVar$var151$7 = 0.0;
+				double reduceVar$var151$4 = 0.0;
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-					reduceVar$var151$7 = (reduceVar$var151$7 + time_impact[t][i$var119][cv$reduction152Index]);
-				var139[i$var119] = reduceVar$var151$7;
+					reduceVar$var151$4 = (reduceVar$var151$4 + time_impact[t][i$var119][cv$reduction152Index]);
+				var139[i$var119] = reduceVar$var151$4;
 				var154[i$var119] = DistributionSampling.samplePoisson(RNG$, sum_t[t][i$var119]);
 			}
 		}
@@ -466,10 +398,10 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 					for(int j = 0; j < time_dim; j += 1)
 						var129[i$var119][j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
-					double reduceVar$var151$8 = 0.0;
+					double reduceVar$var151$5 = 0.0;
 					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						reduceVar$var151$8 = (reduceVar$var151$8 + time_impact[t][i$var119][cv$reduction152Index]);
-					var139[i$var119] = reduceVar$var151$8;
+						reduceVar$var151$5 = (reduceVar$var151$5 + time_impact[t][i$var119][cv$reduction152Index]);
+					var139[i$var119] = reduceVar$var151$5;
 				}
 			}
 		}
@@ -490,10 +422,10 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 			for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 				for(int j = 0; j < time_dim; j += 1)
 					var129[i$var119][j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
-				double reduceVar$var151$9 = 0.0;
+				double reduceVar$var151$6 = 0.0;
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-					reduceVar$var151$9 = (reduceVar$var151$9 + time_impact[t][i$var119][cv$reduction152Index]);
-				var139[i$var119] = reduceVar$var151$9;
+					reduceVar$var151$6 = (reduceVar$var151$6 + time_impact[t][i$var119][cv$reduction152Index]);
+				var139[i$var119] = reduceVar$var151$6;
 			}
 		}
 	}
@@ -590,10 +522,10 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 			for(int i$var119 = 0; i$var119 < n_ac; i$var119 += 1) {
 				for(int j = 0; j < time_dim; j += 1)
 					var129[i$var119][j] = (TimeFeat[t][j] * time_coeff[i$var119][j]);
-				double reduceVar$var151$11 = 0.0;
+				double reduceVar$var151$8 = 0.0;
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-					reduceVar$var151$11 = (reduceVar$var151$11 + time_impact[t][i$var119][cv$reduction152Index]);
-				var139[i$var119] = reduceVar$var151$11;
+					reduceVar$var151$8 = (reduceVar$var151$8 + time_impact[t][i$var119][cv$reduction152Index]);
+				var139[i$var119] = reduceVar$var151$8;
 			}
 		}
 	}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/ReductionTest1/ReductionTest1$SingleThreadCPU_optimisedModelSingle.java
@@ -13,8 +13,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 	private boolean fixedFlag$sample101 = false;
 	private boolean fixedProbFlag$sample101 = false;
 	private boolean fixedProbFlag$sample165 = false;
-	private boolean[][] guard$sample101poisson164$global;
-	private boolean[][] guard$sample101put160$global;
 	private double logProbability$$evidence;
 	private double logProbability$$model;
 	private double logProbability$arr;
@@ -455,85 +453,18 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 			// 
 			// Set the current value to the current state of the tree.
 			double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$originalValue);
-			for(int t = 1; t < T; t += 1)
-				// Set the flags to false
-				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				guard$sample101poisson164$global[(t - 1)][i$var80] = false;
 			for(int t = 1; t < T; t += 1) {
 				// Reduction of array null
 				// 
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				// 
-				// Substituted "index$t$9_5" with its value "t".
-				// 
-				// Substituted "index$i$9_6" with its value "i$var80".
-				double reduceVar$var151$2 = time_impact[t][i$var80][0];
-				for(int cv$reduction480Index = 1; cv$reduction480Index < time_dim; cv$reduction480Index += 1)
-					// Execute the reduction function, saving the result into the return value.
-					// 
-					// Execute the reduction function, saving the result into the return value.
-					// 
-					// Copy the result of the reduction into the variable returned by the reduction.
-					// 
-					// x's comment
-					// Set the left hand term of the reduction function to the return variable value.
-					// 
-					// y's comment
-					// Set the right hand term to a value from the array var141
-					// 
-					// Substituted "index$t$9_5" with its value "t".
-					// 
-					// Substituted "index$i$9_6" with its value "i$var80".
-					reduceVar$var151$2 = (reduceVar$var151$2 + time_impact[t][i$var80][cv$reduction480Index]);
-				if(!guard$sample101poisson164$global[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
-					// 
-					// Guard to check that at most one copy of the code is executed for a given random
-					// variable instance.
-					guard$sample101poisson164$global[(t - 1)][i$var80] = true;
-					
-					// A check to ensure rounding of floating point values can never result in a negative
-					// value.
-					// 
-					// Recorded the probability of reaching sample task 165 with the current configuration.
-					// 
-					// Set an accumulator to record the consumer distributions not seen. Initially set
-					// to 1 as seen values will be deducted from this value.
-					// 
-					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-					// Declaration comment was:
-					// Processing sample task 165 of consumer random variable null.
-					// 
-					// Set an accumulator to sum the probabilities for each possible configuration of
-					// inputs.
-					// 
-					// Substituted "index$i$9_10" with its value "index$i$9_6".
-					// 
-					// Substituted "index$t$9_9" with its value "t".
-					// 
-					// cv$temp$2$var156's comment
-					// Variable declaration of cv$temp$2$var156 moved.
-					// 
-					// Constructing a random variable input for use later.
-					cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$2) + cv$accumulatedProbabilities);
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				// Reduction of array null
-				// 
-				// A generated name to prevent name collisions if the reduction is implemented more
-				// than once in inference and probability code. Initialize the variable to the unit
-				// value
-				double reduceVar$var151$3 = 0.0;
+				double reduceVar$var151$1 = 0.0;
 				
 				// Reduce for every value except a masked value which will be skipped.
 				// 
 				// Substituted "j" with its value "var95".
-				for(int cv$reduction526Index = 0; cv$reduction526Index < var95; cv$reduction526Index += 1)
+				for(int cv$reduction326Index = 0; cv$reduction326Index < var95; cv$reduction326Index += 1)
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Copy the result of the reduction into the variable returned by the reduction.
@@ -544,13 +475,13 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// y's comment
 					// Set the right hand term to a value from the array var141
 					// 
-					// Substituted "index$t$10_6" with its value "t".
+					// Substituted "index$t$4_6" with its value "t".
 					// 
-					// Substituted "index$i$10_7" with its value "i$var80".
-					reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var80][cv$reduction526Index]);
+					// Substituted "index$i$4_7" with its value "i$var80".
+					reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction326Index]);
 				
 				// Substituted "j" with its value "var95".
-				for(int cv$reduction526Index = (var95 + 1); cv$reduction526Index < time_dim; cv$reduction526Index += 1)
+				for(int cv$reduction326Index = (var95 + 1); cv$reduction326Index < time_dim; cv$reduction326Index += 1)
 					// Execute the reduction function, saving the result into the return value.
 					// 
 					// Execute the reduction function, saving the result into the return value.
@@ -563,42 +494,42 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// y's comment
 					// Set the right hand term to a value from the array var141
 					// 
-					// Substituted "index$t$10_6" with its value "t".
+					// Substituted "index$t$4_6" with its value "t".
 					// 
-					// Substituted "index$i$10_7" with its value "i$var80".
-					reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var80][cv$reduction526Index]);
+					// Substituted "index$i$4_7" with its value "i$var80".
+					reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction326Index]);
 				
 				// Copy the result of the reduction into the variable returned by the reduction.
 				// 
 				// Substituted "j" with its value "var95".
 				// 
 				// Set the current value to the current state of the tree.
-				reduceVar$var151$3 = ((TimeFeat[t][var95] * cv$originalValue) + reduceVar$var151$3);
-				if(!guard$sample101poisson164$global[(t - 1)][i$var80])
-					// A check to ensure rounding of floating point values can never result in a negative
-					// value.
-					// 
-					// Recorded the probability of reaching sample task 165 with the current configuration.
-					// 
-					// Set an accumulator to record the consumer distributions not seen. Initially set
-					// to 1 as seen values will be deducted from this value.
-					// 
-					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-					// Declaration comment was:
-					// Processing sample task 165 of consumer random variable null.
-					// 
-					// Set an accumulator to sum the probabilities for each possible configuration of
-					// inputs.
-					// 
-					// Substituted "index$i$10_11" with its value "index$i$10_7".
-					// 
-					// Substituted "index$t$10_10" with its value "t".
-					// 
-					// cv$temp$3$var156's comment
-					// Variable declaration of cv$temp$3$var156 moved.
-					// 
-					// Constructing a random variable input for use later.
-					cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$3) + cv$accumulatedProbabilities);
+				reduceVar$var151$1 = ((TimeFeat[t][var95] * cv$originalValue) + reduceVar$var151$1);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 165 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Processing sample task 165 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "index$i$4_11" with its value "index$i$4_7".
+				// 
+				// Substituted "index$t$4_10" with its value "t".
+				// 
+				// cv$temp$2$var156's comment
+				// Variable declaration of cv$temp$2$var156 moved.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$1) + cv$accumulatedProbabilities);
 			}
 			
 			// Initialize a log space accumulator to take the product of all the distribution
@@ -619,85 +550,33 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 			// 
 			// Substituted "i$var119" with its value "i$var80".
 			time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
-		for(int t = 1; t < T; t += 1)
-			// Set the flags to false
+		for(int t = 1; t < T; t += 1) {
+			// Reduction of array null
 			// 
-			// Guard to check that at most one copy of the code is executed for a given random
-			// variable instance.
-			guard$sample101put160$global[(t - 1)][i$var80] = false;
-		for(int t = 1; t < T; t += 1) {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!guard$sample101put160$global[(t - 1)][i$var80]) {
-				// The body will execute, so should not be executed again
+			// A generated name to prevent name collisions if the reduction is implemented more
+			// than once in inference and probability code. Initialize the variable to the unit
+			// value
+			double reduceVar$var151$0 = 0.0;
+			
+			// For each index in the array to be reduced
+			for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
+				// Execute the reduction function, saving the result into the return value.
 				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				guard$sample101put160$global[(t - 1)][i$var80] = true;
-				
-				// Reduction of array null
+				// Copy the result of the reduction into the variable returned by the reduction.
 				// 
-				// A generated name to prevent name collisions if the reduction is implemented more
-				// than once in inference and probability code. Initialize the variable to the unit
-				// value
-				double reduceVar$var151$0 = 0.0;
-				
-				// For each index in the array to be reduced
-				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-					// Execute the reduction function, saving the result into the return value.
-					// 
-					// Copy the result of the reduction into the variable returned by the reduction.
-					// 
-					// x's comment
-					// Set the left hand term of the reduction function to the return variable value.
-					// 
-					// y's comment
-					// Set the right hand term to a value from the array var141
-					// 
-					// Substituted "index$t$5_4" with its value "t".
-					// 
-					// Substituted "index$i$5_5" with its value "i$var80".
-					reduceVar$var151$0 = (reduceVar$var151$0 + time_impact[t][i$var80][cv$reduction152Index]);
-				
-				// Substituted "index$t$5_4" with its value "t".
-				sum_t[t][i$var80] = reduceVar$var151$0;
-			}
-		}
-		for(int t = 1; t < T; t += 1) {
-			// Constraints moved from conditionals in inner loops/scopes/etc.
-			if(!guard$sample101put160$global[(t - 1)][i$var80]) {
-				// The body will execute, so should not be executed again
+				// x's comment
+				// Set the left hand term of the reduction function to the return variable value.
 				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				guard$sample101put160$global[(t - 1)][i$var80] = true;
-				
-				// Reduction of array null
+				// y's comment
+				// Set the right hand term to a value from the array var141
 				// 
-				// A generated name to prevent name collisions if the reduction is implemented more
-				// than once in inference and probability code. Initialize the variable to the unit
-				// value
-				double reduceVar$var151$1 = 0.0;
-				
-				// For each index in the array to be reduced
-				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-					// Execute the reduction function, saving the result into the return value.
-					// 
-					// Copy the result of the reduction into the variable returned by the reduction.
-					// 
-					// x's comment
-					// Set the left hand term of the reduction function to the return variable value.
-					// 
-					// y's comment
-					// Set the right hand term to a value from the array var141
-					// 
-					// Substituted "index$t$6_4" with its value "t".
-					// 
-					// Substituted "index$i$6_5" with its value "i$var80".
-					reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction152Index]);
-				
-				// Substituted "index$t$6_4" with its value "t".
-				sum_t[t][i$var80] = reduceVar$var151$1;
-			}
+				// Substituted "index$t$3_4" with its value "t".
+				// 
+				// Substituted "index$i$3_5" with its value "i$var80".
+				reduceVar$var151$0 = (reduceVar$var151$0 + time_impact[t][i$var80][cv$reduction152Index]);
+			
+			// Substituted "index$t$3_4" with its value "t".
+			sum_t[t][i$var80] = reduceVar$var151$0;
 		}
 		
 		// An accumulator to allow the value for each distribution to be constructed before
@@ -705,85 +584,18 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 		// 
 		// Substituted "cv$temp$1$var84" with its value "1.0".
 		double cv$accumulatedProbabilities = DistributionSampling.logProbabilityGaussian(cv$proposedValue);
-		for(int t = 1; t < T; t += 1)
-			// Set the flags to false
-			// 
-			// Guard to check that at most one copy of the code is executed for a given random
-			// variable instance.
-			guard$sample101poisson164$global[(t - 1)][i$var80] = false;
 		for(int t = 1; t < T; t += 1) {
 			// Reduction of array null
 			// 
 			// A generated name to prevent name collisions if the reduction is implemented more
 			// than once in inference and probability code. Initialize the variable to the unit
 			// value
-			// 
-			// Substituted "index$t$9_5" with its value "t".
-			// 
-			// Substituted "index$i$9_6" with its value "i$var80".
-			double reduceVar$var151$2 = time_impact[t][i$var80][0];
-			for(int cv$reduction480Index = 1; cv$reduction480Index < time_dim; cv$reduction480Index += 1)
-				// Execute the reduction function, saving the result into the return value.
-				// 
-				// Execute the reduction function, saving the result into the return value.
-				// 
-				// Copy the result of the reduction into the variable returned by the reduction.
-				// 
-				// x's comment
-				// Set the left hand term of the reduction function to the return variable value.
-				// 
-				// y's comment
-				// Set the right hand term to a value from the array var141
-				// 
-				// Substituted "index$t$9_5" with its value "t".
-				// 
-				// Substituted "index$i$9_6" with its value "i$var80".
-				reduceVar$var151$2 = (reduceVar$var151$2 + time_impact[t][i$var80][cv$reduction480Index]);
-			if(!guard$sample101poisson164$global[(t - 1)][i$var80]) {
-				// The body will execute, so should not be executed again
-				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				guard$sample101poisson164$global[(t - 1)][i$var80] = true;
-				
-				// A check to ensure rounding of floating point values can never result in a negative
-				// value.
-				// 
-				// Recorded the probability of reaching sample task 165 with the current configuration.
-				// 
-				// Set an accumulator to record the consumer distributions not seen. Initially set
-				// to 1 as seen values will be deducted from this value.
-				// 
-				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-				// Declaration comment was:
-				// Processing sample task 165 of consumer random variable null.
-				// 
-				// Set an accumulator to sum the probabilities for each possible configuration of
-				// inputs.
-				// 
-				// Substituted "index$i$9_10" with its value "index$i$9_6".
-				// 
-				// Substituted "index$t$9_9" with its value "t".
-				// 
-				// cv$temp$2$var156's comment
-				// Variable declaration of cv$temp$2$var156 moved.
-				// 
-				// Constructing a random variable input for use later.
-				cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$2) + cv$accumulatedProbabilities);
-			}
-		}
-		for(int t = 1; t < T; t += 1) {
-			// Reduction of array null
-			// 
-			// A generated name to prevent name collisions if the reduction is implemented more
-			// than once in inference and probability code. Initialize the variable to the unit
-			// value
-			double reduceVar$var151$3 = 0.0;
+			double reduceVar$var151$1 = 0.0;
 			
 			// Reduce for every value except a masked value which will be skipped.
 			// 
 			// Substituted "j" with its value "var95".
-			for(int cv$reduction526Index = 0; cv$reduction526Index < var95; cv$reduction526Index += 1)
+			for(int cv$reduction326Index = 0; cv$reduction326Index < var95; cv$reduction326Index += 1)
 				// Execute the reduction function, saving the result into the return value.
 				// 
 				// Copy the result of the reduction into the variable returned by the reduction.
@@ -794,13 +606,13 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// y's comment
 				// Set the right hand term to a value from the array var141
 				// 
-				// Substituted "index$t$10_6" with its value "t".
+				// Substituted "index$t$4_6" with its value "t".
 				// 
-				// Substituted "index$i$10_7" with its value "i$var80".
-				reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var80][cv$reduction526Index]);
+				// Substituted "index$i$4_7" with its value "i$var80".
+				reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction326Index]);
 			
 			// Substituted "j" with its value "var95".
-			for(int cv$reduction526Index = (var95 + 1); cv$reduction526Index < time_dim; cv$reduction526Index += 1)
+			for(int cv$reduction326Index = (var95 + 1); cv$reduction326Index < time_dim; cv$reduction326Index += 1)
 				// Execute the reduction function, saving the result into the return value.
 				// 
 				// Execute the reduction function, saving the result into the return value.
@@ -813,47 +625,40 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// y's comment
 				// Set the right hand term to a value from the array var141
 				// 
-				// Substituted "index$t$10_6" with its value "t".
+				// Substituted "index$t$4_6" with its value "t".
 				// 
-				// Substituted "index$i$10_7" with its value "i$var80".
-				reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var80][cv$reduction526Index]);
+				// Substituted "index$i$4_7" with its value "i$var80".
+				reduceVar$var151$1 = (reduceVar$var151$1 + time_impact[t][i$var80][cv$reduction326Index]);
 			
 			// Copy the result of the reduction into the variable returned by the reduction.
 			// 
 			// Substituted "j" with its value "var95".
-			reduceVar$var151$3 = ((TimeFeat[t][var95] * cv$proposedValue) + reduceVar$var151$3);
-			if(!guard$sample101poisson164$global[(t - 1)][i$var80]) {
-				// The body will execute, so should not be executed again
-				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				guard$sample101poisson164$global[(t - 1)][i$var80] = true;
-				
-				// A check to ensure rounding of floating point values can never result in a negative
-				// value.
-				// 
-				// Recorded the probability of reaching sample task 165 with the current configuration.
-				// 
-				// Set an accumulator to record the consumer distributions not seen. Initially set
-				// to 1 as seen values will be deducted from this value.
-				// 
-				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
-				// Declaration comment was:
-				// Processing sample task 165 of consumer random variable null.
-				// 
-				// Set an accumulator to sum the probabilities for each possible configuration of
-				// inputs.
-				// 
-				// Substituted "index$i$10_11" with its value "index$i$10_7".
-				// 
-				// Substituted "index$t$10_10" with its value "t".
-				// 
-				// cv$temp$3$var156's comment
-				// Variable declaration of cv$temp$3$var156 moved.
-				// 
-				// Constructing a random variable input for use later.
-				cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$3) + cv$accumulatedProbabilities);
-			}
+			reduceVar$var151$1 = ((TimeFeat[t][var95] * cv$proposedValue) + reduceVar$var151$1);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 165 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Processing sample task 165 of consumer random variable null.
+			// 
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Substituted "index$i$4_11" with its value "index$i$4_7".
+			// 
+			// Substituted "index$t$4_10" with its value "t".
+			// 
+			// cv$temp$2$var156's comment
+			// Variable declaration of cv$temp$2$var156 moved.
+			// 
+			// Constructing a random variable input for use later.
+			cv$accumulatedProbabilities = (DistributionSampling.logProbabilityPoisson(arr[t][i$var80], reduceVar$var151$1) + cv$accumulatedProbabilities);
 		}
 		
 		// Test if the probability of the sample is sufficient to keep the value. This needs
@@ -884,85 +689,33 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// 
 				// Substituted "i$var119" with its value "i$var80".
 				time_impact[t][i$var80][var95] = (TimeFeat[t][var95] * time_coeff[i$var80][var95]);
-			for(int t = 1; t < T; t += 1)
-				// Set the flags to false
+			for(int t = 1; t < T; t += 1) {
+				// Reduction of array null
 				// 
-				// Guard to check that at most one copy of the code is executed for a given random
-				// variable instance.
-				guard$sample101put160$global[(t - 1)][i$var80] = false;
-			for(int t = 1; t < T; t += 1) {
-				// Constraints moved from conditionals in inner loops/scopes/etc.
-				if(!guard$sample101put160$global[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
+				// A generated name to prevent name collisions if the reduction is implemented more
+				// than once in inference and probability code. Initialize the variable to the unit
+				// value
+				double reduceVar$var151$2 = 0.0;
+				
+				// For each index in the array to be reduced
+				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
+					// Execute the reduction function, saving the result into the return value.
 					// 
-					// Guard to check that at most one copy of the code is executed for a given random
-					// variable instance.
-					guard$sample101put160$global[(t - 1)][i$var80] = true;
-					
-					// Reduction of array null
+					// Copy the result of the reduction into the variable returned by the reduction.
 					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$4 = 0.0;
-					
-					// For each index in the array to be reduced
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$19_4" with its value "t".
-						// 
-						// Substituted "index$i$19_5" with its value "i$var80".
-						reduceVar$var151$4 = (reduceVar$var151$4 + time_impact[t][i$var80][cv$reduction152Index]);
-					
-					// Substituted "index$t$19_4" with its value "t".
-					sum_t[t][i$var80] = reduceVar$var151$4;
-				}
-			}
-			for(int t = 1; t < T; t += 1) {
-				// Constraints moved from conditionals in inner loops/scopes/etc.
-				if(!guard$sample101put160$global[(t - 1)][i$var80]) {
-					// The body will execute, so should not be executed again
+					// x's comment
+					// Set the left hand term of the reduction function to the return variable value.
 					// 
-					// Guard to check that at most one copy of the code is executed for a given random
-					// variable instance.
-					guard$sample101put160$global[(t - 1)][i$var80] = true;
-					
-					// Reduction of array null
+					// y's comment
+					// Set the right hand term to a value from the array var141
 					// 
-					// A generated name to prevent name collisions if the reduction is implemented more
-					// than once in inference and probability code. Initialize the variable to the unit
-					// value
-					double reduceVar$var151$5 = 0.0;
-					
-					// For each index in the array to be reduced
-					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
-						// Execute the reduction function, saving the result into the return value.
-						// 
-						// Copy the result of the reduction into the variable returned by the reduction.
-						// 
-						// x's comment
-						// Set the left hand term of the reduction function to the return variable value.
-						// 
-						// y's comment
-						// Set the right hand term to a value from the array var141
-						// 
-						// Substituted "index$t$20_4" with its value "t".
-						// 
-						// Substituted "index$i$20_5" with its value "i$var80".
-						reduceVar$var151$5 = (reduceVar$var151$5 + time_impact[t][i$var80][cv$reduction152Index]);
-					
-					// Substituted "index$t$20_4" with its value "t".
-					sum_t[t][i$var80] = reduceVar$var151$5;
-				}
+					// Substituted "index$t$9_4" with its value "t".
+					// 
+					// Substituted "index$i$9_5" with its value "i$var80".
+					reduceVar$var151$2 = (reduceVar$var151$2 + time_impact[t][i$var80][cv$reduction152Index]);
+				
+				// Substituted "index$t$9_4" with its value "t".
+				sum_t[t][i$var80] = reduceVar$var151$2;
 			}
 		}
 	}
@@ -971,39 +724,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 	// here prevents repeated allocation and deallocation, and makes the code more amenable
 	// to GPU execution.
 	@Override
-	public final void allocateScratch() {
-		// Allocate scratch space.
-		// Constructor for guard$sample101put160$global
-		{
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			int cv$max_i$var119 = 0;
-			if((1 < T))
-				// Calculate the largest index of i that is possible and allocate an array to hold
-				// the guard for each of these.
-				cv$max_i$var119 = Math.max(0, n_ac);
-			
-			// Allocation of guard$sample101put160$global for single threaded execution
-			// 
-			// Calculate the largest index of t that is possible and allocate an array to hold
-			// the guard for each of these.
-			guard$sample101put160$global = new boolean[Math.max(0, (T - 1))][cv$max_i$var119];
-		}
-		
-		// Calculate the largest index of i that is possible and allocate an array to hold
-		// the guard for each of these.
-		int cv$max_i$var119 = 0;
-		if((1 < T))
-			// Calculate the largest index of i that is possible and allocate an array to hold
-			// the guard for each of these.
-			cv$max_i$var119 = Math.max(0, n_ac);
-		
-		// Allocation of guard$sample101poisson164$global for single threaded execution
-		// 
-		// Calculate the largest index of t that is possible and allocate an array to hold
-		// the guard for each of these.
-		guard$sample101poisson164$global = new boolean[Math.max(0, (T - 1))][cv$max_i$var119];
-	}
+	public final void allocateScratch() {}
 
 	// Method to allocate space for model inputs and outputs.
 	@Override
@@ -1041,9 +762,6 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 		logProbability$sample101 = new double[n_ac][];
 		for(int i$var80 = 0; i$var80 < n_ac; i$var80 += 1)
 			logProbability$sample101[i$var80] = new double[TimeFeat[0].length];
-		
-		// Allocate scratch space
-		allocateScratch();
 	}
 
 	// Method to execute the model code conventionally.
@@ -1072,7 +790,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// A generated name to prevent name collisions if the reduction is implemented more
 					// than once in inference and probability code. Initialize the variable to the unit
 					// value
-					double reduceVar$var151$6 = 0.0;
+					double reduceVar$var151$3 = 0.0;
 					
 					// For each index in the array to be reduced
 					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1080,8 +798,8 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 						// 
 						// y's comment
 						// Set the right hand term to a value from the array var141
-						reduceVar$var151$6 = (reduceVar$var151$6 + time_impact[t][i$var119][cv$reduction152Index]);
-					var139[i$var119] = reduceVar$var151$6;
+						reduceVar$var151$3 = (reduceVar$var151$3 + time_impact[t][i$var119][cv$reduction152Index]);
+					var139[i$var119] = reduceVar$var151$3;
 				}
 				var154[i$var119] = DistributionSampling.samplePoisson(RNG$, sum_t[t][i$var119]);
 			}
@@ -1113,7 +831,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$10 = 0.0;
+				double reduceVar$var151$7 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1123,8 +841,8 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// 
 					// y's comment
 					// Set the right hand term to a value from the array var141
-					reduceVar$var151$10 = (reduceVar$var151$10 + time_impact[t][i$var119][cv$reduction152Index]);
-				var139[i$var119] = reduceVar$var151$10;
+					reduceVar$var151$7 = (reduceVar$var151$7 + time_impact[t][i$var119][cv$reduction152Index]);
+				var139[i$var119] = reduceVar$var151$7;
 			}
 		}
 	}
@@ -1154,7 +872,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$7 = 0.0;
+				double reduceVar$var151$4 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1164,8 +882,8 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// 
 					// y's comment
 					// Set the right hand term to a value from the array var141
-					reduceVar$var151$7 = (reduceVar$var151$7 + time_impact[t][i$var119][cv$reduction152Index]);
-				var139[i$var119] = reduceVar$var151$7;
+					reduceVar$var151$4 = (reduceVar$var151$4 + time_impact[t][i$var119][cv$reduction152Index]);
+				var139[i$var119] = reduceVar$var151$4;
 				var154[i$var119] = DistributionSampling.samplePoisson(RNG$, sum_t[t][i$var119]);
 			}
 		}
@@ -1194,7 +912,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// A generated name to prevent name collisions if the reduction is implemented more
 					// than once in inference and probability code. Initialize the variable to the unit
 					// value
-					double reduceVar$var151$8 = 0.0;
+					double reduceVar$var151$5 = 0.0;
 					
 					// For each index in the array to be reduced
 					for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1202,8 +920,8 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 						// 
 						// y's comment
 						// Set the right hand term to a value from the array var141
-						reduceVar$var151$8 = (reduceVar$var151$8 + time_impact[t][i$var119][cv$reduction152Index]);
-					var139[i$var119] = reduceVar$var151$8;
+						reduceVar$var151$5 = (reduceVar$var151$5 + time_impact[t][i$var119][cv$reduction152Index]);
+					var139[i$var119] = reduceVar$var151$5;
 				}
 			}
 		}
@@ -1234,7 +952,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$9 = 0.0;
+				double reduceVar$var151$6 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1244,8 +962,8 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// 
 					// y's comment
 					// Set the right hand term to a value from the array var141
-					reduceVar$var151$9 = (reduceVar$var151$9 + time_impact[t][i$var119][cv$reduction152Index]);
-				var139[i$var119] = reduceVar$var151$9;
+					reduceVar$var151$6 = (reduceVar$var151$6 + time_impact[t][i$var119][cv$reduction152Index]);
+				var139[i$var119] = reduceVar$var151$6;
 			}
 		}
 	}
@@ -1391,7 +1109,7 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 				// A generated name to prevent name collisions if the reduction is implemented more
 				// than once in inference and probability code. Initialize the variable to the unit
 				// value
-				double reduceVar$var151$11 = 0.0;
+				double reduceVar$var151$8 = 0.0;
 				
 				// For each index in the array to be reduced
 				for(int cv$reduction152Index = 0; cv$reduction152Index < time_dim; cv$reduction152Index += 1)
@@ -1401,8 +1119,8 @@ class ReductionTest1$SingleThreadCPU extends org.sandwood.runtime.internal.model
 					// 
 					// y's comment
 					// Set the right hand term to a value from the array var141
-					reduceVar$var151$11 = (reduceVar$var151$11 + time_impact[t][i$var119][cv$reduction152Index]);
-				var139[i$var119] = reduceVar$var151$11;
+					reduceVar$var151$8 = (reduceVar$var151$8 + time_impact[t][i$var119][cv$reduction152Index]);
+				var139[i$var119] = reduceVar$var151$8;
 			}
 		}
 	}


### PR DESCRIPTION
### Description
Adding a guard so that traces that get the length of an array where the arrays constructor is a get operation cannot move into the put operations that populated that array. This reduces the number of traces, and prevents the generation of relationships that are not required for the analysis. This is done by tracking the type of the array we are concerned with the length of, and then only following traces that involve arrays of the correct type.