### PR TITLE
Removing unrequired passing of the compilationCtx object

### DIFF
--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/APICompile.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/APICompile.java
@@ -508,8 +508,8 @@ public class APICompile {
             compilationCtx.removeScopeSubstitute(scopes.get(i));
 
         c.addTree((TreeBuilderInfo info) -> {
-            ForwardExecutionBuilder.forwardVariableBody(sampleDesc.sampleVariable, compilationCtx);
-            intermediates.setIntermediateValues(false, compilationCtx);
+            ForwardExecutionBuilder.forwardVariableBody(sampleDesc.sampleVariable, info.compilationCtx);
+            intermediates.setIntermediateValues(false, info.compilationCtx);
         });
         IRTreeVoid result = compilationCtx.getOutermostScopeTree();
 

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ForwardExecutionBuilder.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ForwardExecutionBuilder.java
@@ -253,13 +253,13 @@ public class ForwardExecutionBuilder {
 
         VariableDescription<BooleanVariable> guardName = VariableNames.observedGuard(v);
         sc.addTree((TreeBuilderInfo info) -> {
-            compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(guardName,
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(guardName,
                     IRTree.constant(false), "Track if it is possible to reach an observed variable"));
         });
 
         ScopeConstructor obs = sc.addConstraints(obsTraces, Guards.NO_GUARDS);
         obs.addTree((TreeBuilderInfo info) -> {
-            compilationCtx.addTreeToScope(GlobalScope.scope,
+            info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     IRTree.store(guardName, IRTree.constant(true), "Observation reached"));
         });
 
@@ -367,13 +367,13 @@ public class ForwardExecutionBuilder {
                 ScopeStack.popScope(rvScope);
 
                 IRTreeReturn<ArrayVariable<DoubleVariable>> array = load(localNames.get(0));
-                IRTreeReturn<IntVariable> index = newScope.getIndex().getForwardIR(compilationCtx);
+                IRTreeReturn<IntVariable> index = newScope.getIndex().getForwardIR(info.compilationCtx);
                 IRTreeReturn<DoubleVariable> value = arrayGet(array, index);
                 IRTreeReturn<DoubleVariable> prob = multiplyDD(info.probability,
-                        getProbability(rv, newScope, compilationCtx));
+                        getProbability(rv, newScope, info.compilationCtx));
                 value = addDD(value, prob);
                 IRTreeVoid storeValue = arrayPut(array, index, value, "Save the probability of each value");
-                compilationCtx.addTreeToScope(newScope, storeValue);
+                info.compilationCtx.addTreeToScope(newScope, storeValue);
             });
 
             // sum and normalise values

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ObservedValuePropagationBuilder.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ObservedValuePropagationBuilder.java
@@ -335,8 +335,8 @@ public class ObservedValuePropagationBuilder {
                         Variable<?> start = th.peek().task.getOutput();
                         if(start.isObserved())
                             start = start.getObservation().source;
-                        IRTreeReturn<?> current = start.instanceHandle().getForwardIR(compilationCtx);
-                        processTask(th.size() - 1, th, current, info.backTraceInfo, compilationCtx);
+                            IRTreeReturn<?> current = start.instanceHandle().getForwardIR(info.compilationCtx);
+                            processTask(th.size() - 1, th, current, info.backTraceInfo, info.compilationCtx);
                     });
                 }
             }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ProbabilityFunction.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ProbabilityFunction.java
@@ -201,7 +201,7 @@ public class ProbabilityFunction {
                     iterating = iterating || s.iterating();
                     s = s.getEnclosingScope();
                 }
-                
+
                 // If there is only a single sample return.
                 if(!iterating)
                     return false;
@@ -703,14 +703,14 @@ public class ProbabilityFunction {
                             and(load(funcData.fixedFlagName), load(funcData.fixedProbFlagName)),
                             "Should the probability of sample " + funcData.sampleTask.id()
                                     + " be set to fixed. This will only every change the flag to false.");
-                    funcData.compilationCtx.addSetSideEffect(funcData.fixedFlagName, restFixed);
+                    info.compilationCtx.addSetSideEffect(funcData.fixedFlagName, restFixed);
 
                     // Add side effect to clear the flag if a dependency is changed.
                     VariableDescription<?> sampleName = funcData.sampleVariable.getUniqueVarDesc();
                     restFixed = store(funcData.fixedProbFlagName, constant(false),
                             "Unset the fixed probability flag for sample " + funcData.sampleTask.id()
                                     + " as it depends on " + sampleName.name + ".");
-                    funcData.compilationCtx.addSetSideEffect(sampleName, restFixed);
+                    info.compilationCtx.addSetSideEffect(sampleName, restFixed);
                 }
 
                 // Construct an expression to determine if the flag should be set.
@@ -729,19 +729,19 @@ public class ProbabilityFunction {
                                     and(load(sampleFixedName), load(funcData.fixedProbFlagName)),
                                     "Should the probability of sample " + funcData.sampleTask.id()
                                             + " be set to fixed. This will only every change the flag to false.");
-                            funcData.compilationCtx.addSetSideEffect(sampleFixedName, restFixed);
+                            info.compilationCtx.addSetSideEffect(sampleFixedName, restFixed);
 
                             // Add side effect to clear the flag if a dependency is changed.
-                            SampleTraceDesc sampleDesc = funcData.compilationCtx.traces.getSampleTrace(s);
+                            SampleTraceDesc sampleDesc = info.compilationCtx.traces.getSampleTrace(s);
                             VariableDescription<?> sampleName = sampleDesc.sampleVariable.getUniqueVarDesc();
                             restFixed = store(funcData.fixedProbFlagName, constant(false),
                                     "Unset the fixed probability flag for sample " + funcData.sampleTask.id()
                                             + " as it depends on " + sampleName.name + ".");
-                            funcData.compilationCtx.addSetSideEffect(sampleName, restFixed);
+                            info.compilationCtx.addSetSideEffect(sampleName, restFixed);
                         }
                     }
                 }
-                funcData.compilationCtx.addTreeToScope(GlobalScope.scope, store(funcData.fixedProbFlagName, fixed,
+                info.compilationCtx.addTreeToScope(GlobalScope.scope, store(funcData.fixedProbFlagName, fixed,
                         "Now the probability is calculated store if it can be cached or if it needs to be recalculated next time."));
             });
 
@@ -752,35 +752,35 @@ public class ProbabilityFunction {
                     .addTree((TreeBuilderInfo info) -> {
 
                         // Initialize variables
-                        funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
+                        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                                 initializeVariable(accumulatorName, constant(0.0), Tree.NoComment));
 
-                        funcData.compilationCtx.addTreeToScope(funcData.randomStoreScope,
+                        info.compilationCtx.addTreeToScope(funcData.randomStoreScope,
                                 initializeVariable(rvProbabilityName, constant(0.0), Tree.NoComment));
 
                         if(funcData.sampleSkippable) {
-                            funcData.compilationCtx.enterScope(funcData.sampleTaskScope);
-                            funcData.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(guardName,
+                            info.compilationCtx.enterScope(funcData.sampleTaskScope);
+                            info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(guardName,
                                     IRTree.constant(false), "A guard to check if the sample value is ever reached."));
-                            funcData.compilationCtx.leaveScope(funcData.sampleTaskScope);
+                            info.compilationCtx.leaveScope(funcData.sampleTaskScope);
                         }
 
                         if(funcData.storeArgTrees.isEmpty()) // We are not in a loop.
-                            funcData.compilationCtx.addTreeToScope(funcData.sampleStoreScope,
+                            info.compilationCtx.addTreeToScope(funcData.sampleStoreScope,
                                     initializeVariable(sampleValueName, load(funcData.storedName), Tree.NoComment));
                         else
-                            funcData.compilationCtx.addTreeToScope(funcData.sampleStoreScope,
+                            info.compilationCtx.addTreeToScope(funcData.sampleStoreScope,
                                     initializeVariable(sampleValueName,
                                             TreeUtils.getIndirectValue(funcData.storedName, funcData.storeArgTrees),
                                             Tree.NoComment));
 
                         // Accumulate values
-                        funcData.compilationCtx.addTreeToScope(funcData.sampleStoreScope, store(rvProbabilityName,
+                        info.compilationCtx.addTreeToScope(funcData.sampleStoreScope, store(rvProbabilityName,
                                 addDD(load(rvProbabilityName), load(sampleValueName)), Tree.NoComment));
                         if(funcData.sampleSkippable)
-                            funcData.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
+                            info.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
                                     store(guardName, constant(true), "Record that the sample was reached."));
-                        funcData.compilationCtx.addTreeToScope(funcData.randomStoreScope, store(accumulatorName,
+                        info.compilationCtx.addTreeToScope(funcData.randomStoreScope, store(accumulatorName,
                                 addDD(load(accumulatorName), load(rvProbabilityName)), Tree.NoComment));
 
                         // Update the values for the random variables
@@ -908,7 +908,7 @@ public class ProbabilityFunction {
         a = a.addConstraint(funcData.traceToSampleVariable);
 
         a.addTree(0, (TreeBuilderInfo info) -> {
-            IRTreeReturn<?> current = funcData.sampleVariable.getForwardIR(funcData.compilationCtx);
+            IRTreeReturn<?> current = funcData.sampleVariable.getForwardIR(info.compilationCtx);
             int index = funcData.traceToSampleVariable.size() - 1;
             BackTraceInfo backTraceInfo = new BackTraceInfo();
             while(index >= 0) {
@@ -919,11 +919,11 @@ public class ProbabilityFunction {
                     case SAMPLE:
                         break;
                     default:
-                        current = t.getInverseIR(d.argPos, current, backTraceInfo, funcData.compilationCtx);
+                        current = t.getInverseIR(d.argPos, current, backTraceInfo, info.compilationCtx);
                 }
             }
 
-            funcData.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
+            info.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
                     IRTree.initializeVariable(funcData.sampleVariableName, (IRTreeReturn<A>) current,
                             "The sample value to calculate the probability of generating"));
         });
@@ -936,10 +936,10 @@ public class ProbabilityFunction {
             // Calculate the probability of the value in current. If this happens inside an
             // iterating scope this may be called many times with different values.
             IRTreeReturn<DoubleVariable> sampleProbability = getSampleProbability(funcData.randomVariable, sampleValue,
-                    true, funcData.compilationCtx);
+                    true, info.compilationCtx);
 
             // Store the value of the function call, so the function call is only made once.
-            funcData.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
+            info.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
                     initializeVariable(weightedProbability, addDD(log(info.probability), sampleProbability),
                             "Store the value of the function call, so the function call is only made once."));
         });
@@ -969,17 +969,17 @@ public class ProbabilityFunction {
                                 ScopeConstructor c = b.addConstraint(sinkToConditional);
 
                                 c.addTree(2, (TreeBuilderInfo info) -> {
-                                    IRTreeReturn<?> current = sink.getForwardIR(funcData.compilationCtx);
+                                    IRTreeReturn<?> current = sink.getForwardIR(info.compilationCtx);
                                     int index = sinkToConditional.size() - 1;
                                     BackTraceInfo backTraceInfo = new BackTraceInfo();
                                     while(index >= 0) {
                                         DataflowTaskArgDesc currentDesc = sinkToConditional.get(index--);
                                         current = currentDesc.task.getInverseIR(currentDesc.argPos, current,
-                                                backTraceInfo, funcData.compilationCtx);
+                                                backTraceInfo, info.compilationCtx);
                                     }
 
                                     constructObservationTest(weightedProbability, taskDesc, current,
-                                            funcData.compilationCtx);
+                                            info.compilationCtx);
                                 });
                             }
                         }
@@ -990,12 +990,12 @@ public class ProbabilityFunction {
 
         // Merge the resulting weighted probability into the accumulators.
         a.addTree(0, (TreeBuilderInfo info) -> {
-            funcData.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
+            info.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
                     TreeUtils.lseAdd(load(disAccumulator), load(weightedProbability), disAccumulator,
                             "Add the probability of this sample task to the distribution accumulator."));
 
             // Update the probability space seen
-            funcData.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
+            info.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
                     store(probabilityReached, addDD(load(probabilityReached), info.probability),
                             "Add the probability of this distribution configuration to the accumulator."));
         });
@@ -1121,9 +1121,8 @@ public class ProbabilityFunction {
 
                     // Add variables that require per variable values
                     ScopeConstructor perVarScopes = sPerSample.addConstraints(traces, NO_GUARDS);
-                    perVarScopes
-                            .addTree((TreeBuilderInfo info) -> funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
-                                    setValueProbability(sampleProbability, v, guardName, funcData)));
+                    perVarScopes.addTree((TreeBuilderInfo info) -> info.compilationCtx.addTreeToScope(GlobalScope.scope,
+                            setValueProbability(sampleProbability, v, guardName, funcData)));
                 }
             }
 
@@ -1144,9 +1143,8 @@ public class ProbabilityFunction {
 
                     // Add variables that require per variable values
                     ScopeConstructor perVarScopes = sAccumulator.addConstraints(traces, NO_GUARDS);
-                    perVarScopes
-                            .addTree((TreeBuilderInfo info) -> funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
-                                    setValueProbability(accumulatedProbability, v, guardName, funcData)));
+                    perVarScopes.addTree((TreeBuilderInfo info) -> info.compilationCtx.addTreeToScope(GlobalScope.scope,
+                            setValueProbability(accumulatedProbability, v, guardName, funcData)));
 
                 }
             }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorArray.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorArray.java
@@ -1,7 +1,7 @@
 /*
  * Sandwood
  *
- * Copyright (c) 2019-2025, Oracle and/or its affiliates
+ * Copyright (c) 2019-2026, Oracle and/or its affiliates
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
@@ -52,21 +52,21 @@ public abstract class InferenceGeneratorArray<A extends Variable<A>, B extends R
     // Methods passing through to the subclasses. this provides a point where we can add in code that should be executed
     // for all array values, but not for scalars.
     @Override
-    protected void addSampleValueTree(FuncData funcData, CompilationContext compilationCtx) {
-        IRTreeVoid sampleValue = calculateSampleValue(funcData, compilationCtx);
+    protected void addSampleValueTree(FuncData funcData) {
+        IRTreeVoid sampleValue = calculateSampleValue(funcData);
         sampleValue.prefixComment("Calculate the new sample value");
-        funcData.sampleDesc.updateSample(sampleValue, compilationCtx);
+        funcData.sampleDesc.updateSample(sampleValue, funcData.compilationCtx);
     }
 
-    protected abstract IRTreeVoid calculateSampleValue(FuncData funcData, CompilationContext compilationCtx);
+    protected abstract IRTreeVoid calculateSampleValue(FuncData funcData);
 
     @Override
-    protected void constructFunctionVariablesInternal(FuncData funcData, CompilationContext compilationCtx) {
+    protected void constructFunctionVariablesInternal(FuncData funcData) {
         // Set up a pointer for accessing local space.
         IRTreeReturn<ArrayVariable<A>> globalState;
         if(funcData.sampleDesc.targetFound()) {
             List<IRTreeReturn<IntVariable>> indexes = TreeUtils.toArgTrees(funcData.sampleDesc.targetIndexes(),
-                    compilationCtx);
+                    funcData.compilationCtx);
             // Dirty hack to keep getIndirect happy. TODO come up with a cleaner solutions.
             // Recasting the variable type so that the get indirect method can be used in
             // the same way it would be used for variables declared inside a loop.
@@ -75,26 +75,26 @@ public abstract class InferenceGeneratorArray<A extends Variable<A>, B extends R
             globalState = TreeUtils.getIndirectValue(targetName, indexes);
         } else {
             List<IRTreeReturn<IntVariable>> indexes = TreeUtils
-                    .toArgTrees(TreeUtils.getScopeArgs(funcData.sampleDesc.output), compilationCtx);
+                    .toArgTrees(TreeUtils.getScopeArgs(funcData.sampleDesc.output), funcData.compilationCtx);
             globalState = TreeUtils.getIndirectValue(funcData.sampleDesc.output.getUniqueVarDesc(), indexes);
         }
         IRTreeVoid getLocalState = initializeVariable(funcData.targetLocal, globalState,
                 "A reference local to the function for the sample variable.");
-        funcData.targetScope.addTree((TreeBuilderInfo t) -> {
-            compilationCtx.addTreeToScope(GlobalScope.scope, getLocalState);
+        funcData.targetScope.addTree((TreeBuilderInfo info) -> {
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, getLocalState);
         });
-        constructFunctionVariables(funcData, compilationCtx);
+        constructFunctionVariables(funcData);
     }
 
-    protected abstract void constructFunctionVariables(FuncData funcData, CompilationContext compilationCtx);
+    protected abstract void constructFunctionVariables(FuncData funcData);
 
     @Override
-    protected void allocateGlobalStateInternal(CompilationContext compilationCtx, FuncData funcData) {
-        CompilationPhase phase = compilationCtx.phase;
-        compilationCtx.phase = CompilationPhase.ALLOCATION;
-        allocateGlobalState(compilationCtx, funcData);
-        compilationCtx.phase = phase;
+    protected void allocateGlobalStateInternal(FuncData funcData) {
+        CompilationPhase phase = funcData.compilationCtx.phase;
+        funcData.compilationCtx.phase = CompilationPhase.ALLOCATION;
+        allocateGlobalState(funcData);
+        funcData.compilationCtx.phase = phase;
     }
 
-    protected abstract void allocateGlobalState(CompilationContext compilationCtx, FuncData funcData);
+    protected abstract void allocateGlobalState(FuncData funcData);
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorArrayProb.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorArrayProb.java
@@ -11,7 +11,6 @@ package org.sandwood.compiler.compilation.inference;
 import static org.sandwood.compiler.trees.irTree.IRTree.addDD;
 import static org.sandwood.compiler.trees.irTree.IRTree.arrayGet;
 import static org.sandwood.compiler.trees.irTree.IRTree.arrayPut;
-import static org.sandwood.compiler.trees.irTree.IRTree.conditionalAssignment;
 import static org.sandwood.compiler.trees.irTree.IRTree.constant;
 import static org.sandwood.compiler.trees.irTree.IRTree.divideDD;
 import static org.sandwood.compiler.trees.irTree.IRTree.divideDI;
@@ -38,8 +37,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.sandwood.compiler.compilation.CompilationContext;
-import org.sandwood.compiler.compilation.FunctionType;
 import org.sandwood.compiler.compilation.CompilationContext.CompilationPhase;
+import org.sandwood.compiler.compilation.FunctionType;
 import org.sandwood.compiler.compilation.util.TreeUtils;
 import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
@@ -178,7 +177,7 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
     }
 
     @Override
-    protected void constructFunctionVariables(FuncData funcData, CompilationContext compilationCtx) {
+    protected void constructFunctionVariables(FuncData funcData) {
         constructFunctionVariablesProb(funcData);
     }
 
@@ -186,39 +185,39 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
 
     @Override
     protected void getPerDistributedSampleStartIR(FuncData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {
+            TreeBuilderInfo info) {
         DistributableRandomVariable<?, ?> disRV = s.randomVariable;
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(consumerSampleDistributionAccumulator,
-                        loadGlobalField(globalDistributionScratchSpace.get(disRV), funcData, compilationCtx),
+                        loadGlobalField(globalDistributionScratchSpace.get(disRV), funcData),
                         "A local array to hold the accumulated distributions of "
                                 + "the sample tasks for each configuration of distributions."));
 
         VariableDescription<IntVariable> indexName = VariableNames.calcVarName("i", VariableType.IntVariable, true);
         IRTreeVoid body = arrayPut(load(consumerSampleDistributionAccumulator), load(indexName), constant(0.0),
                 Tree.NoComment);
-        IRTreeVoid loop = IRTree.forStmt(body, constant(0), disRV.getNumStates().getForwardIR(compilationCtx),
+        IRTreeVoid loop = IRTree.forStmt(body, constant(0), disRV.getNumStates().getForwardIR(info.compilationCtx),
                 constant(1), indexName, true, "Zero all the elements in the distribution accumulator");
-        compilationCtx.addTreeToScope(GlobalScope.scope, loop);
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, loop);
 
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(reachedDistributions, constant(0.0),
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(reachedDistributions, constant(0.0),
                 "Zero an accumulator to track the probabilities reached."));
     }
 
     @Override
-    protected void getPerDistributedSampleEndIR(FuncData funcData, DistributionSampleTask<?, ?> s, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+    protected void getPerDistributedSampleEndIR(FuncData funcData, DistributionSampleTask<?, ?> s,
+            TreeBuilderInfo info) {
         // Get a local copy of the sample distribution
         IRTreeReturn<ArrayVariable<DoubleVariable>> sampleDistribution = s.getProbabilitiesArray()
-                .getForwardIR(compilationCtx);
+                .getForwardIR(info.compilationCtx);
         VariableDescription<ArrayVariable<DoubleVariable>> sampleDescriptionName = VariableNames
                 .calcVarName("sampleDistribution", sampleDistribution.getOutputType(), true);
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(sampleDescriptionName, sampleDistribution,
-                "A local copy of the samples' distribution."));
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(sampleDescriptionName,
+                sampleDistribution, "A local copy of the samples' distribution."));
 
         VariableDescription<DoubleVariable> overlapName = VariableNames.calcVarName("overlap",
                 VariableType.DoubleVariable, true);
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(overlapName, constant(0.0), "The overlap of the distributions so far."));
 
         // Start constructing the body of the for loop
@@ -249,13 +248,13 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
         // the distribution.
         IRTreeVoid body = sequential(bodyStmts, Tree.NoComment);
         IRTreeVoid loop = IRTree.forStmt(body, constant(0),
-                s.randomVariable.getNumStates().getForwardIR(compilationCtx), constant(1), indexName, true,
+                s.randomVariable.getNumStates().getForwardIR(info.compilationCtx), constant(1), indexName, true,
                 "Calculate the overlap for each element in the distribution");
-        compilationCtx.addTreeToScope(GlobalScope.scope, loop);
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, loop);
 
         // Compute the ratio of the overlap that should be added with 1 being used
         // for the values that are unreachable.
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 store(distributionProbabilityAccumulator, addDD(load(distributionProbabilityAccumulator),
                         log(addDD(
                                 multiplyDD(load(overlapName), load(reachedDistributions)),
@@ -266,60 +265,60 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
     }
 
     @Override
-    protected void getPerConsumerStartIR(FuncData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+    protected void getPerConsumerStartIR(FuncData funcData, TreeBuilderInfo info) {
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(consumerSampleProbabilitiesAccumulator, constant(Double.NEGATIVE_INFINITY),
                         "Set an accumulator to sum the probabilities for each possible configuration " + "of inputs."));
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(consumerSampleDistributionProbabilityAccumulator, constant(1.0),
                         "Set an accumulator to record the consumer distributions not seen. Initially set "
                                 + "to 1 as seen values will be deducted from this value."));
     }
 
     @Override
-    protected void getPerConsumerEndIR(FuncData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+    protected void getPerConsumerEndIR(FuncData funcData, TreeBuilderInfo info) {
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 store(consumerSampleDistributionProbabilityAccumulator,
                         max(load(consumerSampleDistributionProbabilityAccumulator), constant(0.0)),
                         "A check to ensure rounding of floating point values can never result in a negative value."));
-        compilationCtx.addTreeToScope(GlobalScope.scope, TreeUtils.lseAdd(load(consumerSampleProbabilitiesAccumulator),
-                log(load(consumerSampleDistributionProbabilityAccumulator)), (IRTreeReturn<DoubleVariable> output) -> {
-                    return IRTree.store(probabilitiesAccumulator, addDD(output, load(probabilitiesAccumulator)),
-                            Tree.NoComment);
-                }, "Multiply (log space add) in the probability of the sample task to the overall "
-                        + "probability for this configuration of the source random variable."));
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
+                TreeUtils.lseAdd(load(consumerSampleProbabilitiesAccumulator),
+                        log(load(consumerSampleDistributionProbabilityAccumulator)),
+                        (IRTreeReturn<DoubleVariable> output) -> {
+                            return IRTree.store(probabilitiesAccumulator, addDD(output, load(probabilitiesAccumulator)),
+                                    Tree.NoComment);
+                        }, "Multiply (log space add) in the probability of the sample task to the overall "
+                                + "probability for this configuration of the source random variable."));
     }
 
     @Override
-    protected void backTraceScopeStartIR(FuncData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(statesProbabilityValue,
+    protected void backTraceScopeStartIR(FuncData funcData, TreeBuilderInfo info) {
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(statesProbabilityValue,
                 constant(Double.NEGATIVE_INFINITY), "Initialize the summed probabilities to 0 in log space."));
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(reachedDistributionsSource, constant(0.0),
-                "Initialize a counter to track the reached distributions."));
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(distributionProbabilityAccumulator,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(reachedDistributionsSource,
+                constant(0.0), "Initialize a counter to track the reached distributions."));
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(distributionProbabilityAccumulator,
                 constant(0.0),
                 "Initialize an accumulator to take the product of all the distribution probabilities in log space."));
 
-        setSampleValue(funcData, compilationCtx);
+        setSampleValue(funcData);
     }
 
-    protected abstract void setSampleValue(FuncData funcData, CompilationContext compilationCtx);
+    protected abstract void setSampleValue(FuncData funcData);
 
     @Override
-    protected void backTraceScopeEndIR(FuncData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
+    protected void backTraceScopeEndIR(FuncData funcData, TreeBuilderInfo info) {
         IRTreeReturn<DoubleVariable> value = addDD(
                 subtractDD(load(statesProbabilityValue), log(load(reachedDistributionsSource))),
                 load(distributionProbabilityAccumulator));
 
-        saveBackTraceProbability(funcData, value, compilationCtx);
+        saveBackTraceProbability(funcData, value);
     }
 
-    protected abstract void saveBackTraceProbability(FuncData funcData, IRTreeReturn<DoubleVariable> value,
-            CompilationContext compilationCtx);
+    protected abstract void saveBackTraceProbability(FuncData funcData, IRTreeReturn<DoubleVariable> value);
 
     @Override
-    protected void addDistributionProbabilities(ScopeConstructor targetScope, FuncData funcData,
-            CompilationContext compilationCtx) {
+    protected void addDistributionProbabilities(ScopeConstructor targetScope, FuncData funcData) {
         targetScope = targetScope
                 .addComment("Set the calculated probabilities to be the distribution values, and normalize");
 
@@ -329,9 +328,9 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
             // Bound for loops.
             VariableDescription<IntVariable> endBound = VariableNames.calcVarName("endOfLoop", VariableType.IntVariable,
                     true);
-            compilationCtx.addTreeToScope(GlobalScope.scope,
+            info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     initializeVariable(endBound,
-                            ((ArrayVariable<?>) funcData.sampleDesc.output).getMaxLength(compilationCtx),
+                            ((ArrayVariable<?>) funcData.sampleDesc.output).getMaxLength(info.compilationCtx),
                             "End bound for loops."));
 
             VariableDescription<IntVariable> indexName = VariableNames.calcVarName("index", VariableType.IntVariable,
@@ -341,15 +340,15 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
             VariableDescription<ArrayVariable<DoubleVariable>> localProbability = VariableNames
                     .calcVarName("localProbability", VariableType.arrayType(VariableType.DoubleVariable), true);
             IRTreeReturn<ArrayVariable<DoubleVariable>> probabilityArray = ((DistributionSampleTask<?, ?>) funcData.sampleDesc.sample)
-                    .getProbabilitiesArray().getForwardIR(compilationCtx);
-            compilationCtx.addTreeToScope(GlobalScope.scope,
+                    .getProbabilitiesArray().getForwardIR(info.compilationCtx);
+            info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     initializeVariable(localProbability, probabilityArray, "Local copy of the probability array"));
             VariableDescription<DoubleVariable> sumName = VariableNames.calcVarName("probabilitySum",
                     VariableType.DoubleVariable, true);
             VariableDescription<DoubleVariable> valueName = VariableNames.calcVarName("probability",
                     VariableType.DoubleVariable, true);
 
-            compilationCtx.addTreeToScope(GlobalScope.scope,
+            info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     initializeVariable(sumName, constant(0.0), Tree.NoComment));
             IRTreeVoid body = sequential(
                     "Copy all values across moving out of log space in the process, "
@@ -357,7 +356,7 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
                     initializeVariable(valueName, arrayGet(arrayValue, load(indexName)), Tree.NoComment),
                     store(sumName, addDD(load(sumName), load(valueName)), Tree.NoComment),
                     arrayPut(load(localProbability), load(indexName), load(valueName), Tree.NoComment));
-            compilationCtx.addTreeToScope(GlobalScope.scope,
+            info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     forStmt(body, constant(0), load(endBound), constant(1), indexName, true,
                             "Copy all probabilities, moving out of log space in the process, "
                                     + "and summing the probabilities in the process ready to normalise them."));
@@ -374,7 +373,7 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
                     arrayPut(load(localProbability), load(indexName),
                             divideDD(arrayGet(load(localProbability), load(indexName)), load(sumName)), Tree.NoComment),
                     constant(0), load(endBound), constant(1), indexName, true, "Normalise the copied values");
-            compilationCtx.addTreeToScope(GlobalScope.scope,
+            info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     ifElse(guard, ifBody, Tree.NoComment, elseBody, Tree.NoComment));
 
         });
@@ -382,14 +381,13 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
 
     @Override
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> s,
-            IRTreeReturn<DoubleVariable> sourceProbability, FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<DoubleVariable> sourceProbability, FuncData funcData, TreeBuilderInfo info) {
         VariableDescription<DoubleVariable> distributionProbability = VariableNames
                 .calcVarName("distributionProbability", VariableType.DoubleVariable, true);
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(distributionProbability, multiplyDD(sourceProbability, info.probability),
                         "The probability of reaching the consumer with this set of consumer arguments"));
-        compilationCtx.addTreeToScope(GlobalScope.scope, store(reachedDistributions,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, store(reachedDistributions,
                 addDD(load(reachedDistributions), load(distributionProbability)), "Record the reached distribution."));
 
         DistributableRandomVariable<?, ?> random = s.randomVariable;
@@ -399,43 +397,41 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
         args.add(load(distributionProbability));
         args.addAll(funcData.consumerRVArgs);
 
-        compilationCtx.addTreeToScope(GlobalScope.scope, functionCall(FunctionType.ADD_DISTRIBUTION, random.getType(),
-                "Add the current distribution to the distribution accumulator.", args));
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, functionCall(FunctionType.ADD_DISTRIBUTION,
+                random.getType(), "Add the current distribution to the distribution accumulator.", args));
     }
 
     @Override
-    protected void getPerSourceConfigStartIR(FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+    protected void getPerSourceConfigStartIR(FuncData funcData, TreeBuilderInfo info) {
         IRTreeVoid updateReachable = store(reachedDistributionsSource,
                 addDD(load(reachedDistributionsSource), info.probability), "Record the reached probability density.");
-        compilationCtx.addTreeToScope(GlobalScope.scope, updateReachable);
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, updateReachable);
 
         // Initialize an accumulator for the probabilities.
-        IRTreeReturn<DoubleVariable> sampleProbability = getSourceValueProbability(funcData, compilationCtx);
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(probabilitiesAccumulator,
+        IRTreeReturn<DoubleVariable> sampleProbability = getSourceValueProbability(funcData);
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(probabilitiesAccumulator,
                 addDD(log(info.probability), sampleProbability),
                 "An accumulator to allow the value for each distribution to be constructed before it is added to the index probabilities."));
     }
 
-    private IRTreeReturn<DoubleVariable> getSourceValueProbability(FuncData funcData,
-            CompilationContext compilationCtx) {
-        List<IRTreeReturn<?>> args = constructArguments(funcData.sourceRandom, compilationCtx, funcData.getTarget());
+    private IRTreeReturn<DoubleVariable> getSourceValueProbability(FuncData funcData) {
+        List<IRTreeReturn<?>> args = constructArguments(funcData.sourceRandom, funcData.compilationCtx,
+                funcData.getTarget());
         IRTreeReturn<DoubleVariable> sampleProbability = functionCallReturn(FunctionType.LOG_PROBABILITY,
                 VariableType.DoubleVariable, funcData.sourceRandom.getType(), args);
         return sampleProbability;
     }
 
     @Override
-    protected void getPerSourceConfigEndIR(FuncData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
-        compilationCtx.addTreeToScope(GlobalScope.scope, TreeUtils.lseAdd(load(statesProbabilityValue),
+    protected void getPerSourceConfigEndIR(FuncData funcData, TreeBuilderInfo info) {
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, TreeUtils.lseAdd(load(statesProbabilityValue),
                 load(probabilitiesAccumulator), statesProbabilityValue,
                 "Add the values for the source and any standard consumers for this configuration of arguments to the source."));
     }
 
     @Override
-    protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer, FuncData funcData,
-            CompilationContext compilationCtx) {
-        funcData.consumerRVArgs = constructArguments(consumer, compilationCtx);
+    protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer, FuncData funcData) {
+        funcData.consumerRVArgs = constructArguments(consumer, info.compilationCtx);
     }
 
     protected List<IRTreeReturn<?>> constructArguments(RandomVariable<?, ?> random, CompilationContext compilationCtx,
@@ -475,7 +471,7 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
     }
 
     @Override
-    protected void finalize(FuncData funcData, CompilationContext compilationCtx) {}
+    protected void finalize(FuncData funcData) {}
 
     /**
      * Method to construct the for loop to iterate through each possible output of the random variable.
@@ -485,14 +481,14 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
      * 
      */
     @Override
-    protected ScopeConstructor getBackTraceScope(FuncData funcData, CompilationContext compilationCtx) {
+    protected ScopeConstructor getBackTraceScope(FuncData funcData) {
         return funcData.targetScope.addForLoop(Variable.intVariable(0), funcData.noStates, Variable.intVariable(1),
                 valuePosName, Tree.NoComment, true);
     }
 
     // No global state is required.
     @Override
-    protected void allocateGlobalState(CompilationContext compilationCtx, FuncData funcData) {
+    protected void allocateGlobalState(FuncData funcData) {
         for(RandomVariable<?, ?> rv:funcData.consumingRVs) {
             for(DataflowTask<?> d:rv.getConsumers()) {
                 if(((SampleTask<?, ?>) d).isDistribution()) {
@@ -502,43 +498,42 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
                     VariableDescription<ArrayVariable<DoubleVariable>> disAccumulatorName = getDistributionAccumulatorName(
                             disRV);
                     globalDistributionScratchSpace.put(disRV, disAccumulatorName);
-                    allocateGlobalArray(compilationCtx, funcData, disRV, disAccumulatorName);
+                    allocateGlobalArray(funcData, disRV, disAccumulatorName);
                     break;
                 }
             }
         }
 
-        allocateGlobalStateProb(funcData, compilationCtx);
+        allocateGlobalStateProb(funcData);
     }
 
-    protected abstract void allocateGlobalStateProb(FuncData funcData, CompilationContext compilationCtx);
+    protected abstract void allocateGlobalStateProb(FuncData funcData);
 
-    protected <C extends Variable<C>> void allocateGlobalArray(CompilationContext compilationCtx, FuncData funcData,
-            DistributableRandomVariable<?, ?> rv, VariableDescription<ArrayVariable<C>> variableDescription) {
+    protected <C extends Variable<C>> void allocateGlobalArray(FuncData funcData, DistributableRandomVariable<?, ?> rv,
+            VariableDescription<ArrayVariable<C>> variableDescription) {
         // Allocate space for storing the results.
-        compilationCtx.pushScopeState();
+        funcData.compilationCtx.pushScopeState();
         // Because of the reuse of max this needs to be serial. We could overcome this by taking a copy of the value of
         // max in a new in, but as I am not sure that parallel allocation is a beneficial, for now we will make this
         // serial and skip any overhead.
-        compilationCtx.pushIsSerial(true);
+        funcData.compilationCtx.pushIsSerial(true);
 
         // Update phase
-        CompilationPhase currentPhase = compilationCtx.phase;
-        compilationCtx.phase = CompilationPhase.ALLOCATION;
+        CompilationPhase currentPhase = funcData.compilationCtx.phase;
+        funcData.compilationCtx.phase = CompilationPhase.ALLOCATION;
 
-        IRTreeReturn<IntVariable> noStates = rv.getMaxNoStates(compilationCtx);
+        IRTreeReturn<IntVariable> noStates = rv.getMaxNoStates(funcData.compilationCtx);
 
         // Allocate and store the largest value
-        globalFieldAllocation(variableDescription, newArray(noStates, variableDescription.type), funcData,
-                compilationCtx);
+        globalFieldAllocation(variableDescription, newArray(noStates, variableDescription.type), funcData);
         // Get the allocator
-        IRTreeVoid allocator = compilationCtx.getOutermostScopeTree();
+        IRTreeVoid allocator = funcData.compilationCtx.getOutermostScopeTree();
 
-        compilationCtx.phase = currentPhase;
-        compilationCtx.popIsSerial();
-        compilationCtx.popScopeState();
+        funcData.compilationCtx.phase = currentPhase;
+        funcData.compilationCtx.popIsSerial();
+        funcData.compilationCtx.popScopeState();
 
-        createGlobalField(variableDescription, allocator, funcData, compilationCtx);
+        createGlobalField(variableDescription, allocator, funcData);
     }
 
     /**
@@ -555,7 +550,7 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
 
     @Override
     protected void getObservationToSampleIR(SampleTask<?, ?> task, IRTreeReturn<?> current, FuncData funcData,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {
+            TreeBuilderInfo info) {
         List<IRTreeReturn<?>> args = new ArrayList<>();
         args.add(current);
         args.addAll(funcData.consumerRVArgs);
@@ -564,7 +559,7 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
 
         // Construct a tree to generate the probability, and save it to the sample
         // accumulator.
-        compilationCtx.addTreeToScope(task.scope(),
+        info.compilationCtx.addTreeToScope(task.scope(),
                 TreeUtils.lseAdd(load(consumerSampleProbabilitiesAccumulator),
                         addDD(log(info.probability), sampleProbability), consumerSampleProbabilitiesAccumulator,
                         "Record the probability of sample task " + task.id()
@@ -574,24 +569,23 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
                 info.probability);
         IRTreeVoid sample = store(consumerSampleDistributionProbabilityAccumulator, outputValue,
                 "Recorded the probability of reaching sample task " + task.id() + " with the current configuration.");
-        compilationCtx.addTreeToScope(task.scope(), sample);
+        info.compilationCtx.addTreeToScope(task.scope(), sample);
     }
 
     @Override
     protected <C extends ScalarVariable<C>, D extends ScalarVariable<D>> void getDeterministicObservationToConditionalIR(
-            IRTreeReturn<C> current, ScalarVariable<D> input, FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
-        IRTreeReturn<D> inputValue = input.getForwardIR(compilationCtx);
+            IRTreeReturn<C> current, ScalarVariable<D> input, FuncData funcData, TreeBuilderInfo info) {
+        IRTreeReturn<D> inputValue = input.getForwardIR(funcData.compilationCtx);
         IRTreeReturn<BooleanVariable> guard = IRTree.eq(current, inputValue);
         IRTreeVoid recordValid = TreeUtils.lseAdd(load(consumerSampleProbabilitiesAccumulator), log(info.probability),
                 consumerSampleProbabilitiesAccumulator, "Record if the conditional is valid.");
         IRTreeVoid condition = IRTree.ifElse(guard, recordValid, "Check observed variable is possible");
-        compilationCtx.addTreeToScope(GlobalScope.scope, condition);
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, condition);
 
         IRTreeReturn<DoubleVariable> outputValue = subtractDD(load(consumerSampleDistributionProbabilityAccumulator),
                 info.probability);
         IRTreeVoid sample = store(consumerSampleDistributionProbabilityAccumulator, outputValue,
                 "Recorded the probability of reaching branch with the current configuration.");
-        compilationCtx.addTreeToScope(GlobalScope.scope, sample);
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, sample);
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorBase.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorBase.java
@@ -99,6 +99,8 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
         // TODO work out if we can make this a private variable of the parent class.
         public final ScopeConstructor targetScope;
 
+        public final CompilationContext compilationCtx;
+
         /**
          *
          * @param sampleDesc
@@ -134,6 +136,8 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
             this.sampleUpdated = sampleUpdated;
 
             targetScope = constructTargetScope(compilationCtx);
+
+            this.compilationCtx = compilationCtx;
         }
 
         private ScopeConstructor constructTargetScope(CompilationContext compilationCtx) {
@@ -192,7 +196,7 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
 
             // If there are no traces return the current target scope
             if(observationTraces == null) {
-                initializeConstrainedFlags(targetScope, compilationCtx);
+                initializeConstrainedFlags(targetScope);
                 return targetScope;
             }
 
@@ -221,11 +225,11 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
             return observationScopes.ifScopeConstructor();
         }
 
-        private void initializeConstrainedFlags(ScopeConstructor targetScope, CompilationContext compilationCtx) {
+        private void initializeConstrainedFlags(ScopeConstructor targetScope) {
             targetScope.addTree((TreeBuilderInfo info) -> {
                 IRTreeVoid t = TreeUtils.setIsConstrained(sampleDesc.sample, constant(false), IRTree.NoComment,
-                        compilationCtx);
-                compilationCtx.addTreeToScope(GlobalScope.scope, t);
+                        info.compilationCtx);
+                info.compilationCtx.addTreeToScope(GlobalScope.scope, t);
             });
         }
 
@@ -234,13 +238,13 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
             observationScopes.ifScopeConstructor().addTree((TreeBuilderInfo info) -> {
                 IRTreeVoid t = TreeUtils.setIsConstrained(sampleDesc.sample, constant(false), IRTree.NoComment,
                         compilationCtx);
-                compilationCtx.addTreeToScope(GlobalScope.scope, t);
+                info.compilationCtx.addTreeToScope(GlobalScope.scope, t);
             });
 
             observationScopes.elseScopeConstructor().addTree((TreeBuilderInfo info) -> {
                 IRTreeVoid t = TreeUtils.setIsConstrained(sampleDesc.sample, constant(true), IRTree.NoComment,
                         compilationCtx);
-                compilationCtx.addTreeToScope(GlobalScope.scope, t);
+                info.compilationCtx.addTreeToScope(GlobalScope.scope, t);
             });
         }
 
@@ -278,12 +282,12 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
         FuncData funcData = getFunctionData(sample, compilationCtx);
 
         // Add any constructors before we start restructuring scopes.
-        allocateGlobalStateInternal(compilationCtx, funcData);
+        allocateGlobalStateInternal(funcData);
 
         // Clear the context ready to start
-        constructFunctionVariablesInternal(funcData, compilationCtx);
+        constructFunctionVariablesInternal(funcData);
 
-        getBackTraceScope(funcData, compilationCtx).addTree((TreeBuilderInfo outerInfo) -> {
+        getBackTraceScope(funcData).addTree((TreeBuilderInfo outerInfo) -> {
             ScopeConstructor a = ScopeConstructor.construct(funcData.sampleDesc.sample, GlobalScope.scope,
                     funcData.distributionTraces,
                     "Exploring all the possible distribution values for random variable "
@@ -293,12 +297,11 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
 
             a = a.addFixedFlag(funcData.sampleDesc.sample, false);
 
-            a.addTree((TreeBuilderInfo info) -> backTraceScopeStartIR(funcData, info, compilationCtx));
+            a.addTree((TreeBuilderInfo info) -> backTraceScopeStartIR(funcData, info));
 
             { // Handle all the normal samples
                 ScopeConstructor sourceDisArgs = a.applyAllDistributedArguments();
-                sourceDisArgs.addTree(0,
-                        (TreeBuilderInfo info) -> getPerSourceConfigStartIR(funcData, info, compilationCtx));
+                sourceDisArgs.addTree(0, (TreeBuilderInfo info) -> getPerSourceConfigStartIR(funcData, info));
 
                 // For each random variable that consumes the results of this sample.
                 for(RandomVariable<?, ?> consumingRV:funcData.consumingRVs) {
@@ -327,11 +330,11 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                                 else
                                     ifGuard = constant(false);
                                 IfElseScopeConstructors ifsc = b.addCondition(ifGuard);
-                                processSample(s, consumingRV, ifsc.ifScopeConstructor(), groupedTraces.get(s), funcData,
-                                        compilationCtx);
+                                processSample(s, consumingRV, ifsc.ifScopeConstructor(), groupedTraces.get(s),
+                                        funcData);
                             }
                         } else {
-                            processSample(s, consumingRV, b, groupedTraces.get(s), funcData, compilationCtx);
+                            processSample(s, consumingRV, b, groupedTraces.get(s), funcData);
                         }
                     }
                 }
@@ -352,14 +355,14 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                         Map<DataflowTaskArgDesc, Set<TraceHandle>> sinkToConditional = splitTraces.sinkToConditional
                                 .get(sinkTask);
                         if(sink.isObserved()) {
-                            c.addTree((TreeBuilderInfo info) -> getPerConsumerStartIR(funcData, info, compilationCtx));
+                            c.addTree((TreeBuilderInfo info) -> getPerConsumerStartIR(funcData, info));
                             // Handle observed outputs.
                             for(DataflowTaskArgDesc d:sinkToConditional.keySet()) {
                                 ScalarVariable<?> input = (ScalarVariable<?>) d.task.getInput(d.argPos);
                                 if(input.isDeterministic()) {
                                     // input is deterministic, so can be recovered directly.
                                     processObservedDeterministicConditional(sink, sinkToConditional.get(d), input,
-                                            funcData, c, compilationCtx);
+                                            funcData, c);
                                 } else {
                                     // Input will need to be inverted for a calculation with the source random variable
                                     // There currently can only be one random variable in this scenario.
@@ -367,7 +370,7 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                                             "This code is part of the feature to observe outputs from conditionals. It is not yet fully implemented.");
                                 }
                             }
-                            c.addTree((TreeBuilderInfo info) -> getPerConsumerEndIR(funcData, info, compilationCtx));
+                            c.addTree((TreeBuilderInfo info) -> getPerConsumerEndIR(funcData, info));
                         } else {
                             for(DataflowTaskArgDesc branchPointDesc:sinkToConditional.keySet()) {
                                 // Handle RV consumer
@@ -393,11 +396,10 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                                                 ifGuard = constant(false);
                                             IfElseScopeConstructors ifsc = consumerSC.addCondition(ifGuard);
                                             processSample(s, consumingRV, ifsc.ifScopeConstructor(),
-                                                    groupedTraces.get(s), funcData, compilationCtx);
+                                                    groupedTraces.get(s), funcData);
                                         }
                                     } else {
-                                        processSample(s, consumingRV, consumerSC, groupedTraces.get(s), funcData,
-                                                compilationCtx);
+                                        processSample(s, consumingRV, consumerSC, groupedTraces.get(s), funcData);
                                     }
                                 }
 
@@ -419,8 +421,8 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                                                     + " of consumer random variable " + sourceRV.getAlias() + ".")
                                             .addConstraint(sampleTrace);
 
-                                    sourceSC.addTree(2, (TreeBuilderInfo info) -> getPerConsumerStartIR(funcData, info,
-                                            compilationCtx));
+                                    sourceSC.addTree(2,
+                                            (TreeBuilderInfo info) -> getPerConsumerStartIR(funcData, info));
 
                                     ScopeConstructor dConsumerAllArgs = sourceSC.applyAllDistributedArguments();
                                     /*
@@ -439,7 +441,7 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                                          * expectation that the optimisation phase can move shared values out where
                                          * appropriate.
                                          */
-                                        getConsumerRVInputIR(info, sourceRV, funcData, compilationCtx);
+                                        getConsumerRVInputIR(info, sourceRV, funcData);
 
                                         Trace trace = sampleTrace.getTrace();
 
@@ -464,19 +466,17 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                                                     + end.endLine);
                                         }
 
-                                        getObservationToSampleIR(source, current, funcData, info, compilationCtx);
+                                        getObservationToSampleIR(source, current, funcData, info);
                                     });
 
-                                    sourceSC.addTree(2, (TreeBuilderInfo info) -> getPerConsumerEndIR(funcData, info,
-                                            compilationCtx));
+                                    sourceSC.addTree(2, (TreeBuilderInfo info) -> getPerConsumerEndIR(funcData, info));
                                 }
                             }
                         }
                     }
                 }
 
-                sourceDisArgs.addTree(0,
-                        (TreeBuilderInfo info) -> getPerSourceConfigEndIR(funcData, info, compilationCtx));
+                sourceDisArgs.addTree(0, (TreeBuilderInfo info) -> getPerSourceConfigEndIR(funcData, info));
             }
 
             { // Handle all the distributed samples
@@ -509,7 +509,7 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                         for(DistributionSampleTask<?, ?> ds:tasks) {
                             if(ds == sample) // If the distributed sample is the same as the sample we know it is not
                                 // fixed, otherwise we have to test.
-                                processDistributionSample(ds, consumingRV, b, funcData, compilationCtx);
+                                processDistributionSample(ds, consumingRV, b, funcData);
                             else {
                                 IRTreeReturn<BooleanVariable> ifGuard;
                                 if(compilationCtx.traces.getFixableTasks().contains(ds))
@@ -517,28 +517,27 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                                 else
                                     ifGuard = constant(true);
                                 IfElseScopeConstructors ifsc = b.addCondition(ifGuard);
-                                processDistributionSample(ds, consumingRV, ifsc.ifScopeConstructor(), funcData,
-                                        compilationCtx);
+                                processDistributionSample(ds, consumingRV, ifsc.ifScopeConstructor(), funcData);
                             }
                         }
                     }
                 }
             }
 
-            a.addTree((TreeBuilderInfo info) -> backTraceScopeEndIR(funcData, info, compilationCtx));
+            a.addTree((TreeBuilderInfo info) -> backTraceScopeEndIR(funcData, info));
         });
 
-        finalize(funcData, compilationCtx);
+        finalize(funcData);
 
         {
             // Construct sample value and all the intermediate variables.
-            ScopeConstructor targetScope = getSampleTaskScope(funcData, compilationCtx);
+            ScopeConstructor targetScope = getSampleTaskScope(funcData);
             if(funcData.sampleDesc.sample.isDistribution()) {
 
-                addDistributionProbabilities(targetScope, funcData, compilationCtx);
+                addDistributionProbabilities(targetScope, funcData);
             } else {
                 targetScope.addTree((TreeBuilderInfo info) -> {
-                    addSampleValueTree(funcData, compilationCtx);
+                    addSampleValueTree(funcData);
                 });
             }
         }
@@ -567,14 +566,14 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                 functionArgs, result, comment, knownValues);
     }
 
-    protected ScopeConstructor getSampleTaskScope(FuncData funcData, CompilationContext compilationCtx) {
+    protected ScopeConstructor getSampleTaskScope(FuncData funcData) {
         IRTreeReturn<BooleanVariable> constrainedGuard = TreeUtils.getIsConstrained(funcData.sampleDesc.sample,
-                compilationCtx);
+                funcData.compilationCtx);
         return funcData.targetScope.addCondition(constrainedGuard).ifScopeConstructor();
     }
 
     private void processSample(SampleTask<?, ?> s, RandomVariable<?, ?> consumer, ScopeConstructor b,
-            Set<TraceHandle> observationTraces, FuncData funcData, CompilationContext compilationCtx) {
+            Set<TraceHandle> observationTraces, FuncData funcData) {
         /*
          * Construct the trace from the RV to the sample. TODO if we go to having RVs as part of arrays then we need
          * capture this trace in the Traces object and get it by querying.
@@ -587,32 +586,32 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
         // Record if the consuming sample task is constrained.
         c.addTree((TreeBuilderInfo info) -> {
             IRTreeVoid setFlag;
-            if(compilationCtx.traces.getFixableTasks().contains(s))
+            if(info.compilationCtx.traces.getFixableTasks().contains(s))
                 setFlag = initializeVariable(constrained,
-                        or(load(VariableNames.fixedFlagName(s)), TreeUtils.getIsConstrained(s, compilationCtx)),
+                        or(load(VariableNames.fixedFlagName(s)), TreeUtils.getIsConstrained(s, info.compilationCtx)),
                         "Flag recording if this sample task of the consuming random variable is constrained.");
             else
-                setFlag = initializeVariable(constrained, TreeUtils.getIsConstrained(s, compilationCtx),
+                setFlag = initializeVariable(constrained, TreeUtils.getIsConstrained(s, info.compilationCtx),
                         "Flag recording if this sample task of the consuming random variable is constrained.");
-            compilationCtx.addTreeToScope(GlobalScope.scope, setFlag);
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, setFlag);
         });
 
         // Add a condition so the task is only processed if it is constrained.
         IfElseScopeConstructors constrainedCondition = c.addCondition(load(constrained));
         c = constrainedCondition.ifScopeConstructor();
 
-        processConstrainedSample(c, consumer, observationTraces, funcData, compilationCtx);
+        processConstrainedSample(c, consumer, observationTraces, funcData);
     }
 
     private void processConstrainedSample(ScopeConstructor c, RandomVariable<?, ?> consumer,
-            Set<TraceHandle> observationTraces, FuncData funcData, CompilationContext compilationCtx) {
+            Set<TraceHandle> observationTraces, FuncData funcData) {
         c.addTree(0, (TreeBuilderInfo info) -> {
             IRTreeVoid t = TreeUtils.setIsConstrained(funcData.sampleDesc.sample, constant(true),
-                    "Mark that the sample has observed constrained data.", compilationCtx);
-            compilationCtx.addTreeToScope(GlobalScope.scope, t);
+                    "Mark that the sample has observed constrained data.", info.compilationCtx);
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, t);
         });
 
-        c.addTree((TreeBuilderInfo info) -> getPerConsumerStartIR(funcData, info, compilationCtx));
+        c.addTree((TreeBuilderInfo info) -> getPerConsumerStartIR(funcData, info));
 
         ScopeConstructor dConsumerAllArgs = c.applyAllDistributedArguments();
 
@@ -622,21 +621,21 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
              * operations, or to an observed value so is not allowed to be a distribution. It does need to have a
              * constraint on the trace though to make sure the trace is valid.
              */
-            getInverseIR(h, consumer, funcData, dConsumerAllArgs, compilationCtx);
+            getInverseIR(h, consumer, funcData, dConsumerAllArgs);
 
-        c.addTree((TreeBuilderInfo info) -> getPerConsumerEndIR(funcData, info, compilationCtx));
+        c.addTree((TreeBuilderInfo info) -> getPerConsumerEndIR(funcData, info));
     }
 
     private void processObservedDeterministicConditional(Variable<?> sink, Set<TraceHandle> observationTraces,
-            ScalarVariable<?> input, FuncData funcData, ScopeConstructor b, CompilationContext compilationCtx) {
+            ScalarVariable<?> input, FuncData funcData, ScopeConstructor b) {
         ScopeConstructor c = b.addComment("Processing observed variable " + sink.getAlias());
         c = c.applyAllDistributedArguments();
         for(TraceHandle h:observationTraces)
-            getInverseIR(h, sink, input, funcData, c, compilationCtx);
+            getInverseIR(h, sink, input, funcData, c);
     }
 
     private <C extends ScalarVariable<C>> void getInverseIR(TraceHandle h, Variable<?> sink, ScalarVariable<?> input,
-            FuncData funcData, ScopeConstructor sc, CompilationContext compilationCtx) {
+            FuncData funcData, ScopeConstructor sc) {
         sc = sc.addConstraint(h);
         sc.addTree((TreeBuilderInfo info) -> {
             Trace trace = h.getTrace();
@@ -644,14 +643,14 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
             DataflowTaskArgDesc d = trace.pop();
             ProducingDataflowTask<?> t = d.task;
 
-            IRTreeReturn<?> current = sink.getForwardIR(compilationCtx);
+            IRTreeReturn<?> current = sink.getForwardIR(funcData.compilationCtx);
 
             while(!trace.isEmpty()) {
-                current = t.getInverseIR(d.argPos, current, info.backTraceInfo, compilationCtx);
+                current = t.getInverseIR(d.argPos, current, info.backTraceInfo, funcData.compilationCtx);
                 d = trace.pop();
                 t = d.task;
             }
-            current = t.getInverseIR(d.argPos, current, info.backTraceInfo, compilationCtx);
+            current = t.getInverseIR(d.argPos, current, info.backTraceInfo, funcData.compilationCtx);
 
             if(info.backTraceInfo.noGetValues() != 0) {
                 Location start = h.get(0).task.getLocation();
@@ -660,14 +659,13 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                         + start.startLine + " through to line " + end.endLine);
             }
 
-            getDeterministicObservationToConditionalIR((IRTreeReturn<C>) current, input, funcData, info,
-                    compilationCtx);
+            getDeterministicObservationToConditionalIR((IRTreeReturn<C>) current, input, funcData, info);
         });
 
     }
 
     private void processDistributionSample(DistributionSampleTask<?, ?> s, RandomVariable<?, ?> consumer,
-            ScopeConstructor b, FuncData funcData, CompilationContext compilationCtx) {
+            ScopeConstructor b, FuncData funcData) {
         /*
          * Construct the trace from the RV to the sample. TODO if we go to having RVs as part of arrays then we need
          * capture this trace in the Traces object and get it by querying.
@@ -677,18 +675,18 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                 "Processing sample task " + s.id() + " of consumer random variable " + consumer.getAlias() + ".")
                 .addConstraint(th);
 
-        c.addTree((TreeBuilderInfo info) -> getPerDistributedSampleStartIR(funcData, s, info, compilationCtx));
+        c.addTree((TreeBuilderInfo info) -> getPerDistributedSampleStartIR(funcData, s, info));
 
         ScopeConstructor dConsumerAllArgs = c.applyDistributedArguments(1).applyDistributedArguments(2);
 
         VariableDescription<DoubleVariable> reachedSourceName = VariableNames.scopeVarName("reachedSourceProbability",
                 VariableType.DoubleVariable);
-        dConsumerAllArgs.addTree((TreeBuilderInfo info) -> compilationCtx.addTreeToScope(GlobalScope.scope,
+        dConsumerAllArgs.addTree((TreeBuilderInfo info) -> info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(reachedSourceName, constant(0.0),
                         "Declare and zero an accumulator for tracking the reached source probability space.")));
 
         ScopeConstructor dSourceAllArgs = dConsumerAllArgs.resetProbabilities().applyDistributedArguments(0);
-        dSourceAllArgs.addTree((TreeBuilderInfo info) -> compilationCtx.addTreeToScope(GlobalScope.scope,
+        dSourceAllArgs.addTree((TreeBuilderInfo info) -> info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 store(reachedSourceName, addDD(load(reachedSourceName), info.probability),
                         "Add the probability of this argument configuration.")));
 
@@ -702,12 +700,12 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
              * be distributions in the sample trace that is not possible, so it is placed here with the expectation that
              * the optimisation phase can move shared values out where appropriate.
              */
-            getConsumerRVInputIR(info, consumer, funcData, compilationCtx);
+            getConsumerRVInputIR(info, consumer, funcData);
             info.changeSubstitutions(constraintCount - 1);
-            getDistributionSampleIR(s, load(reachedSourceName), funcData, info, compilationCtx);
+            getDistributionSampleIR(s, load(reachedSourceName), funcData, info);
         });
 
-        c.addTree((TreeBuilderInfo info) -> getPerDistributedSampleEndIR(funcData, s, info, compilationCtx));
+        c.addTree((TreeBuilderInfo info) -> getPerDistributedSampleEndIR(funcData, s, info));
     }
 
     private TraceHandle getTraceRVToSample(SampleTask<?, ?> s, RandomVariable<?, ?> rv) {
@@ -717,49 +715,40 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
         return TraceHandle.getTraceHandle(t);
     }
 
-    protected abstract void backTraceScopeStartIR(FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx);
+    protected abstract void backTraceScopeStartIR(FuncData funcData, TreeBuilderInfo info);
 
-    protected abstract void backTraceScopeEndIR(FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx);
+    protected abstract void backTraceScopeEndIR(FuncData funcData, TreeBuilderInfo info);
 
-    protected abstract void finalize(FuncData funcData, CompilationContext compilationCtx);
+    protected abstract void finalize(FuncData funcData);
 
-    protected abstract void addDistributionProbabilities(ScopeConstructor targetScope, FuncData funcData,
-            CompilationContext compilationCtx);
+    protected abstract void addDistributionProbabilities(ScopeConstructor targetScope, FuncData funcData);
 
     protected abstract String getInferenceType();
 
-    protected abstract ScopeConstructor getBackTraceScope(FuncData funcData, CompilationContext compilationCtx);
+    protected abstract ScopeConstructor getBackTraceScope(FuncData funcData);
 
     protected abstract void getDistributionSampleIR(DistributionSampleTask<?, ?> s,
-            IRTreeReturn<DoubleVariable> sourceProbability, FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx);
+            IRTreeReturn<DoubleVariable> sourceProbability, FuncData funcData, TreeBuilderInfo info);
 
-    protected abstract void getPerSourceConfigStartIR(FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx);
+    protected abstract void getPerSourceConfigStartIR(FuncData funcData, TreeBuilderInfo info);
 
-    protected abstract void getPerSourceConfigEndIR(FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx);
+    protected abstract void getPerSourceConfigEndIR(FuncData funcData, TreeBuilderInfo info);
 
-    protected abstract void getPerConsumerStartIR(FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx);
+    protected abstract void getPerConsumerStartIR(FuncData funcData, TreeBuilderInfo info);
 
-    protected abstract void getPerConsumerEndIR(FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx);
+    protected abstract void getPerConsumerEndIR(FuncData funcData, TreeBuilderInfo info);
 
     protected abstract void getPerDistributedSampleStartIR(FuncData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx);
+            TreeBuilderInfo info);
 
     protected abstract void getPerDistributedSampleEndIR(FuncData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx);
+            TreeBuilderInfo info);
 
-    protected abstract void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer, FuncData funcData,
-            CompilationContext compilationCtx);
+    protected abstract void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer,
+            FuncData funcData);
 
     protected abstract <C extends ScalarVariable<C>, D extends ScalarVariable<D>> void getDeterministicObservationToConditionalIR(
-            IRTreeReturn<C> current, ScalarVariable<D> input, FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx);
+            IRTreeReturn<C> current, ScalarVariable<D> input, FuncData funcData, TreeBuilderInfo info);
 
     private void addTraces(Map<SampleTask<?, ?>, Set<TraceHandle>> groupedTraces, List<TraceHandle> traces) {
         for(TraceHandle t:traces) {
@@ -771,9 +760,9 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
 
     // This method takes a scope constructor as it might not always be applied to the target scope. In MH it will be
     // needed to both set and revert the sample value
-    protected abstract void addSampleValueTree(FuncData funcData, CompilationContext compilationCtx);
+    protected abstract void addSampleValueTree(FuncData funcData);
 
-    protected abstract void constructFunctionVariablesInternal(FuncData funcData, CompilationContext compilationCtx);
+    protected abstract void constructFunctionVariablesInternal(FuncData funcData);
 
     /**
      * Method to get the inverse intermediate representation tree.
@@ -784,7 +773,7 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
      * @param compilationCtx The compilation context for this compilation process.
      */
     private <X extends Variable<X>> void getInverseIR(TraceHandle traceHandle, RandomVariable<?, ?> consumer,
-            FuncData funcData, ScopeConstructor sc, CompilationContext compilationCtx) {
+            FuncData funcData, ScopeConstructor sc) {
         if(TraceArrayRestrictions.restrictionRequired(traceHandle))
             sc = sc.addComment("Check that the value can reach the sample task");
         sc = sc.addConstraint(traceHandle); // Constraint still added to maintain a predictable
@@ -803,7 +792,7 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
              * be distributions in the sample trace that is not possible, so, it is placed here with the expectation
              * that the optimisation phase can move shared values out where appropriate.
              */
-            getConsumerRVInputIR(info, consumer, funcData, compilationCtx);
+            getConsumerRVInputIR(info, consumer, funcData);
 
             info.changeSubstitutions(constraintCount - 1);
             Trace trace = traceHandle.getTrace();
@@ -812,10 +801,10 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
             ProducingDataflowTask<?> t = d.task;
 
             Variable<?> v = t.getOutput();
-            IRTreeReturn<?> current = v.getForwardIR(compilationCtx);
+            IRTreeReturn<?> current = v.getForwardIR(info.compilationCtx);
 
             while(t.getType() != DFType.SAMPLE) {
-                current = t.getInverseIR(d.argPos, current, info.backTraceInfo, compilationCtx);
+                current = t.getInverseIR(d.argPos, current, info.backTraceInfo, info.compilationCtx);
                 d = trace.pop();
                 t = d.task;
             }
@@ -827,32 +816,33 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                         + start.startLine + " through to line " + end.endLine);
             }
 
-            getObservationToSampleIR(sTask, current, funcData, info, compilationCtx);
+            getObservationToSampleIR(sTask, current, funcData, info);
         });
     }
 
     protected abstract void getObservationToSampleIR(SampleTask<?, ?> task, IRTreeReturn<?> current, FuncData funcData,
-            TreeBuilderInfo info, CompilationContext compilationCtx);
+            TreeBuilderInfo info);
 
-    protected abstract void allocateGlobalStateInternal(CompilationContext compilationCtx, FuncData funcData);
+    protected abstract void allocateGlobalStateInternal(FuncData funcData);
 
     protected <V extends Variable<V>> void globalFieldAllocation(VariableDescription<V> fieldName,
-            IRTreeReturn<V> localAllocation, FunctionData<A, B, S> funcData, CompilationContext compilationCtx) {
+            IRTreeReturn<V> localAllocation, FunctionData<A, B, S> funcData) {
         List<Scope> scopes = funcData.sampleDesc.scopes;
         FunctionUtils.globalFieldAllocation(fieldName, localAllocation, funcData.isSerial,
-                scopes.get(scopes.size() - 1), compilationCtx);
+                scopes.get(scopes.size() - 1), funcData.compilationCtx);
     }
 
     protected <V extends Variable<V>> void createGlobalField(VariableDescription<V> fieldName, IRTreeVoid allocator,
-            FunctionData<A, B, S> funcData, CompilationContext compilationCtx) {
+            FunctionData<A, B, S> funcData) {
         List<Scope> scopes = funcData.sampleDesc.scopes;
         FunctionUtils.createGlobalField(fieldName, allocator, funcData.isSerial, scopes.get(scopes.size() - 1),
-                compilationCtx);
+                funcData.compilationCtx);
     }
 
     protected <V extends Variable<V>> IRTreeReturn<V> loadGlobalField(VariableDescription<V> varDesc,
-            FunctionData<A, B, S> funcData, CompilationContext compilationCtx) {
+            FunctionData<A, B, S> funcData) {
         List<Scope> scopes = funcData.sampleDesc.scopes;
-        return FunctionUtils.loadGlobalField(varDesc, funcData.isSerial, scopes.get(scopes.size() - 1), compilationCtx);
+        return FunctionUtils.loadGlobalField(varDesc, funcData.isSerial, scopes.get(scopes.size() - 1),
+                funcData.compilationCtx);
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorScalar.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorScalar.java
@@ -1,7 +1,7 @@
 /*
  * Sandwood
  *
- * Copyright (c) 2019-2025, Oracle and/or its affiliates
+ * Copyright (c) 2019-2026, Oracle and/or its affiliates
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
@@ -29,29 +29,29 @@ public abstract class InferenceGeneratorScalar<A extends ScalarVariable<A>, B ex
     }
 
     @Override
-    protected void addSampleValueTree(FuncData funcData, CompilationContext compilationCtx) {
-        IRTreeReturn<A> sampleValue = calculateSampleValue(compilationCtx, funcData);
-        funcData.sampleDesc.updateSample(sampleValue, compilationCtx);
+    protected void addSampleValueTree(FuncData funcData) {
+        IRTreeReturn<A> sampleValue = calculateSampleValue(funcData);
+        funcData.sampleDesc.updateSample(sampleValue, funcData.compilationCtx);
     }
 
-    protected abstract IRTreeReturn<A> calculateSampleValue(CompilationContext compilationCtx, FuncData funcData);
+    protected abstract IRTreeReturn<A> calculateSampleValue(FuncData funcData);
 
     // Methods passing through to the subclasses. this provides a point where we can add in code that should be executed
     // for all scalar values, but not for arrays.
     @Override
-    protected void allocateGlobalStateInternal(CompilationContext compilationCtx, FuncData funcData) {
-        CompilationPhase phase = compilationCtx.phase;
-        compilationCtx.phase = CompilationPhase.ALLOCATION;
-        allocateGlobalState(compilationCtx, funcData);
-        compilationCtx.phase = phase;
+    protected void allocateGlobalStateInternal(FuncData funcData) {
+        CompilationPhase phase = funcData.compilationCtx.phase;
+        funcData.compilationCtx.phase = CompilationPhase.ALLOCATION;
+        allocateGlobalState(funcData);
+        funcData.compilationCtx.phase = phase;
     }
 
-    protected abstract void allocateGlobalState(CompilationContext compilationCtx, FuncData funcData);
+    protected abstract void allocateGlobalState(FuncData funcData);
 
     @Override
-    protected void constructFunctionVariablesInternal(FuncData funcData, CompilationContext compilationCtx) {
-        constructFunctionVariables(funcData, compilationCtx);
+    protected void constructFunctionVariablesInternal(FuncData funcData) {
+        constructFunctionVariables(funcData);
     }
 
-    protected abstract void constructFunctionVariables(FuncData funcData, CompilationContext compilationCtx);
+    protected abstract void constructFunctionVariables(FuncData funcData);
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorScalarProb.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorScalarProb.java
@@ -182,10 +182,10 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
     private boolean canSetCurrent = false;
 
     @Override
-    protected void constructFunctionVariables(FuncData funcData, CompilationContext compilationCtx) {
+    protected void constructFunctionVariables(FuncData funcData) {
         // TODO update this so that it just recovers the maximum number of states from the random variable.
-        funcData.targetScope.addTree((TreeBuilderInfo) -> {
-            compilationCtx.addTreeToScope(GlobalScope.scope,
+        funcData.targetScope.addTree((TreeBuilderInfo info) -> {
+            info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     initializeVariable(numStatesName, constant(0), "Calculate the number of states to evaluate."));
         });
 
@@ -199,20 +199,20 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
         }
 
         internal.addTree((TreeBuilderInfo info) -> {
-            compilationCtx.addTreeToScope(GlobalScope.scope, store(numStatesName,
-                    max(load(numStatesName), funcData.noStates.getForwardIR(compilationCtx)), getInferenceType()));
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, store(numStatesName,
+                    max(load(numStatesName), funcData.noStates.getForwardIR(info.compilationCtx)), getInferenceType()));
         });
 
         funcData.targetScope.addTree((TreeBuilderInfo info) -> {
-            constructFunctionVariablesProb(compilationCtx, funcData);
+            constructFunctionVariablesProb(funcData);
         });
 
         currentValueName = VariableNames.calcVarName("currentValue", funcData.sampleDesc.output.getType(), true);
         currentValue = Variable.namedVariable(currentValueName);
-        compilationCtx.addSubstitute(funcData.sampleDesc.output, currentValue);
+        funcData.compilationCtx.addSubstitute(funcData.sampleDesc.output, currentValue);
     }
 
-    protected abstract void constructFunctionVariablesProb(CompilationContext compilationCtx, FuncData funcData);
+    protected abstract void constructFunctionVariablesProb(FuncData funcData);
 
     protected IRTreeVoid setCurrentValue(IRTreeReturn<A> value, String comment) {
         if(!canSetCurrent)
@@ -226,39 +226,39 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
 
     @Override
     protected void getPerDistributedSampleStartIR(FuncData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {
+            TreeBuilderInfo info) {
         DistributableRandomVariable<?, ?> disRV = s.randomVariable;
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(consumerSampleDistributionAccumulator,
-                        loadGlobalField(globalDistributionScratchSpace.get(disRV), funcData, compilationCtx),
+                        loadGlobalField(globalDistributionScratchSpace.get(disRV), funcData),
                         "A local array to hold the accumulated distributions of "
                                 + "the sample tasks for each configuration of distributions."));
 
         VariableDescription<IntVariable> indexName = VariableNames.calcVarName("i", VariableType.IntVariable, true);
         IRTreeVoid body = arrayPut(load(consumerSampleDistributionAccumulator), load(indexName), constant(0.0),
                 Tree.NoComment);
-        IRTreeVoid loop = IRTree.forStmt(body, constant(0), disRV.getNumStates().getForwardIR(compilationCtx),
+        IRTreeVoid loop = IRTree.forStmt(body, constant(0), disRV.getNumStates().getForwardIR(funcData.compilationCtx),
                 constant(1), indexName, true, "Zero all the elements in the distribution accumulator");
-        compilationCtx.addTreeToScope(GlobalScope.scope, loop);
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, loop);
 
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(reachedDistributions, constant(0.0),
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(reachedDistributions, constant(0.0),
                 "Zero an accumulator to track the probabilities reached."));
     }
 
     @Override
-    protected void getPerDistributedSampleEndIR(FuncData funcData, DistributionSampleTask<?, ?> s, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+    protected void getPerDistributedSampleEndIR(FuncData funcData, DistributionSampleTask<?, ?> s,
+            TreeBuilderInfo info) {
         // Get a local copy of the sample distribution
         IRTreeReturn<ArrayVariable<DoubleVariable>> sampleDistribution = s.getProbabilitiesArray()
-                .getForwardIR(compilationCtx);
+                .getForwardIR(info.compilationCtx);
         VariableDescription<ArrayVariable<DoubleVariable>> sampleDescriptionName = VariableNames
                 .calcVarName("sampleDistribution", sampleDistribution.getOutputType(), true);
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(sampleDescriptionName, sampleDistribution,
-                "A local copy of the samples' distribution."));
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(sampleDescriptionName,
+                sampleDistribution, "A local copy of the samples' distribution."));
 
         VariableDescription<DoubleVariable> overlapName = VariableNames.calcVarName("overlap",
                 VariableType.DoubleVariable, true);
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(overlapName, constant(0.0), "The overlap of the distributions so far."));
 
         // Start constructing the body of the for loop
@@ -289,13 +289,13 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
         // the distribution.
         IRTreeVoid body = sequential(bodyStmts, Tree.NoComment);
         IRTreeVoid loop = IRTree.forStmt(body, constant(0),
-                s.randomVariable.getNumStates().getForwardIR(compilationCtx), constant(1), indexName, true,
+                s.randomVariable.getNumStates().getForwardIR(info.compilationCtx), constant(1), indexName, true,
                 "Calculate the overlap for each element in the distribution");
-        compilationCtx.addTreeToScope(GlobalScope.scope, loop);
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, loop);
 
         // Compute the ratio of the overlap that should be added with 1 being used
         // for the values that are unreachable.
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 store(distributionProbabilityAccumulator, addDD(load(distributionProbabilityAccumulator),
                         log(addDD(
                                 multiplyDD(load(overlapName), load(reachedDistributions)),
@@ -306,71 +306,71 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
     }
 
     @Override
-    protected void getPerConsumerStartIR(FuncData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+    protected void getPerConsumerStartIR(FuncData funcData, TreeBuilderInfo info) {
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(consumerSampleProbabilitiesAccumulator, constant(Double.NEGATIVE_INFINITY),
                         "Set an accumulator to sum the probabilities for each possible configuration " + "of inputs."));
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(consumerSampleDistributionProbabilityAccumulator, constant(1.0),
                         "Set an accumulator to record the consumer distributions not seen. Initially set "
                                 + "to 1 as seen values will be deducted from this value."));
     }
 
     @Override
-    protected void getPerConsumerEndIR(FuncData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+    protected void getPerConsumerEndIR(FuncData funcData, TreeBuilderInfo info) {
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 store(consumerSampleDistributionProbabilityAccumulator,
                         max(load(consumerSampleDistributionProbabilityAccumulator), constant(0.0)),
                         "A check to ensure rounding of floating point values can never result in a negative value."));
-        compilationCtx.addTreeToScope(GlobalScope.scope, TreeUtils.lseAdd(load(consumerSampleProbabilitiesAccumulator),
-                log(load(consumerSampleDistributionProbabilityAccumulator)), (IRTreeReturn<DoubleVariable> output) -> {
-                    return IRTree.store(probabilitiesAccumulator, addDD(output, load(probabilitiesAccumulator)),
-                            Tree.NoComment);
-                }, "Multiply (log space add) in the probability of the sample task to the overall "
-                        + "probability for this configuration of the source random variable."));
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
+                TreeUtils.lseAdd(load(consumerSampleProbabilitiesAccumulator),
+                        log(load(consumerSampleDistributionProbabilityAccumulator)),
+                        (IRTreeReturn<DoubleVariable> output) -> {
+                            return IRTree.store(probabilitiesAccumulator, addDD(output, load(probabilitiesAccumulator)),
+                                    Tree.NoComment);
+                        }, "Multiply (log space add) in the probability of the sample task to the overall "
+                                + "probability for this configuration of the source random variable."));
     }
 
     @Override
-    protected void backTraceScopeStartIR(FuncData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(statesProbabilityValue,
+    protected void backTraceScopeStartIR(FuncData funcData, TreeBuilderInfo info) {
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(statesProbabilityValue,
                 constant(Double.NEGATIVE_INFINITY), "Initialize the summed probabilities to 0."));
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(reachedDistributionsSource, constant(0.0),
-                "Initialize a counter to track the reached distributions."));
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(distributionProbabilityAccumulator,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(reachedDistributionsSource,
+                constant(0.0), "Initialize a counter to track the reached distributions."));
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(distributionProbabilityAccumulator,
                 constant(0.0),
                 "Initialize a log space accumulator to take the product of all the distribution probabilities."));
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeUnsetVariable(currentValueName, "The value currently being tested"));
 
         canSetCurrent = true;
-        setSampleValue(funcData, compilationCtx);
+        setSampleValue(funcData);
         canSetCurrent = false;
     }
 
-    protected abstract void setSampleValue(FuncData funcData, CompilationContext compilationCtx);
+    protected abstract void setSampleValue(FuncData funcData);
 
     @Override
-    protected void backTraceScopeEndIR(FuncData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
+    protected void backTraceScopeEndIR(FuncData funcData, TreeBuilderInfo info) {
         IRTreeReturn<DoubleVariable> value = addDD(
                 subtractDD(load(statesProbabilityValue), log(load(reachedDistributionsSource))),
                 load(distributionProbabilityAccumulator));
 
-        saveBackTraceProbability(funcData, value, compilationCtx);
+        saveBackTraceProbability(funcData, value);
     }
 
-    protected abstract void saveBackTraceProbability(FuncData funcData, IRTreeReturn<DoubleVariable> value,
-            CompilationContext compilationCtx);
+    protected abstract void saveBackTraceProbability(FuncData funcData, IRTreeReturn<DoubleVariable> value);
 
     @Override
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> s,
-            IRTreeReturn<DoubleVariable> sourceProbability, FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<DoubleVariable> sourceProbability, FuncData funcData, TreeBuilderInfo info) {
         VariableDescription<DoubleVariable> distributionProbability = VariableNames
                 .calcVarName("distributionProbability", VariableType.DoubleVariable, true);
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(distributionProbability, multiplyDD(sourceProbability, info.probability),
                         "The probability of reaching the consumer with this set of consumer arguments"));
-        compilationCtx.addTreeToScope(GlobalScope.scope, store(reachedDistributions,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, store(reachedDistributions,
                 addDD(load(reachedDistributions), load(distributionProbability)), "Record the reached distribution."));
 
         DistributableRandomVariable<?, ?> random = s.randomVariable;
@@ -380,43 +380,41 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
         args.add(load(distributionProbability));
         args.addAll(funcData.consumerRVArgs);
 
-        compilationCtx.addTreeToScope(GlobalScope.scope, functionCall(FunctionType.ADD_DISTRIBUTION, random.getType(),
-                "Add the current distribution to the distribution accumulator.", args));
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, functionCall(FunctionType.ADD_DISTRIBUTION,
+                random.getType(), "Add the current distribution to the distribution accumulator.", args));
     }
 
     @Override
-    protected void getPerSourceConfigStartIR(FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+    protected void getPerSourceConfigStartIR(FuncData funcData, TreeBuilderInfo info) {
         IRTreeVoid updateReachable = store(reachedDistributionsSource,
                 addDD(load(reachedDistributionsSource), info.probability), "Record the reached probability density.");
-        compilationCtx.addTreeToScope(GlobalScope.scope, updateReachable);
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, updateReachable);
 
         // Initialize an accumulator for the probabilities.
-        IRTreeReturn<DoubleVariable> sampleProbability = getSourceValueProbability(funcData, compilationCtx);
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(probabilitiesAccumulator,
+        IRTreeReturn<DoubleVariable> sampleProbability = getSourceValueProbability(funcData);
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(probabilitiesAccumulator,
                 addDD(log(info.probability), sampleProbability),
                 "An accumulator to allow the value for each distribution to be constructed before it is added to the index probabilities."));
     }
 
-    private IRTreeReturn<DoubleVariable> getSourceValueProbability(FuncData funcData,
-            CompilationContext compilationCtx) {
-        List<IRTreeReturn<?>> args = constructArguments(funcData.sourceRandom, compilationCtx, getCurrentValue());
+    private IRTreeReturn<DoubleVariable> getSourceValueProbability(FuncData funcData) {
+        List<IRTreeReturn<?>> args = constructArguments(funcData.sourceRandom, funcData.compilationCtx,
+                getCurrentValue());
         IRTreeReturn<DoubleVariable> sampleProbability = functionCallReturn(FunctionType.LOG_PROBABILITY,
                 VariableType.DoubleVariable, funcData.sourceRandom.getType(), args);
         return sampleProbability;
     }
 
     @Override
-    protected void getPerSourceConfigEndIR(FuncData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
-        compilationCtx.addTreeToScope(GlobalScope.scope, TreeUtils.lseAdd(load(statesProbabilityValue),
+    protected void getPerSourceConfigEndIR(FuncData funcData, TreeBuilderInfo info) {
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, TreeUtils.lseAdd(load(statesProbabilityValue),
                 load(probabilitiesAccumulator), statesProbabilityValue,
                 "Add the values for the source and any standard consumers for this configuration of arguments to the source."));
     }
 
     @Override
-    protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer, FuncData funcData,
-            CompilationContext compilationCtx) {
-        funcData.consumerRVArgs = constructArguments(consumer, compilationCtx);
+    protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer, FuncData funcData) {
+        funcData.consumerRVArgs = constructArguments(consumer, info.compilationCtx);
     }
 
     protected List<IRTreeReturn<?>> constructArguments(RandomVariable<?, ?> random, CompilationContext compilationCtx,
@@ -456,8 +454,8 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
     }
 
     @Override
-    protected void finalize(FuncData funcData, CompilationContext compilationCtx) {
-        compilationCtx.removeSubstitute(funcData.sampleDesc.output);
+    protected void finalize(FuncData funcData) {
+        funcData.compilationCtx.removeSubstitute(funcData.sampleDesc.output);
     }
 
     /**
@@ -468,7 +466,7 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
      * 
      */
     @Override
-    protected ScopeConstructor getBackTraceScope(FuncData funcData, CompilationContext compilationCtx) {
+    protected ScopeConstructor getBackTraceScope(FuncData funcData) {
         ScopeConstructor target = funcData.targetScope.addForLoop(Variable.intVariable(0),
                 Variable.namedVariable(numStatesName), Variable.intVariable(1), valuePosName, Tree.NoComment, true);
         SampleTask<A, B> sample = funcData.sampleDesc.sample;
@@ -481,7 +479,7 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
 
     // No global state is required.
     @Override
-    protected void allocateGlobalState(CompilationContext compilationCtx, FuncData funcData) {
+    protected void allocateGlobalState(FuncData funcData) {
         for(RandomVariable<?, ?> rv:funcData.consumingRVs) {
             for(DataflowTask<?> d:rv.getConsumers()) {
                 if(((SampleTask<?, ?>) d).isDistribution()) {
@@ -491,45 +489,44 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
                     VariableDescription<ArrayVariable<DoubleVariable>> disAccumulatorName = getDistributionAccumulatorName(
                             disRV);
                     globalDistributionScratchSpace.put(disRV, disAccumulatorName);
-                    allocateGlobalArray(compilationCtx, funcData, disRV, disAccumulatorName);
+                    allocateGlobalArray(funcData, disRV, disAccumulatorName);
                     break;
                 }
             }
         }
 
-        allocateGlobalStateProb(funcData, compilationCtx);
+        allocateGlobalStateProb(funcData);
     }
 
-    protected abstract void allocateGlobalStateProb(FuncData funcData, CompilationContext compilationCtx);
+    protected abstract void allocateGlobalStateProb(FuncData funcData);
 
-    protected <C extends Variable<C>> void allocateGlobalArray(CompilationContext compilationCtx, FuncData funcData,
-            DistributableRandomVariable<?, ?> rv, VariableDescription<ArrayVariable<C>> variableDescription) {
+    protected <C extends Variable<C>> void allocateGlobalArray(FuncData funcData, DistributableRandomVariable<?, ?> rv,
+            VariableDescription<ArrayVariable<C>> variableDescription) {
         // Allocate space for storing the results.
-        compilationCtx.pushScopeState();
+        funcData.compilationCtx.pushScopeState();
         /*
          * Because of the reuse of max this needs to be serial. We could overcome this by taking a copy of the value of
          * max in a new in, but as I am not sure that parallel allocation is a beneficial, for now we will make this
          * serial and skip any overhead.
          */
-        compilationCtx.pushIsSerial(true);
+        funcData.compilationCtx.pushIsSerial(true);
 
         // Update phase
-        CompilationPhase currentPhase = compilationCtx.phase;
-        compilationCtx.phase = CompilationPhase.ALLOCATION;
+        CompilationPhase currentPhase = funcData.compilationCtx.phase;
+        funcData.compilationCtx.phase = CompilationPhase.ALLOCATION;
 
-        IRTreeReturn<IntVariable> noStates = rv.getMaxNoStates(compilationCtx);
+        IRTreeReturn<IntVariable> noStates = rv.getMaxNoStates(funcData.compilationCtx);
 
         // Allocate and store the largest value
-        globalFieldAllocation(variableDescription, newArray(noStates, variableDescription.type), funcData,
-                compilationCtx);
+        globalFieldAllocation(variableDescription, newArray(noStates, variableDescription.type), funcData);
         // Get the allocator
-        IRTreeVoid allocator = compilationCtx.getOutermostScopeTree();
+        IRTreeVoid allocator = funcData.compilationCtx.getOutermostScopeTree();
 
-        compilationCtx.phase = currentPhase;
-        compilationCtx.popIsSerial();
-        compilationCtx.popScopeState();
+        funcData.compilationCtx.phase = currentPhase;
+        funcData.compilationCtx.popIsSerial();
+        funcData.compilationCtx.popScopeState();
 
-        createGlobalField(variableDescription, allocator, funcData, compilationCtx);
+        createGlobalField(variableDescription, allocator, funcData);
     }
 
     /**
@@ -546,7 +543,7 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
 
     @Override
     protected void getObservationToSampleIR(SampleTask<?, ?> task, IRTreeReturn<?> current, FuncData funcData,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {
+            TreeBuilderInfo info) {
         List<IRTreeReturn<?>> args = new ArrayList<>();
         args.add(current);
         args.addAll(funcData.consumerRVArgs);
@@ -554,7 +551,7 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
                 VariableType.DoubleVariable, task.randomVariable.getType(), args);
 
         // Construct a tree to generate the probability, and save it to the sample accumulator.
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 TreeUtils.lseAdd(load(consumerSampleProbabilitiesAccumulator),
                         addDD(log(info.probability), sampleProbability), consumerSampleProbabilitiesAccumulator,
                         "Record the probability of sample task " + task.id()
@@ -564,24 +561,23 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
                 info.probability);
         IRTreeVoid sample = store(consumerSampleDistributionProbabilityAccumulator, outputValue,
                 "Recorded the probability of reaching sample task " + task.id() + " with the current configuration.");
-        compilationCtx.addTreeToScope(GlobalScope.scope, sample);
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, sample);
     }
 
     @Override
     protected <C extends ScalarVariable<C>, D extends ScalarVariable<D>> void getDeterministicObservationToConditionalIR(
-            IRTreeReturn<C> current, ScalarVariable<D> input, FuncData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
-        IRTreeReturn<D> inputValue = input.getForwardIR(compilationCtx);
+            IRTreeReturn<C> current, ScalarVariable<D> input, FuncData funcData, TreeBuilderInfo info) {
+        IRTreeReturn<D> inputValue = input.getForwardIR(info.compilationCtx);
         IRTreeReturn<BooleanVariable> guard = IRTree.eq(current, inputValue);
         IRTreeVoid recordValid = TreeUtils.lseAdd(load(consumerSampleProbabilitiesAccumulator), log(info.probability),
                 consumerSampleProbabilitiesAccumulator, "Record if the conditional is valid.");
         IRTreeVoid condition = IRTree.ifElse(guard, recordValid, "Check observed variable is possible");
-        compilationCtx.addTreeToScope(GlobalScope.scope, condition);
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, condition);
 
         IRTreeReturn<DoubleVariable> outputValue = subtractDD(load(consumerSampleDistributionProbabilityAccumulator),
                 info.probability);
         IRTreeVoid sample = store(consumerSampleDistributionProbabilityAccumulator, outputValue,
                 "Recorded the probability of reaching branch with the current configuration.");
-        compilationCtx.addTreeToScope(GlobalScope.scope, sample);
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, sample);
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/BetaToBernoulliBinomial.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/BetaToBernoulliBinomial.java
@@ -103,14 +103,13 @@ public class BetaToBernoulliBinomial
      * @return The intermediate tree representation of the method to infer a sample value.
      */
     @Override
-    protected IRTreeReturn<DoubleVariable> calculateSampleValue(CompilationContext compilationCtx,
-            BetaToBernoulliBinomialData funcData) {
+    protected IRTreeReturn<DoubleVariable> calculateSampleValue(BetaToBernoulliBinomialData funcData) {
         // TODO adjust this so it traces back to find the constructor, and get the
         // values
         // from them. This will allow arrays of random variables to be constructed.
         // Get the arguments constructed
-        IRTreeReturn<DoubleVariable> alphaArg = funcData.sourceRandom.alpha.getForwardIR(compilationCtx);
-        IRTreeReturn<DoubleVariable> betaArg = funcData.sourceRandom.beta.getForwardIR(compilationCtx);
+        IRTreeReturn<DoubleVariable> alphaArg = funcData.sourceRandom.alpha.getForwardIR(funcData.compilationCtx);
+        IRTreeReturn<DoubleVariable> betaArg = funcData.sourceRandom.beta.getForwardIR(funcData.compilationCtx);
 
         // Construct a tree to construct the sample variable.
         if(funcData.distributedConsumers)
@@ -130,20 +129,20 @@ public class BetaToBernoulliBinomial
      * @param funcData       The function data for this inference method constructor.
      */
     @Override
-    protected void constructFunctionVariables(BetaToBernoulliBinomialData funcData, CompilationContext compilationCtx) {
+    protected void constructFunctionVariables(BetaToBernoulliBinomialData funcData) {
         // add a trees to initialize the temporary variables.
         funcData.targetScope.addTree((TreeBuilderInfo info) -> {
             if(funcData.distributedConsumers) {
-                compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.noTrueNameDis,
+                info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.noTrueNameDis,
                         constant(0.0), "Local variable to record the number of true samples."));
 
-                compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.noTrialsNameDis,
-                        constant(0.0), "Local variable to record the number of samples."));
+                info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(
+                        funcData.noTrialsNameDis, constant(0.0), "Local variable to record the number of samples."));
             } else {
-                compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.noTrueName,
+                info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.noTrueName,
                         constant(0), "Local variable to record the number of true samples."));
 
-                compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.noTrialsName,
+                info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.noTrialsName,
                         constant(0), "Local variable to record the number of samples."));
             }
         });
@@ -151,12 +150,12 @@ public class BetaToBernoulliBinomial
 
     @Override
     protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer,
-            BetaToBernoulliBinomialData funcData, CompilationContext compilationCtx) {}
+            BetaToBernoulliBinomialData funcData) {}
 
     @SuppressWarnings("unchecked")
     @Override
     protected void getObservationToSampleIR(SampleTask<?, ?> task, IRTreeReturn<?> current,
-            BetaToBernoulliBinomialData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
+            BetaToBernoulliBinomialData funcData, TreeBuilderInfo info) {
 
         RandomVariableType<?, ?> type = task.randomVariable.getType();
         IRTreeVoid[] trees = new IRTreeVoid[2];
@@ -180,7 +179,7 @@ public class BetaToBernoulliBinomial
             if(funcData.distributedConsumers) {
                 trees[0] = store(funcData.noTrialsNameDis,
                         addDD(load(funcData.noTrialsNameDis),
-                                multiplyDI(info.probability, binomial.length.getForwardIR(compilationCtx))),
+                                multiplyDI(info.probability, binomial.length.getForwardIR(info.compilationCtx))),
                         "Increment the number of booleans sampled.");
                 trees[1] = store(funcData.noTrueNameDis,
                         addDD(load(funcData.noTrueNameDis),
@@ -188,7 +187,7 @@ public class BetaToBernoulliBinomial
                         "Add to the count the number of booleans that were true.");
             } else {
                 trees[0] = store(funcData.noTrialsName,
-                        addII(load(funcData.noTrialsName), binomial.length.getForwardIR(compilationCtx)),
+                        addII(load(funcData.noTrialsName), binomial.length.getForwardIR(info.compilationCtx)),
                         "Increment the number of booleans sampled.");
                 trees[1] = store(funcData.noTrueName,
                         addII(load(funcData.noTrueName), (IRTreeReturn<IntVariable>) current),
@@ -198,7 +197,7 @@ public class BetaToBernoulliBinomial
             throw new CompilerException(
                     "This inference technique cannot be used with this type of pairing. There is an error in the selection mechanism");
 
-        compilationCtx.addTreeToScope(GlobalScope.scope, sequential(trees, "Include the value sampled by task "
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, sequential(trees, "Include the value sampled by task "
                 + task.id() + " from random variable " + task.randomVariable.getVarDesc() + "."));
     }
 
@@ -248,15 +247,15 @@ public class BetaToBernoulliBinomial
     }
 
     @Override // No global state, so nothing to do here.
-    protected void allocateGlobalState(CompilationContext compilationCtx, BetaToBernoulliBinomialData funcData) {}
+    protected void allocateGlobalState(BetaToBernoulliBinomialData funcData) {}
 
     @Override
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> task,
-            IRTreeReturn<DoubleVariable> sourceProbability, BetaToBernoulliBinomialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<DoubleVariable> sourceProbability, BetaToBernoulliBinomialData funcData,
+            TreeBuilderInfo info) {
         VariableDescription<DoubleVariable> distributionProbability = VariableNames
                 .calcVarName("distributionProbability", VariableType.DoubleVariable, true);
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(distributionProbability, multiplyDD(sourceProbability, info.probability),
                         "The probability of reaching the consumer with this set of consumer arguments"));
         ArrayVariable<DoubleVariable> distribution = task.getProbabilitiesArray();
@@ -285,8 +284,8 @@ public class BetaToBernoulliBinomial
                     addDD(load(accumulator),
                             multiplyDI(arrayGet(load(distribution), load(indexName)), load(indexName))),
                     Tree.NoComment);
-            scopedTrees.add(IRTree.forStmt(forBody, constant(1), distribution.length().getForwardIR(compilationCtx),
-                    constant(1), indexName, true,
+            scopedTrees.add(IRTree.forStmt(forBody, constant(1),
+                    distribution.length().getForwardIR(info.compilationCtx), constant(1), indexName, true,
                     "Loop over all the possible boolean variable counts adding them to the accumulator. "
                             + "Zero is missed as it will always have the value zero."));
             scopedTrees.add(store(funcData.noTrueNameDis, multiplyDD(load(distributionProbability), load(accumulator)),
@@ -297,32 +296,28 @@ public class BetaToBernoulliBinomial
             throw new CompilerException(
                     "This inference technique cannot be used with this type of pairing. There is an error in the selection mechanism");
 
-        compilationCtx.addTreeToScope(GlobalScope.scope, sequential(trees, "Include the distribution sampled by task "
-                + task.id() + " from random variable " + task.randomVariable.getVarDesc() + "."));
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
+                sequential(trees, "Include the distribution sampled by task " + task.id() + " from random variable "
+                        + task.randomVariable.getVarDesc() + "."));
     }
 
     @Override
-    protected void getPerSourceConfigStartIR(BetaToBernoulliBinomialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigStartIR(BetaToBernoulliBinomialData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerSourceConfigEndIR(BetaToBernoulliBinomialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigEndIR(BetaToBernoulliBinomialData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerStartIR(BetaToBernoulliBinomialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerStartIR(BetaToBernoulliBinomialData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerEndIR(BetaToBernoulliBinomialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerEndIR(BetaToBernoulliBinomialData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void finalize(BetaToBernoulliBinomialData funcData, CompilationContext compilationCtx) {}
+    protected void finalize(BetaToBernoulliBinomialData funcData) {}
 
     @Override
-    protected ScopeConstructor getBackTraceScope(BetaToBernoulliBinomialData funcData,
-            CompilationContext compilationCtx) {
+    protected ScopeConstructor getBackTraceScope(BetaToBernoulliBinomialData funcData) {
         return funcData.targetScope;
     }
 
@@ -332,31 +327,28 @@ public class BetaToBernoulliBinomial
     }
 
     @Override
-    protected void addDistributionProbabilities(ScopeConstructor targetScope, BetaToBernoulliBinomialData funcData,
-            CompilationContext compilationCtx) {
+    protected void addDistributionProbabilities(ScopeConstructor targetScope, BetaToBernoulliBinomialData funcData) {
         throw new CompilerException("Unable to merge distributions in this inference method.");
     }
 
     @Override
-    protected void backTraceScopeStartIR(BetaToBernoulliBinomialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeStartIR(BetaToBernoulliBinomialData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void backTraceScopeEndIR(BetaToBernoulliBinomialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeEndIR(BetaToBernoulliBinomialData funcData, TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleStartIR(BetaToBernoulliBinomialData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleEndIR(BetaToBernoulliBinomialData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected <C extends ScalarVariable<C>, D extends ScalarVariable<D>> void getDeterministicObservationToConditionalIR(
             IRTreeReturn<C> current, ScalarVariable<D> input, BetaToBernoulliBinomialData funcData,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {
+            TreeBuilderInfo info) {
         throw new CompilerException("Unable to infer conditional guards in a conjugate prior.");
     }
 

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/DirichletToCategoricalMultinomial.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/DirichletToCategoricalMultinomial.java
@@ -93,11 +93,12 @@ public class DirichletToCategoricalMultinomial extends
      * @return The intermediate representation tree for the call to construct a sample value.
      */
     @Override
-    protected IRTreeVoid calculateSampleValue(DirichletToCategoricalData funcData, CompilationContext compilationCtx) {
+    protected IRTreeVoid calculateSampleValue(DirichletToCategoricalData funcData) {
         // Construct the arguments.
-        IRTreeReturn<ArrayVariable<DoubleVariable>> betaArg = funcData.sourceRandom.beta.getForwardIR(compilationCtx);
+        IRTreeReturn<ArrayVariable<DoubleVariable>> betaArg = funcData.sourceRandom.beta
+                .getForwardIR(funcData.compilationCtx);
         IRTreeReturn<ArrayVariable<DoubleVariable>> count = load(countNameLocal);
-        IRTreeReturn<IntVariable> betaLength = funcData.sourceRandom.beta.getLength(compilationCtx);
+        IRTreeReturn<IntVariable> betaLength = funcData.sourceRandom.beta.getLength(funcData.compilationCtx);
 
         // Construct a tree to construct the sample variable for a given element.
 
@@ -113,32 +114,32 @@ public class DirichletToCategoricalMultinomial extends
      * @param funcData       The function data for this inference function.
      */
     @Override
-    protected void constructFunctionVariables(DirichletToCategoricalData funcData, CompilationContext compilationCtx) {
+    protected void constructFunctionVariables(DirichletToCategoricalData funcData) {
         funcData.targetScope.addTree((TreeBuilderInfo info) -> {
             // Set up a pointer for accessing local space.
             IRTreeReturn<ArrayVariable<DoubleVariable>> globalState = loadGlobalField(funcData.countNameGlobal,
-                    funcData, compilationCtx);
+                    funcData);
             IRTreeVoid getLocalState = initializeVariable(countNameLocal, globalState,
                     "A local reference to the scratch space.");
-            compilationCtx.addTreeToScope(GlobalScope.scope, getLocalState);
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, getLocalState);
 
             IRTreeReturn<IntVariable> arrayLengthVal = funcData.sourceRandom.beta.scopedLength(null)
-                    .getForwardIR(compilationCtx);
+                    .getForwardIR(info.compilationCtx);
             IRTreeVoid arrayLengthVar = initializeVariable(arrayLength, arrayLengthVal, "Get the length of the array");
-            compilationCtx.addTreeToScope(GlobalScope.scope, arrayLengthVar);
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, arrayLengthVar);
 
             IRTreeReturn<ArrayVariable<DoubleVariable>> array = load(countNameLocal);
             IRTreeVoid body = arrayPut(array, load(loopIndex), constant(0.0), Tree.NoComment);
             IRFor loop = IRTree.forStmt(body, constant(0), load(arrayLength), constant(1), loopIndex, true,
                     "Initialize the array values to 0.");
-            compilationCtx.addTreeToScope(GlobalScope.scope, loop);
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, loop);
         });
     }
 
     @SuppressWarnings("unchecked")
     @Override
     protected void getObservationToSampleIR(SampleTask<?, ?> task, IRTreeReturn<?> current,
-            DirichletToCategoricalData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
+            DirichletToCategoricalData funcData, TreeBuilderInfo info) {
 
         IRTreeReturn<ArrayVariable<DoubleVariable>> count = load(countNameLocal);
         RandomVariableType<?, ?> type = task.randomVariable.getType();
@@ -147,13 +148,13 @@ public class DirichletToCategoricalMultinomial extends
             IRTreeVoid tree = arrayPut(count, index, addDD(arrayGet(count, index), info.probability),
                     "Increment the sample counter with the value " + "sampled by sample task " + task.id()
                             + " of random variable " + task.randomVariable.getVarDesc());
-            compilationCtx.addTreeToScope(task.scope(), tree);
+            info.compilationCtx.addTreeToScope(task.scope(), tree);
         } else if(type == VariableType.Multinomial) {
             // Save the reference to the sample value for efficient access.
             IRTreeReturn<ArrayVariable<IntVariable>> sampleValue = (IRTreeReturn<ArrayVariable<IntVariable>>) current;
             VariableDescription<ArrayVariable<IntVariable>> sampleValueName = VariableNames.calcVarName("sampleValue",
                     sampleValue.getOutputType(), true);
-            compilationCtx.addTreeToScope(GlobalScope.scope,
+            info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     initializeVariable(sampleValueName, sampleValue, Tree.NoComment));
 
             // Construct a body to scale and increment the value.
@@ -166,7 +167,7 @@ public class DirichletToCategoricalMultinomial extends
             // Add the body to a for loop
             IRFor loop = IRTree.forStmt(body, constant(0), load(arrayLength), constant(1), loopIndex, true,
                     "Update all the counts");
-            compilationCtx.addTreeToScope(GlobalScope.scope, loop);
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, loop);
         }
 
     }
@@ -217,42 +218,41 @@ public class DirichletToCategoricalMultinomial extends
     }
 
     @Override
-    protected void allocateGlobalState(CompilationContext compilationCtx, DirichletToCategoricalData funcData) {
+    protected void allocateGlobalState(DirichletToCategoricalData funcData) {
         // Allocate space for storing the results.
-        compilationCtx.pushScopeState();
+        funcData.compilationCtx.pushScopeState();
         // Because of the reuse of max this needs to be serial. This could be overcome
         // this by taking a copy of the value of max, but as I am not sure that parallel
         // allocation is a beneficial, for now this is serial.
-        compilationCtx.pushIsSerial(true);
+        funcData.compilationCtx.pushIsSerial(true);
 
         // Update phase
-        CompilationPhase currentPhase = compilationCtx.phase;
-        compilationCtx.phase = CompilationPhase.ALLOCATION;
+        CompilationPhase currentPhase = funcData.compilationCtx.phase;
+        funcData.compilationCtx.phase = CompilationPhase.ALLOCATION;
 
         // Search for the largest possible array value.
         IRTreeReturn<IntVariable> arrayLength = ((ArrayVariable<DoubleVariable>) funcData.sampleDesc.output)
-                .getMaxLength(compilationCtx);
+                .getMaxLength(funcData.compilationCtx);
         // Allocate and store the largest value
         globalFieldAllocation(funcData.countNameGlobal,
-                newArray(arrayLength, VariableType.arrayType(VariableType.DoubleVariable)), funcData, compilationCtx);
+                newArray(arrayLength, VariableType.arrayType(VariableType.DoubleVariable)), funcData);
         // Get the allocator
-        IRTreeVoid allocator = compilationCtx.getOutermostScopeTree();
+        IRTreeVoid allocator = funcData.compilationCtx.getOutermostScopeTree();
 
-        compilationCtx.phase = currentPhase;
-        compilationCtx.popIsSerial();
-        compilationCtx.popScopeState();
+        funcData.compilationCtx.phase = currentPhase;
+        funcData.compilationCtx.popIsSerial();
+        funcData.compilationCtx.popScopeState();
 
-        createGlobalField(funcData.countNameGlobal, allocator, funcData, compilationCtx);
+        createGlobalField(funcData.countNameGlobal, allocator, funcData);
     }
 
     @Override
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> s,
-            IRTreeReturn<DoubleVariable> sourceProbability, DirichletToCategoricalData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<DoubleVariable> sourceProbability, DirichletToCategoricalData funcData, TreeBuilderInfo info) {
 
         VariableDescription<DoubleVariable> distributionProbability = VariableNames
                 .calcVarName("distributionProbability", VariableType.DoubleVariable, true);
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(distributionProbability, multiplyDD(sourceProbability, info.probability),
                         "The probability of reaching the consumer with this set of consumer arguments"));
 
@@ -260,7 +260,7 @@ public class DirichletToCategoricalMultinomial extends
         IRTreeReturn<DoubleVariable> currentValue = arrayGet(array, load(loopIndex));
 
         IRTreeReturn<ArrayVariable<DoubleVariable>> probabilityArray = s.getProbabilitiesArray()
-                .getForwardIR(compilationCtx);
+                .getForwardIR(info.compilationCtx);
         IRTreeReturn<DoubleVariable> rvProbability = arrayGet(probabilityArray, load(loopIndex));
         IRTreeReturn<DoubleVariable> mergeValue = addDD(currentValue,
                 multiplyDD(rvProbability, load(distributionProbability)));
@@ -268,35 +268,30 @@ public class DirichletToCategoricalMultinomial extends
         IRTreeVoid body = arrayPut(array, load(loopIndex), mergeValue, Tree.NoComment);
         IRFor loop = IRTree.forStmt(body, constant(0), load(arrayLength), constant(1), loopIndex, true,
                 "Merge the distribution probabilities into the count");
-        compilationCtx.addTreeToScope(GlobalScope.scope, loop);
+        info.compilationCtx.addTreeToScope(GlobalScope.scope, loop);
     }
 
     @Override
     protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer,
-            DirichletToCategoricalData funcData, CompilationContext compilationCtx) {}
+            DirichletToCategoricalData funcData) {}
 
     @Override
-    protected void getPerSourceConfigStartIR(DirichletToCategoricalData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigStartIR(DirichletToCategoricalData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerSourceConfigEndIR(DirichletToCategoricalData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigEndIR(DirichletToCategoricalData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerStartIR(DirichletToCategoricalData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerStartIR(DirichletToCategoricalData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerEndIR(DirichletToCategoricalData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerEndIR(DirichletToCategoricalData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void finalize(DirichletToCategoricalData funcData, CompilationContext compilationCtx) {}
+    protected void finalize(DirichletToCategoricalData funcData) {}
 
     @Override
-    protected ScopeConstructor getBackTraceScope(DirichletToCategoricalData funcData,
-            CompilationContext compilationCtx) {
+    protected ScopeConstructor getBackTraceScope(DirichletToCategoricalData funcData) {
         return funcData.targetScope;
     }
 
@@ -306,31 +301,28 @@ public class DirichletToCategoricalMultinomial extends
     }
 
     @Override
-    protected void addDistributionProbabilities(ScopeConstructor targetScope, DirichletToCategoricalData funcData,
-            CompilationContext compilationCtx) {
+    protected void addDistributionProbabilities(ScopeConstructor targetScope, DirichletToCategoricalData funcData) {
         throw new CompilerException("Unable to merge distributions in this inference method.");
     }
 
     @Override
-    protected void backTraceScopeStartIR(DirichletToCategoricalData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeStartIR(DirichletToCategoricalData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void backTraceScopeEndIR(DirichletToCategoricalData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeEndIR(DirichletToCategoricalData funcData, TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleStartIR(DirichletToCategoricalData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleEndIR(DirichletToCategoricalData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected <C extends ScalarVariable<C>, D extends ScalarVariable<D>> void getDeterministicObservationToConditionalIR(
-            IRTreeReturn<C> current, ScalarVariable<D> input, DirichletToCategoricalData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<C> current, ScalarVariable<D> input, DirichletToCategoricalData funcData,
+            TreeBuilderInfo info) {
         throw new CompilerException("Unable to infer conditional guards in a conjugate prior.");
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GammaToExponential.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GammaToExponential.java
@@ -49,17 +49,17 @@ public class GammaToExponential
         extends InferenceGeneratorScalar<DoubleVariable, Gamma, GammaToExponential.GammaToExponentialData> {
     protected static class GammaToExponentialData
             extends InferenceGeneratorScalar.ScalarFunctionData<DoubleVariable, Gamma> {
-        // Names for the different variables that will be needed to construct for this
-        // function.
-        final VariableDescription<DoubleVariable> sumName;
-        final VariableDescription<IntVariable> countName;
-
         protected GammaToExponentialData(SampleTask<DoubleVariable, Gamma> sample, CompilationContext compilationCtx) {
             super(sample, false, compilationCtx);
-            sumName = VariableNames.calcVarName("sum", VariableType.DoubleVariable, true);
-            countName = VariableNames.calcVarName("count", VariableType.IntVariable, true);
         }
     }
+
+    // Names for the different variables that will be needed to construct for this
+    // function.
+    private final VariableDescription<DoubleVariable> sumName = VariableNames.calcVarName("sum",
+            VariableType.DoubleVariable, true);
+    private final VariableDescription<IntVariable> countName = VariableNames.calcVarName("count",
+            VariableType.IntVariable, true);
 
     private GammaToExponential() {}
 
@@ -78,19 +78,18 @@ public class GammaToExponential
      * @return The function call to generate a sample value for this function data.
      */
     @Override
-    protected IRTreeReturn<DoubleVariable> calculateSampleValue(CompilationContext compilationCtx,
-            GammaToExponentialData funcData) {
+    protected IRTreeReturn<DoubleVariable> calculateSampleValue(GammaToExponentialData funcData) {
         /*
          * TODO adjust this so it traces back to find the constructor, and get the values from them. This will allow
          * arrays of random variables. Get the arguments constructed
          */
-        IRTreeReturn<DoubleVariable> alpha = funcData.sourceRandom.alpha.getForwardIR(compilationCtx);
-        IRTreeReturn<DoubleVariable> beta = funcData.sourceRandom.beta.getForwardIR(compilationCtx);
+        IRTreeReturn<DoubleVariable> alpha = funcData.sourceRandom.alpha.getForwardIR(funcData.compilationCtx);
+        IRTreeReturn<DoubleVariable> beta = funcData.sourceRandom.beta.getForwardIR(funcData.compilationCtx);
 
         // Construct a tree to construct the sample variable.
         IRTreeReturn<DoubleVariable> mean = IRTree.functionCallReturn(FunctionType.CONJUGATE_SAMPLE,
-                VariableType.DoubleVariable, VariableType.Gamma, VariableType.Exponential, alpha, beta,
-                load(funcData.sumName), load(funcData.countName));
+                VariableType.DoubleVariable, VariableType.Gamma, VariableType.Exponential, alpha, beta, load(sumName),
+                load(countName));
         return mean;
     }
 
@@ -101,13 +100,13 @@ public class GammaToExponential
      * @param funcData       The function data for this inference function.
      */
     @Override
-    protected void constructFunctionVariables(GammaToExponentialData funcData, CompilationContext compilationCtx) {
+    protected void constructFunctionVariables(GammaToExponentialData funcData) {
         // add a trees to initialize the temporary variables.
         funcData.targetScope.addTree((TreeBuilderInfo info) -> {
-            compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sumName, constant(0.0),
-                    "Variable to track the sum of the samples."));
+            info.compilationCtx.addTreeToScope(GlobalScope.scope,
+                    IRTree.initializeVariable(sumName, constant(0.0), "Variable to track the sum of the samples."));
 
-            compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.countName, constant(0),
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(countName, constant(0),
                     "Variable to record how many samples have been included in this calculation."));
         });
     }
@@ -115,16 +114,16 @@ public class GammaToExponential
     @SuppressWarnings("unchecked")
     @Override
     protected void getObservationToSampleIR(SampleTask<?, ?> task, IRTreeReturn<?> current,
-            GammaToExponentialData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
+            GammaToExponentialData funcData, TreeBuilderInfo info) {
 
         List<IRTreeVoid> trees = new ArrayList<>();
-        trees.add(store(funcData.sumName, addDD(load(funcData.sumName), (IRTreeReturn<DoubleVariable>) current),
+        trees.add(store(sumName, addDD(load(sumName), (IRTreeReturn<DoubleVariable>) current),
                 "Include this sample by adding the value to the sum."));
 
-        trees.add(store(funcData.countName, addII(load(funcData.countName), constant(1)),
+        trees.add(store(countName, addII(load(countName), constant(1)),
                 "Increment the number of samples in the calculation."));
 
-        compilationCtx.addTreeToScope(task.scope(), sequential(trees, "Consume sample task " + task.id()
+        info.compilationCtx.addTreeToScope(task.scope(), sequential(trees, "Consume sample task " + task.id()
                 + " from random variable " + task.randomVariable.getVarDesc() + "."));
     }
 
@@ -189,37 +188,32 @@ public class GammaToExponential
     }
 
     @Override // No global state, so nothing to do here.
-    protected void allocateGlobalState(CompilationContext compilationCtx, GammaToExponentialData funcData) {}
+    protected void allocateGlobalState(GammaToExponentialData funcData) {}
 
     @Override
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> s,
-            IRTreeReturn<DoubleVariable> sourceProbability, GammaToExponentialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<DoubleVariable> sourceProbability, GammaToExponentialData funcData, TreeBuilderInfo info) {
         throw new CompilerException("Distribution samples are not yet supported in this inference "
                 + "technique. If this has been reached there is a bug in the compiler.");
     }
 
     @Override
-    protected void getPerSourceConfigStartIR(GammaToExponentialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigStartIR(GammaToExponentialData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerSourceConfigEndIR(GammaToExponentialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigEndIR(GammaToExponentialData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerStartIR(GammaToExponentialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerStartIR(GammaToExponentialData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerEndIR(GammaToExponentialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerEndIR(GammaToExponentialData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void finalize(GammaToExponentialData funcData, CompilationContext compilationCtx) {}
+    protected void finalize(GammaToExponentialData funcData) {}
 
     @Override
-    protected ScopeConstructor getBackTraceScope(GammaToExponentialData funcData, CompilationContext compilationCtx) {
+    protected ScopeConstructor getBackTraceScope(GammaToExponentialData funcData) {
         return funcData.targetScope;
     }
 
@@ -229,35 +223,31 @@ public class GammaToExponential
     }
 
     @Override
-    protected void addDistributionProbabilities(ScopeConstructor targetScope, GammaToExponentialData funcData,
-            CompilationContext compilationCtx) {
+    protected void addDistributionProbabilities(ScopeConstructor targetScope, GammaToExponentialData funcData) {
         throw new CompilerException("Unable to merge distributions in this inference method.");
     }
 
     @Override
-    protected void backTraceScopeStartIR(GammaToExponentialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeStartIR(GammaToExponentialData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void backTraceScopeEndIR(GammaToExponentialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeEndIR(GammaToExponentialData funcData, TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleStartIR(GammaToExponentialData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleEndIR(GammaToExponentialData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer,
-            GammaToExponentialData funcData, CompilationContext compilationCtx) {}
+            GammaToExponentialData funcData) {}
 
     @Override
     protected <C extends ScalarVariable<C>, D extends ScalarVariable<D>> void getDeterministicObservationToConditionalIR(
-            IRTreeReturn<C> current, ScalarVariable<D> input, GammaToExponentialData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<C> current, ScalarVariable<D> input, GammaToExponentialData funcData, TreeBuilderInfo info) {
         throw new CompilerException("Unable to infer conditional guards in a conjugate prior.");
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GammaToGaussian.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GammaToGaussian.java
@@ -86,13 +86,12 @@ public class GammaToGaussian
      * @return The function call to generate a sample value for this function data.
      */
     @Override
-    protected IRTreeReturn<DoubleVariable> calculateSampleValue(CompilationContext compilationCtx,
-            GammaToGaussianData funcData) {
+    protected IRTreeReturn<DoubleVariable> calculateSampleValue(GammaToGaussianData funcData) {
         // TODO adjust this so it traces back to find the constructor, and get the values from them. This will allow
         // arrays of random variables.
         // Get the arguments constructed
-        IRTreeReturn<DoubleVariable> alpha = funcData.sourceRandom.alpha.getForwardIR(compilationCtx);
-        IRTreeReturn<DoubleVariable> beta = funcData.sourceRandom.beta.getForwardIR(compilationCtx);
+        IRTreeReturn<DoubleVariable> alpha = funcData.sourceRandom.alpha.getForwardIR(funcData.compilationCtx);
+        IRTreeReturn<DoubleVariable> beta = funcData.sourceRandom.beta.getForwardIR(funcData.compilationCtx);
 
         // Construct a tree to construct the sample variable.
         IRTreeReturn<DoubleVariable> mean = IRTree.functionCallReturn(FunctionType.CONJUGATE_SAMPLE,
@@ -108,31 +107,32 @@ public class GammaToGaussian
      * @param funcData       The function data for this inference function.
      */
     @Override
-    protected void constructFunctionVariables(GammaToGaussianData funcData, CompilationContext compilationCtx) {
+    protected void constructFunctionVariables(GammaToGaussianData funcData) {
         funcData.targetScope.addTree((TreeBuilderInfo info) -> {
             // add a trees to initialize the temporary variables.
-            compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sumName, constant(0.0),
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sumName,
+                    constant(0.0),
                     "Variable to track the sum of the difference between the samples and the random variables mean squared."));
 
-            compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.countName, constant(0),
-                    "Variable to record how many samples have been included in this calculation."));
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.countName,
+                    constant(0), "Variable to record how many samples have been included in this calculation."));
         });
     }
 
     @Override
     protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer,
-            GammaToGaussianData funcData, CompilationContext compilationCtx) {
+            GammaToGaussianData funcData) {
         VariableDescription<DoubleVariable> muName = VariableNames.calcVarName(consumer, "mu",
                 VariableType.DoubleVariable);
-        compilationCtx.addTreeToScope(consumer.getParent().scope(),
-                initializeVariable(muName, ((Gaussian) consumer).mean.getForwardIR(compilationCtx),
+        info.compilationCtx.addTreeToScope(consumer.getParent().scope(),
+                initializeVariable(muName, ((Gaussian) consumer).mean.getForwardIR(info.compilationCtx),
                         "The mean parameter for Gaussian " + consumer.getVarDesc() + "."));
     }
 
     @SuppressWarnings("unchecked")
     @Override
     protected void getObservationToSampleIR(SampleTask<?, ?> task, IRTreeReturn<?> current,
-            GammaToGaussianData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
+            GammaToGaussianData funcData, TreeBuilderInfo info) {
         VariableDescription<DoubleVariable> muName = VariableNames.calcVarName(task.randomVariable, "mu",
                 VariableType.DoubleVariable);
         VariableDescription<DoubleVariable> diffName = VariableNames.calcVarName(task.randomVariable, "diff",
@@ -148,7 +148,7 @@ public class GammaToGaussian
         trees.add(store(funcData.countName, addII(load(funcData.countName), constant(1)),
                 "Increment the number of samples in the calculation."));
 
-        compilationCtx.addTreeToScope(task.scope(), sequential(trees, "Consume sample task " + task.id()
+        info.compilationCtx.addTreeToScope(task.scope(), sequential(trees, "Consume sample task " + task.id()
                 + " from random variable " + task.randomVariable.getVarDesc() + "."));
     }
 
@@ -249,37 +249,32 @@ public class GammaToGaussian
     }
 
     @Override // No global state, so nothing to do here.
-    protected void allocateGlobalState(CompilationContext compilationCtx, GammaToGaussianData funcData) {}
+    protected void allocateGlobalState(GammaToGaussianData funcData) {}
 
     @Override
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> s,
-            IRTreeReturn<DoubleVariable> sourceProbability, GammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<DoubleVariable> sourceProbability, GammaToGaussianData funcData, TreeBuilderInfo info) {
         throw new CompilerException("Distribution samples are not yet supported in this inference "
                 + "technique. If this has been reached there is a bug in the compiler.");
     }
 
     @Override
-    protected void getPerSourceConfigStartIR(GammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigStartIR(GammaToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerSourceConfigEndIR(GammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigEndIR(GammaToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerStartIR(GammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerStartIR(GammaToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerEndIR(GammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerEndIR(GammaToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void finalize(GammaToGaussianData funcData, CompilationContext compilationCtx) {}
+    protected void finalize(GammaToGaussianData funcData) {}
 
     @Override
-    protected ScopeConstructor getBackTraceScope(GammaToGaussianData funcData, CompilationContext compilationCtx) {
+    protected ScopeConstructor getBackTraceScope(GammaToGaussianData funcData) {
         return funcData.targetScope;
     }
 
@@ -289,31 +284,27 @@ public class GammaToGaussian
     }
 
     @Override
-    protected void addDistributionProbabilities(ScopeConstructor targetScope, GammaToGaussianData funcData,
-            CompilationContext compilationCtx) {
+    protected void addDistributionProbabilities(ScopeConstructor targetScope, GammaToGaussianData funcData) {
         throw new CompilerException("Unable to merge distributions in this inference method.");
     }
 
     @Override
-    protected void backTraceScopeStartIR(GammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeStartIR(GammaToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void backTraceScopeEndIR(GammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeEndIR(GammaToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleStartIR(GammaToGaussianData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleEndIR(GammaToGaussianData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected <C extends ScalarVariable<C>, D extends ScalarVariable<D>> void getDeterministicObservationToConditionalIR(
-            IRTreeReturn<C> current, ScalarVariable<D> input, GammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<C> current, ScalarVariable<D> input, GammaToGaussianData funcData, TreeBuilderInfo info) {
         throw new CompilerException("Unable to infer conditional guards in a conjugate prior.");
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GammaToPoisson.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GammaToPoisson.java
@@ -86,15 +86,14 @@ public class GammaToPoisson extends InferenceGeneratorScalar<DoubleVariable, Gam
      * @return The intermediate representation tree for the function call to generate a sample with this function data.
      */
     @Override
-    protected IRTreeReturn<DoubleVariable> calculateSampleValue(CompilationContext compilationCtx,
-            GammaToPoissonData funcData) {
+    protected IRTreeReturn<DoubleVariable> calculateSampleValue(GammaToPoissonData funcData) {
         // TODO adjust this so it traces back to find the constructor, and get the
         // values
         // from them. This will allow arrays of random variables.
 
         // Get the arguments constructed
-        IRTreeReturn<DoubleVariable> alpha = funcData.sourceRandom.alpha.getForwardIR(compilationCtx);
-        IRTreeReturn<DoubleVariable> beta = funcData.sourceRandom.beta.getForwardIR(compilationCtx);
+        IRTreeReturn<DoubleVariable> alpha = funcData.sourceRandom.alpha.getForwardIR(funcData.compilationCtx);
+        IRTreeReturn<DoubleVariable> beta = funcData.sourceRandom.beta.getForwardIR(funcData.compilationCtx);
 
         // Construct a tree to construct the sample variable.
         IRTreeReturn<DoubleVariable> mean = IRTree.functionCallReturn(FunctionType.CONJUGATE_SAMPLE,
@@ -111,16 +110,16 @@ public class GammaToPoisson extends InferenceGeneratorScalar<DoubleVariable, Gam
      * @param funcData       The function data for generating this inference function.
      */
     @Override
-    protected void constructFunctionVariables(GammaToPoissonData funcData, CompilationContext compilationCtx) {
+    protected void constructFunctionVariables(GammaToPoissonData funcData) {
         // add a trees to initialize the temporary variables.
         funcData.targetScope.addTree((TreeBuilderInfo info) -> {
-            compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sumName, constant(0.0),
-                    "Variable to store the sum of all the samples from consuming random variables."));
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sumName,
+                    constant(0.0), "Variable to store the sum of all the samples from consuming random variables."));
             if(funcData.distributedConsumers)
-                compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.countNameDis,
+                info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.countNameDis,
                         constant(0.0), "Variable to record the number of samples from consuming random variables."));
             else
-                compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.countName,
+                info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.countName,
                         constant(0), "Variable to record the number of samples from consuming random variables."));
         });
     }
@@ -128,7 +127,7 @@ public class GammaToPoisson extends InferenceGeneratorScalar<DoubleVariable, Gam
     @SuppressWarnings("unchecked")
     @Override
     protected void getObservationToSampleIR(SampleTask<?, ?> task, IRTreeReturn<?> current, GammaToPoissonData funcData,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {
+            TreeBuilderInfo info) {
         List<IRTreeVoid> trees = new ArrayList<>();
         if(funcData.distributedConsumers) {
             trees.add(store(funcData.sumName,
@@ -143,7 +142,7 @@ public class GammaToPoisson extends InferenceGeneratorScalar<DoubleVariable, Gam
             trees.add(store(funcData.countName, addII(load(funcData.countName), constant(1)), Tree.NoComment));
         }
 
-        compilationCtx.addTreeToScope(task.scope(),
+        info.compilationCtx.addTreeToScope(task.scope(),
                 sequential(trees, "Add the value of a sample from consuming random variable "
                         + task.randomVariable.getVarDesc() + " to the inference state."));
     }
@@ -203,37 +202,32 @@ public class GammaToPoisson extends InferenceGeneratorScalar<DoubleVariable, Gam
     }
 
     @Override // No global state, so nothing to do here.
-    protected void allocateGlobalState(CompilationContext compilationCtx, GammaToPoissonData funcData) {}
+    protected void allocateGlobalState(GammaToPoissonData funcData) {}
 
     @Override
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> s,
-            IRTreeReturn<DoubleVariable> sourceProbability, GammaToPoissonData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<DoubleVariable> sourceProbability, GammaToPoissonData funcData, TreeBuilderInfo info) {
         throw new CompilerException("Distribution samples are not yet supported in this inference "
                 + "technique. If this has been reached there is a bug in the compiler.");
     }
 
     @Override
-    protected void getPerSourceConfigStartIR(GammaToPoissonData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigStartIR(GammaToPoissonData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerSourceConfigEndIR(GammaToPoissonData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigEndIR(GammaToPoissonData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerStartIR(GammaToPoissonData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerStartIR(GammaToPoissonData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerEndIR(GammaToPoissonData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerEndIR(GammaToPoissonData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void finalize(GammaToPoissonData funcData, CompilationContext compilationCtx) {}
+    protected void finalize(GammaToPoissonData funcData) {}
 
     @Override
-    protected ScopeConstructor getBackTraceScope(GammaToPoissonData funcData, CompilationContext compilationCtx) {
+    protected ScopeConstructor getBackTraceScope(GammaToPoissonData funcData) {
         return funcData.targetScope;
     }
 
@@ -243,35 +237,31 @@ public class GammaToPoisson extends InferenceGeneratorScalar<DoubleVariable, Gam
     }
 
     @Override
-    protected void addDistributionProbabilities(ScopeConstructor targetScope, GammaToPoissonData funcData,
-            CompilationContext compilationCtx) {
+    protected void addDistributionProbabilities(ScopeConstructor targetScope, GammaToPoissonData funcData) {
         throw new CompilerException("Unable to merge distributions in Gamma to Poisson inference method.");
     }
 
     @Override
-    protected void backTraceScopeStartIR(GammaToPoissonData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeStartIR(GammaToPoissonData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void backTraceScopeEndIR(GammaToPoissonData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeEndIR(GammaToPoissonData funcData, TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleStartIR(GammaToPoissonData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleEndIR(GammaToPoissonData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer,
-            GammaToPoissonData funcData, CompilationContext compilationCtx) {}
+            GammaToPoissonData funcData) {}
 
     @Override
     protected <C extends ScalarVariable<C>, D extends ScalarVariable<D>> void getDeterministicObservationToConditionalIR(
-            IRTreeReturn<C> current, ScalarVariable<D> input, GammaToPoissonData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<C> current, ScalarVariable<D> input, GammaToPoissonData funcData, TreeBuilderInfo info) {
         throw new CompilerException("Unable to infer conditional guards in a conjugate prior.");
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GaussianToGaussian.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GaussianToGaussian.java
@@ -119,13 +119,12 @@ public class GaussianToGaussian
      * @return The intermediate representation tree for generating a sample value based on the function data.
      */
     @Override
-    protected IRTreeReturn<DoubleVariable> calculateSampleValue(CompilationContext compilationCtx,
-            GaussianToGaussianData funcData) {
+    protected IRTreeReturn<DoubleVariable> calculateSampleValue(GaussianToGaussianData funcData) {
         // TODO adjust this so we trace back to find the constructor, and get the values
         // from them. This will allow us to have arrays of random variables.
         // Get the arguments constructed
-        IRTreeReturn<DoubleVariable> mean0 = funcData.sourceRandom.mean.getForwardIR(compilationCtx);
-        IRTreeReturn<DoubleVariable> variance0 = funcData.sourceRandom.variance.getForwardIR(compilationCtx);
+        IRTreeReturn<DoubleVariable> mean0 = funcData.sourceRandom.mean.getForwardIR(funcData.compilationCtx);
+        IRTreeReturn<DoubleVariable> variance0 = funcData.sourceRandom.variance.getForwardIR(funcData.compilationCtx);
 
         // Construct a tree to construct the sample variable.
         IRTreeReturn<DoubleVariable> mean = IRTree.functionCallReturn(FunctionType.CONJUGATE_SAMPLE,
@@ -141,24 +140,25 @@ public class GaussianToGaussian
      * @param funcData       The function data for this function inference method.
      */
     @Override
-    protected void constructFunctionVariables(GaussianToGaussianData funcData, CompilationContext compilationCtx) {
+    protected void constructFunctionVariables(GaussianToGaussianData funcData) {
         // add a trees to initialize the temporary variables.
         funcData.targetScope.addTree((TreeBuilderInfo info) -> {
-            compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sumName, constant(0.0),
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sumName,
+                    constant(0.0),
                     "State to record the weighting of each sample that is consumed. This is the:\nsum of the sample denominator*(the sample value - the sample nominator)."));
-            compilationCtx.addTreeToScope(GlobalScope.scope,
+            info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     IRTree.initializeVariable(funcData.denominatorSquareSumName, constant(0.0),
                             "State for storing the sum of the squares of the sample denominators."));
-            compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sigmaNotFoundName,
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sigmaNotFoundName,
                     constant(true), "Flag to record if we have a value for Sigma."));
-            compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sigmaValueName,
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sigmaValueName,
                     constant(1.0), "State for the value of sigma once we find it."));
         });
     }
 
     @Override
     protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer,
-            GaussianToGaussianData funcData, CompilationContext compilationCtx) {
+            GaussianToGaussianData funcData) {
 
         // Get the trace of operations between the consuming random variable, and the
         // sample task.
@@ -169,9 +169,9 @@ public class GaussianToGaussian
 
         IRTreeVoid denomInit = initializeVariable(funcData.denominatorName, constant(1.0),
                 "State for tracking the changes that happen to the sampled value between it being consumed and it being produced.");
-        compilationCtx.addTreeToScope(consumer.getParent().scope(), denomInit);
+        funcData.compilationCtx.addTreeToScope(consumer.getParent().scope(), denomInit);
         IRTreeVoid numeratorInit = initializeVariable(funcData.numeratorName, constant(0.0), Tree.NoComment);
-        compilationCtx.addTreeToScope(consumer.getParent().scope(), numeratorInit);
+        funcData.compilationCtx.addTreeToScope(consumer.getParent().scope(), numeratorInit);
 
         // Stack to record which index we are currently working on.
         Stack<IRTreeReturn<IntVariable>> indexes = new Stack<>();
@@ -191,28 +191,30 @@ public class GaussianToGaussian
                     Add<?, ?, ?> a = (Add<?, ?, ?>) t;
                     if(d.argPos == 0) {
                         if(a.right.getType() == VariableType.IntVariable) {
-                            IRTreeReturn<IntVariable> rightTree = ((IntVariable) a.right).getForwardIR(compilationCtx);
+                            IRTreeReturn<IntVariable> rightTree = ((IntVariable) a.right)
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = addDI(load(funcData.numeratorName), rightTree);
-                            compilationCtx.addTreeToScope(a.scope(),
+                            funcData.compilationCtx.addTreeToScope(a.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                         } else {
                             IRTreeReturn<DoubleVariable> rightTree = ((DoubleVariable) a.right)
-                                    .getForwardIR(compilationCtx);
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = addDD(load(funcData.numeratorName), rightTree);
-                            compilationCtx.addTreeToScope(a.scope(),
+                            funcData.compilationCtx.addTreeToScope(a.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                         }
                     } else {
                         if(a.left.getType() == VariableType.IntVariable) {
-                            IRTreeReturn<IntVariable> leftTree = ((IntVariable) a.left).getForwardIR(compilationCtx);
+                            IRTreeReturn<IntVariable> leftTree = ((IntVariable) a.left)
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = addID(leftTree, load(funcData.numeratorName));
-                            compilationCtx.addTreeToScope(a.scope(),
+                            funcData.compilationCtx.addTreeToScope(a.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                         } else {
                             IRTreeReturn<DoubleVariable> leftTree = ((DoubleVariable) a.left)
-                                    .getForwardIR(compilationCtx);
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = addDD(leftTree, load(funcData.numeratorName));
-                            compilationCtx.addTreeToScope(a.scope(),
+                            funcData.compilationCtx.addTreeToScope(a.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                         }
                     }
@@ -223,48 +225,49 @@ public class GaussianToGaussian
                     if(d.argPos == 0) {
                         if(div.right.getType() == VariableType.IntVariable) {
                             IRTreeReturn<IntVariable> rightTree = ((IntVariable) div.right)
-                                    .getForwardIR(compilationCtx);
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = divideDI(load(funcData.numeratorName),
                                     rightTree);
-                            compilationCtx.addTreeToScope(div.scope(),
+                            funcData.compilationCtx.addTreeToScope(div.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                             IRTreeReturn<DoubleVariable> denominatorTerm = divideDI(load(funcData.denominatorName),
                                     rightTree);
-                            compilationCtx.addTreeToScope(div.scope(),
+                            funcData.compilationCtx.addTreeToScope(div.scope(),
                                     store(funcData.denominatorName, denominatorTerm, Tree.NoComment));
                         } else {
                             IRTreeReturn<DoubleVariable> rightTree = ((DoubleVariable) div.right)
-                                    .getForwardIR(compilationCtx);
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = divideDD(load(funcData.numeratorName),
                                     rightTree);
-                            compilationCtx.addTreeToScope(div.scope(),
+                            funcData.compilationCtx.addTreeToScope(div.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                             IRTreeReturn<DoubleVariable> denominatorTerm = divideDD(load(funcData.denominatorName),
                                     rightTree);
-                            compilationCtx.addTreeToScope(div.scope(),
+                            funcData.compilationCtx.addTreeToScope(div.scope(),
                                     store(funcData.denominatorName, denominatorTerm, Tree.NoComment));
                         }
                     } else {
                         if(div.left.getType() == VariableType.IntVariable) {
-                            IRTreeReturn<IntVariable> leftTree = ((IntVariable) div.left).getForwardIR(compilationCtx);
+                            IRTreeReturn<IntVariable> leftTree = ((IntVariable) div.left)
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = divideID(leftTree,
                                     load(funcData.numeratorName));
-                            compilationCtx.addTreeToScope(div.scope(),
+                            funcData.compilationCtx.addTreeToScope(div.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                             IRTreeReturn<DoubleVariable> denominatorTerm = divideID(leftTree,
                                     load(funcData.denominatorName));
-                            compilationCtx.addTreeToScope(div.scope(),
+                            funcData.compilationCtx.addTreeToScope(div.scope(),
                                     store(funcData.denominatorName, denominatorTerm, Tree.NoComment));
                         } else {
                             IRTreeReturn<DoubleVariable> leftTree = ((DoubleVariable) div.left)
-                                    .getForwardIR(compilationCtx);
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = divideDD(leftTree,
                                     load(funcData.numeratorName));
-                            compilationCtx.addTreeToScope(div.scope(),
+                            funcData.compilationCtx.addTreeToScope(div.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                             IRTreeReturn<DoubleVariable> denominatorTerm = divideDD(leftTree,
                                     load(funcData.denominatorName));
-                            compilationCtx.addTreeToScope(div.scope(),
+                            funcData.compilationCtx.addTreeToScope(div.scope(),
                                     store(funcData.denominatorName, denominatorTerm, Tree.NoComment));
                         }
                     }
@@ -277,48 +280,50 @@ public class GaussianToGaussian
                     Multiply<?, ?, ?> m = (Multiply<?, ?, ?>) t;
                     if(d.argPos == 0) {
                         if(m.right.getType() == VariableType.IntVariable) {
-                            IRTreeReturn<IntVariable> rightTree = ((IntVariable) m.right).getForwardIR(compilationCtx);
+                            IRTreeReturn<IntVariable> rightTree = ((IntVariable) m.right)
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = multiplyDI(load(funcData.numeratorName),
                                     rightTree);
-                            compilationCtx.addTreeToScope(m.scope(),
+                            funcData.compilationCtx.addTreeToScope(m.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                             IRTreeReturn<DoubleVariable> denominatorTerm = multiplyDI(load(funcData.denominatorName),
                                     rightTree);
-                            compilationCtx.addTreeToScope(m.scope(),
+                            funcData.compilationCtx.addTreeToScope(m.scope(),
                                     store(funcData.denominatorName, denominatorTerm, Tree.NoComment));
                         } else {
                             IRTreeReturn<DoubleVariable> rightTree = ((DoubleVariable) m.right)
-                                    .getForwardIR(compilationCtx);
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = multiplyDD(load(funcData.numeratorName),
                                     rightTree);
-                            compilationCtx.addTreeToScope(m.scope(),
+                            funcData.compilationCtx.addTreeToScope(m.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                             IRTreeReturn<DoubleVariable> denominatorTerm = multiplyDD(load(funcData.denominatorName),
                                     rightTree);
-                            compilationCtx.addTreeToScope(m.scope(),
+                            funcData.compilationCtx.addTreeToScope(m.scope(),
                                     store(funcData.denominatorName, denominatorTerm, Tree.NoComment));
                         }
                     } else {
                         if(m.left.getType() == VariableType.IntVariable) {
-                            IRTreeReturn<IntVariable> leftTree = ((IntVariable) m.left).getForwardIR(compilationCtx);
+                            IRTreeReturn<IntVariable> leftTree = ((IntVariable) m.left)
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = multiplyID(leftTree,
                                     load(funcData.numeratorName));
-                            compilationCtx.addTreeToScope(m.scope(),
+                            funcData.compilationCtx.addTreeToScope(m.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                             IRTreeReturn<DoubleVariable> denominatorTerm = multiplyID(leftTree,
                                     load(funcData.denominatorName));
-                            compilationCtx.addTreeToScope(m.scope(),
+                            funcData.compilationCtx.addTreeToScope(m.scope(),
                                     store(funcData.denominatorName, denominatorTerm, Tree.NoComment));
                         } else {
                             IRTreeReturn<DoubleVariable> leftTree = ((DoubleVariable) m.left)
-                                    .getForwardIR(compilationCtx);
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = multiplyDD(leftTree,
                                     load(funcData.numeratorName));
-                            compilationCtx.addTreeToScope(m.scope(),
+                            funcData.compilationCtx.addTreeToScope(m.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                             IRTreeReturn<DoubleVariable> denominatorTerm = multiplyDD(leftTree,
                                     load(funcData.denominatorName));
-                            compilationCtx.addTreeToScope(m.scope(),
+                            funcData.compilationCtx.addTreeToScope(m.scope(),
                                     store(funcData.denominatorName, denominatorTerm, Tree.NoComment));
                         }
                     }
@@ -327,49 +332,51 @@ public class GaussianToGaussian
                 case NEGATE: {
                     Negate<?> n = (Negate<?>) t;
                     IRTreeReturn<DoubleVariable> numeratorTerm = negate(load(funcData.numeratorName));
-                    compilationCtx.addTreeToScope(n.scope(),
+                    funcData.compilationCtx.addTreeToScope(n.scope(),
                             store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                     IRTreeReturn<DoubleVariable> denominatorTerm = negate(load(funcData.denominatorName));
-                    compilationCtx.addTreeToScope(n.scope(),
+                    funcData.compilationCtx.addTreeToScope(n.scope(),
                             store(funcData.denominatorName, denominatorTerm, Tree.NoComment));
                 }
                     break;
                 case PUT:
                     if(d.argPos == 2) {
                         PutTask<?> pt = (PutTask<?>) t;
-                        indexes.push(pt.index.getForwardIR(compilationCtx));
+                        indexes.push(pt.index.getForwardIR(funcData.compilationCtx));
                     }
                     break;
                 case SUBTRACTION: {
                     Subtract<?, ?, ?> s = (Subtract<?, ?, ?>) t;
                     if(d.argPos == 0) {
                         if(s.right.getType() == VariableType.IntVariable) {
-                            IRTreeReturn<IntVariable> rightTree = ((IntVariable) s.right).getForwardIR(compilationCtx);
+                            IRTreeReturn<IntVariable> rightTree = ((IntVariable) s.right)
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = subtractDI(load(funcData.numeratorName),
                                     rightTree);
-                            compilationCtx.addTreeToScope(s.scope(),
+                            funcData.compilationCtx.addTreeToScope(s.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                         } else {
                             IRTreeReturn<DoubleVariable> rightTree = ((DoubleVariable) s.right)
-                                    .getForwardIR(compilationCtx);
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = subtractDD(load(funcData.numeratorName),
                                     rightTree);
-                            compilationCtx.addTreeToScope(s.scope(),
+                            funcData.compilationCtx.addTreeToScope(s.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                         }
                     } else {
                         if(s.left.getType() == VariableType.IntVariable) {
-                            IRTreeReturn<IntVariable> leftTree = ((IntVariable) s.left).getForwardIR(compilationCtx);
+                            IRTreeReturn<IntVariable> leftTree = ((IntVariable) s.left)
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = subtractID(leftTree,
                                     load(funcData.numeratorName));
-                            compilationCtx.addTreeToScope(s.scope(),
+                            funcData.compilationCtx.addTreeToScope(s.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                         } else {
                             IRTreeReturn<DoubleVariable> leftTree = ((DoubleVariable) s.left)
-                                    .getForwardIR(compilationCtx);
+                                    .getForwardIR(funcData.compilationCtx);
                             IRTreeReturn<DoubleVariable> numeratorTerm = subtractDD(leftTree,
                                     load(funcData.numeratorName));
-                            compilationCtx.addTreeToScope(s.scope(),
+                            funcData.compilationCtx.addTreeToScope(s.scope(),
                                     store(funcData.numeratorName, numeratorTerm, Tree.NoComment));
                         }
                     }
@@ -388,10 +395,10 @@ public class GaussianToGaussian
                             throw new CompilerException(
                                     "It is currently not possible to track through the end value for a reduction range.");
                         case 2: // Empty Value
-                            reduceEmptyValue(ri, compilationCtx);
+                            reduceEmptyValue(ri, funcData.compilationCtx);
                             break;
                         default: // one of the inputs.
-                            reduceArrayValue(ri, indexes.pop(), compilationCtx);
+                            reduceArrayValue(ri, indexes.pop(), funcData.compilationCtx);
                             break;
                     }
                     break;
@@ -399,8 +406,8 @@ public class GaussianToGaussian
                 case REDUCTION_RETURN: {
                     ReductionReturnTask<?> rrt = (ReductionReturnTask<?>) t;
                     ReductionScope<?> reductionScope = rrt.getReductionScope();
-                    compilationCtx.removeScopeSubstitute(reductionScope);
-                    compilationCtx.removeSubstitute(reductionScope.j);
+                    funcData.compilationCtx.removeScopeSubstitute(reductionScope);
+                    funcData.compilationCtx.removeSubstitute(reductionScope.j);
                     break;
                 }
                 case COPY:
@@ -441,7 +448,7 @@ public class GaussianToGaussian
     @SuppressWarnings("unchecked")
     @Override
     protected void getObservationToSampleIR(SampleTask<?, ?> task, IRTreeReturn<?> current,
-            GaussianToGaussianData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
+            GaussianToGaussianData funcData, TreeBuilderInfo info) {
         List<IRTreeVoid> trees = new ArrayList<>();
         trees.add(store(funcData.denominatorSquareSumName,
                 addDD(load(funcData.denominatorSquareSumName),
@@ -453,13 +460,13 @@ public class GaussianToGaussian
                                 subtractDD((IRTreeReturn<DoubleVariable>) current, load(funcData.numeratorName)))),
                 "Add the weighting of the sample to the sum."));
 
-        trees.add(ifElse(load(funcData.sigmaNotFoundName), sequential(Tree.NoComment,
-                store(funcData.sigmaValueName, ((Gaussian) task.randomVariable).variance.getForwardIR(compilationCtx),
-                        Tree.NoComment),
-                store(funcData.sigmaNotFoundName, constant(false), Tree.NoComment)),
+        trees.add(ifElse(load(funcData.sigmaNotFoundName),
+                sequential(Tree.NoComment, store(funcData.sigmaValueName,
+                        ((Gaussian) task.randomVariable).variance.getForwardIR(info.compilationCtx), Tree.NoComment),
+                        store(funcData.sigmaNotFoundName, constant(false), Tree.NoComment)),
                 "If we have not got the value of sigma yet record it and set a flag so it is not recorded again."));
 
-        compilationCtx.addTreeToScope(task.scope(),
+        info.compilationCtx.addTreeToScope(task.scope(),
                 sequential(trees, "Record the value of a sample generated by a consuming sample " + task.id()
                         + " of random variable " + task.randomVariable.getVarDesc() + "."));
     }
@@ -574,37 +581,32 @@ public class GaussianToGaussian
     }
 
     @Override // No global state, so nothing to do here.
-    protected void allocateGlobalState(CompilationContext compilationCtx, GaussianToGaussianData funcData) {}
+    protected void allocateGlobalState(GaussianToGaussianData funcData) {}
 
     @Override
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> s,
-            IRTreeReturn<DoubleVariable> sourceProbability, GaussianToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<DoubleVariable> sourceProbability, GaussianToGaussianData funcData, TreeBuilderInfo info) {
         throw new CompilerException("Distribution samples are not yet supported for Gaussian to Gaussian inference. "
                 + "If this has been reached there is a bug in the compiler.");
     }
 
     @Override
-    protected void getPerSourceConfigStartIR(GaussianToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigStartIR(GaussianToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerSourceConfigEndIR(GaussianToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigEndIR(GaussianToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerStartIR(GaussianToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerStartIR(GaussianToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerEndIR(GaussianToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerEndIR(GaussianToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void finalize(GaussianToGaussianData funcData, CompilationContext compilationCtx) {}
+    protected void finalize(GaussianToGaussianData funcData) {}
 
     @Override
-    protected ScopeConstructor getBackTraceScope(GaussianToGaussianData funcData, CompilationContext compilationCtx) {
+    protected ScopeConstructor getBackTraceScope(GaussianToGaussianData funcData) {
         return funcData.targetScope;
     }
 
@@ -614,31 +616,27 @@ public class GaussianToGaussian
     }
 
     @Override
-    protected void addDistributionProbabilities(ScopeConstructor targetScope, GaussianToGaussianData funcData,
-            CompilationContext compilationCtx) {
+    protected void addDistributionProbabilities(ScopeConstructor targetScope, GaussianToGaussianData funcData) {
         throw new CompilerException("Unable to merge distributions in Gaussian Gaussian inference.");
     }
 
     @Override
-    protected void backTraceScopeStartIR(GaussianToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeStartIR(GaussianToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void backTraceScopeEndIR(GaussianToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeEndIR(GaussianToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleStartIR(GaussianToGaussianData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleEndIR(GaussianToGaussianData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected <C extends ScalarVariable<C>, D extends ScalarVariable<D>> void getDeterministicObservationToConditionalIR(
-            IRTreeReturn<C> current, ScalarVariable<D> input, GaussianToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<C> current, ScalarVariable<D> input, GaussianToGaussianData funcData, TreeBuilderInfo info) {
         throw new CompilerException("Unable to infer conditional guards in a conjugate prior.");
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/InverseGammaToGaussian.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/InverseGammaToGaussian.java
@@ -95,13 +95,12 @@ public class InverseGammaToGaussian extends
      * @return The intermediate representation tree to calculate a sample value based on the function data.
      */
     @Override
-    protected IRTreeReturn<DoubleVariable> calculateSampleValue(CompilationContext compilationCtx,
-            InverseGammaToGaussianData funcData) {
+    protected IRTreeReturn<DoubleVariable> calculateSampleValue(InverseGammaToGaussianData funcData) {
         // TODO adjust this so we trace back to find the constructor, and get the values
         // from them. This will allow us to have arrays of random variables.
         // Get the arguments constructed
-        IRTreeReturn<DoubleVariable> alpha = funcData.sourceRandom.alpha.getForwardIR(compilationCtx);
-        IRTreeReturn<DoubleVariable> beta = funcData.sourceRandom.beta.getForwardIR(compilationCtx);
+        IRTreeReturn<DoubleVariable> alpha = funcData.sourceRandom.alpha.getForwardIR(funcData.compilationCtx);
+        IRTreeReturn<DoubleVariable> beta = funcData.sourceRandom.beta.getForwardIR(funcData.compilationCtx);
 
         // Construct a tree to construct the sample variable.
         IRTreeReturn<DoubleVariable> mean = IRTree.functionCallReturn(FunctionType.CONJUGATE_SAMPLE,
@@ -118,36 +117,38 @@ public class InverseGammaToGaussian extends
      * @param funcData       The function data for this inference function generator.
      */
     @Override
-    protected void constructFunctionVariables(InverseGammaToGaussianData funcData, CompilationContext compilationCtx) {
+    protected void constructFunctionVariables(InverseGammaToGaussianData funcData) {
         // add a trees to initialize the temporary variables.
         funcData.targetScope.addTree((TreeBuilderInfo info) -> {
-            compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sumName, constant(0.0),
+            funcData.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.sumName,
+                    constant(0.0),
                     "Variable to track the sum of the difference between the samples and the random variables mean squared."));
 
             if(funcData.distributedConsumers)
-                compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.countNameDis,
-                        constant(0.0), "Variable to record the number of samples from consuming random variables."));
+                funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
+                        IRTree.initializeVariable(funcData.countNameDis, constant(0.0),
+                                "Variable to record the number of samples from consuming random variables."));
             else
-                compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.countName,
+                funcData.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(funcData.countName,
                         constant(0), "Variable to record the number of samples from consuming random variables."));
         });
     }
 
     @Override
     protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer,
-            InverseGammaToGaussianData funcData, CompilationContext compilationCtx) {
+            InverseGammaToGaussianData funcData) {
         VariableDescription<DoubleVariable> muName = VariableNames.calcVarName(consumer, "mu",
                 VariableType.DoubleVariable);
 
-        compilationCtx.addTreeToScope(consumer.getParent().scope(),
-                initializeVariable(muName, ((Gaussian) consumer).mean.getForwardIR(compilationCtx),
+        info.compilationCtx.addTreeToScope(consumer.getParent().scope(),
+                initializeVariable(muName, ((Gaussian) consumer).mean.getForwardIR(info.compilationCtx),
                         "The mean parameter for Gaussian " + consumer.getVarDesc() + "."));
     }
 
     @SuppressWarnings("unchecked")
     @Override
     protected void getObservationToSampleIR(SampleTask<?, ?> task, IRTreeReturn<?> current,
-            InverseGammaToGaussianData funcData, TreeBuilderInfo info, CompilationContext compilationCtx) {
+            InverseGammaToGaussianData funcData, TreeBuilderInfo info) {
 
         VariableDescription<DoubleVariable> muName = VariableNames.calcVarName(task.randomVariable, "mu",
                 VariableType.DoubleVariable);
@@ -170,7 +171,7 @@ public class InverseGammaToGaussian extends
                     "Increment the number of samples in the calculation."));
         }
 
-        compilationCtx.addTreeToScope(task.scope(), sequential(trees, "Consume sample task " + task.id()
+        info.compilationCtx.addTreeToScope(task.scope(), sequential(trees, "Consume sample task " + task.id()
                 + " from random variable " + task.randomVariable.getVarDesc() + "."));
     }
 
@@ -271,38 +272,32 @@ public class InverseGammaToGaussian extends
     }
 
     @Override // No global state, so nothing to do here.
-    protected void allocateGlobalState(CompilationContext compilationCtx, InverseGammaToGaussianData funcData) {}
+    protected void allocateGlobalState(InverseGammaToGaussianData funcData) {}
 
     @Override
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> s,
-            IRTreeReturn<DoubleVariable> sourceProbability, InverseGammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<DoubleVariable> sourceProbability, InverseGammaToGaussianData funcData, TreeBuilderInfo info) {
         throw new CompilerException(
                 "Distribution samples are not yet supported in " + getInferenceType() + " inference.");
     }
 
     @Override
-    protected void getPerSourceConfigStartIR(InverseGammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigStartIR(InverseGammaToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerSourceConfigEndIR(InverseGammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerSourceConfigEndIR(InverseGammaToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerStartIR(InverseGammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerStartIR(InverseGammaToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void getPerConsumerEndIR(InverseGammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void getPerConsumerEndIR(InverseGammaToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void finalize(InverseGammaToGaussianData funcData, CompilationContext compilationCtx) {}
+    protected void finalize(InverseGammaToGaussianData funcData) {}
 
     @Override
-    protected ScopeConstructor getBackTraceScope(InverseGammaToGaussianData funcData,
-            CompilationContext compilationCtx) {
+    protected ScopeConstructor getBackTraceScope(InverseGammaToGaussianData funcData) {
         return funcData.targetScope;
     }
 
@@ -312,31 +307,28 @@ public class InverseGammaToGaussian extends
     }
 
     @Override
-    protected void addDistributionProbabilities(ScopeConstructor targetScope, InverseGammaToGaussianData funcData,
-            CompilationContext compilationCtx) {
+    protected void addDistributionProbabilities(ScopeConstructor targetScope, InverseGammaToGaussianData funcData) {
         throw new CompilerException("Unable to merge distributions in this " + getInferenceType() + " inference.");
     }
 
     @Override
-    protected void backTraceScopeStartIR(InverseGammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeStartIR(InverseGammaToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
-    protected void backTraceScopeEndIR(InverseGammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {}
+    protected void backTraceScopeEndIR(InverseGammaToGaussianData funcData, TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleStartIR(InverseGammaToGaussianData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected void getPerDistributedSampleEndIR(InverseGammaToGaussianData funcData, DistributionSampleTask<?, ?> s,
-            TreeBuilderInfo info, CompilationContext compilationCtx) {}
+            TreeBuilderInfo info) {}
 
     @Override
     protected <C extends ScalarVariable<C>, D extends ScalarVariable<D>> void getDeterministicObservationToConditionalIR(
-            IRTreeReturn<C> current, ScalarVariable<D> input, InverseGammaToGaussianData funcData, TreeBuilderInfo info,
-            CompilationContext compilationCtx) {
+            IRTreeReturn<C> current, ScalarVariable<D> input, InverseGammaToGaussianData funcData,
+            TreeBuilderInfo info) {
         throw new CompilerException("Unable to infer conditional guards in a conjugate prior.");
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/marginalization/MarginalizationFunctions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/marginalization/MarginalizationFunctions.java
@@ -128,26 +128,24 @@ public class MarginalizationFunctions<A extends ScalarVariable<A>, B extends Dis
     }
 
     @Override
-    protected void constructFunctionVariablesProb(CompilationContext compilationCtx,
-            MarginalizationData<A, B> funcData) {
+    protected void constructFunctionVariablesProb(MarginalizationData<A, B> funcData) {
         // Set up a pointer for accessing local space.
         IRTreeReturn<ArrayVariable<DoubleVariable>> globalState = loadGlobalField(funcData.statesProbabilityNameGlobal,
-                funcData, compilationCtx);
+                funcData);
         IRTreeVoid getLocalState = initializeVariable(statesProbabilityNameLocal, globalState,
                 "Get a local reference to the scratch space.");
-        compilationCtx.addTreeToScope(GlobalScope.scope, getLocalState);
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, getLocalState);
     }
 
     @Override
-    protected void allocateGlobalStateProb(MarginalizationData<A, B> funcData, CompilationContext compilationCtx) {
-        allocateGlobalArray(compilationCtx, funcData, funcData.sourceRandom, funcData.statesProbabilityNameGlobal);
+    protected void allocateGlobalStateProb(MarginalizationData<A, B> funcData) {
+        allocateGlobalArray(funcData, funcData.sourceRandom, funcData.statesProbabilityNameGlobal);
     }
 
     @Override
-    protected IRTreeReturn<A> calculateSampleValue(CompilationContext compilationCtx,
-            MarginalizationData<A, B> funcData) {
+    protected IRTreeReturn<A> calculateSampleValue(MarginalizationData<A, B> funcData) {
         IRTreeReturn<ArrayVariable<DoubleVariable>> arrayValue = load(statesProbabilityNameLocal);
-        normalizeArray(arrayValue, arrayValue, compilationCtx);
+        normalizeArray(arrayValue, arrayValue, funcData.compilationCtx);
 
         return funcData.sourceRandom.getStateValue(functionCallReturn(FunctionType.SAMPLE, VariableType.IntVariable,
                 VariableType.Categorical, arrayValue, load(numStatesName)));
@@ -188,27 +186,25 @@ public class MarginalizationFunctions<A extends ScalarVariable<A>, B extends Dis
     }
 
     @Override
-    protected void setSampleValue(MarginalizationData<A, B> funcData, CompilationContext compilationCtx) {
-        compilationCtx.addTreeToScope(GlobalScope.scope, setCurrentValue(
+    protected void setSampleValue(MarginalizationData<A, B> funcData) {
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, setCurrentValue(
                 funcData.sourceRandom.getStateValue(funcData.valuePos), "Value of the variable at this index"));
         // This is still required for the case that this is not a distribution, in which
         // case independent values that are not the sample value still need to be set.
         if(!funcData.sampleDesc.sample.isDistribution())
-            funcData.sampleDesc.updateSample(getCurrentValue(), compilationCtx);
+            funcData.sampleDesc.updateSample(getCurrentValue(), funcData.compilationCtx);
     }
 
     @Override
-    protected void saveBackTraceProbability(MarginalizationData<A, B> funcData, IRTreeReturn<DoubleVariable> value,
-            CompilationContext compilationCtx) {
+    protected void saveBackTraceProbability(MarginalizationData<A, B> funcData, IRTreeReturn<DoubleVariable> value) {
         IRTreeReturn<ArrayVariable<DoubleVariable>> array = load(statesProbabilityNameLocal);
         IRTreeVoid arraySet = arrayPut(array, funcData.valuePos, value,
                 "Save the calculated index value into the array of index value probabilities");
-        compilationCtx.addTreeToScope(GlobalScope.scope, arraySet);
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, arraySet);
     }
 
     @Override
-    protected void addDistributionProbabilities(ScopeConstructor targetScope, MarginalizationData<A, B> funcData,
-            CompilationContext compilationCtx) {
+    protected void addDistributionProbabilities(ScopeConstructor targetScope, MarginalizationData<A, B> funcData) {
         targetScope = targetScope
                 .addComment("Set the calculated probabilities to be the distribution values, and normalize");
         targetScope.addTree((TreeBuilderInfo info) -> {
@@ -218,11 +214,11 @@ public class MarginalizationFunctions<A extends ScalarVariable<A>, B extends Dis
             VariableDescription<ArrayVariable<DoubleVariable>> localProbability = VariableNames
                     .calcVarName("localProbability", VariableType.arrayType(VariableType.DoubleVariable), true);
             IRTreeReturn<ArrayVariable<DoubleVariable>> probabilityArray = ((DistributionSampleTask<?, ?>) funcData.sampleDesc.sample)
-                    .getProbabilitiesArray().getForwardIR(compilationCtx);
-            compilationCtx.addTreeToScope(GlobalScope.scope,
+                    .getProbabilitiesArray().getForwardIR(funcData.compilationCtx);
+            funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
                     initializeVariable(localProbability, probabilityArray, "Local copy of the probability array"));
 
-            normalizeArray(arrayValue, load(localProbability), compilationCtx);
+            normalizeArray(arrayValue, load(localProbability), funcData.compilationCtx);
         });
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsArrayFunctions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsArrayFunctions.java
@@ -84,10 +84,10 @@ public abstract class MetropolisHastingsArrayFunctions<A extends Variable<A>, B 
      * 
      */
     @Override
-    protected ScopeConstructor getBackTraceScope(MetropolisHastingsArrayData<A, B> funcData,
-            CompilationContext compilationCtx) {
-        ScopeConstructor targetScope = super.getBackTraceScope(funcData, compilationCtx);
-        IRTreeReturn<BooleanVariable> guard = or(TreeUtils.getIsConstrained(funcData.sampleDesc.sample, compilationCtx),
+    protected ScopeConstructor getBackTraceScope(MetropolisHastingsArrayData<A, B> funcData) {
+        ScopeConstructor targetScope = super.getBackTraceScope(funcData);
+        IRTreeReturn<BooleanVariable> guard = or(
+                TreeUtils.getIsConstrained(funcData.sampleDesc.sample, funcData.compilationCtx),
                 eq(funcData.valuePos, constant(0)));
         targetScope = targetScope.addCondition(guard).ifScopeConstructor();
         funcData.sampleTargetScope = targetScope;
@@ -95,8 +95,7 @@ public abstract class MetropolisHastingsArrayFunctions<A extends Variable<A>, B 
     }
 
     @Override
-    protected ScopeConstructor getSampleTaskScope(MetropolisHastingsArrayData<A, B> funcData,
-            CompilationContext compilationCtx) {
+    protected ScopeConstructor getSampleTaskScope(MetropolisHastingsArrayData<A, B> funcData) {
         return funcData.sampleTargetScope;
     }
 
@@ -124,8 +123,7 @@ public abstract class MetropolisHastingsArrayFunctions<A extends Variable<A>, B 
 
     // No global state is required.
     @Override
-    protected void allocateGlobalStateProb(MetropolisHastingsArrayData<A, B> funcData,
-            CompilationContext compilationCtx) {}
+    protected void allocateGlobalStateProb(MetropolisHastingsArrayData<A, B> funcData) {}
 
     /**
      * This method contains the meat of the code generation for this inference step. First we generate the intermediate
@@ -134,16 +132,15 @@ public abstract class MetropolisHastingsArrayFunctions<A extends Variable<A>, B 
      * <p>
      * TODO make the lower bound of the uniform distribution a user configurable parameter.
      *
-     * @param funcData       the function data for this inference function generator.
-     * @param compilationCtx The compilation context for this compilation process.
+     * @param funcData the function data for this inference function generator.
      */
     @Override
-    protected void addSampleValueTree(MetropolisHastingsArrayData<A, B> funcData, CompilationContext compilationCtx) {
+    protected void addSampleValueTree(MetropolisHastingsArrayData<A, B> funcData) {
 
         VariableDescription<DoubleVariable> ratioName = VariableNames.calcVarName("ratio", VariableType.DoubleVariable,
                 true);
         IRTreeReturn<DoubleVariable> ratio = subtractDD(load(proposedProbabilityName), load(originalProbabilityName));
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(ratioName, ratio,
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(ratioName, ratio,
                 "Ratio of the probability of proposed and original sample values"));
 
         IRTreeReturn<DoubleVariable> bound = log(functionCallReturn(FunctionType.SAMPLE, VariableType.DoubleVariable,
@@ -157,7 +154,7 @@ public abstract class MetropolisHastingsArrayFunctions<A extends Variable<A>, B 
                 "Test if the probability of the sample is sufficient to keep the value. This needs to be less than or equal "
                         + "as otherwise if the proposed value is not possible and the random value is 0 an impossible value will be "
                         + "accepted.",
-                compilationCtx);
+                funcData.compilationCtx);
         targetScope = targetScope.addCondition(eq(funcData.valuePos, constant(1))).ifScopeConstructor();
         targetScope = targetScope.addCondition(guard).ifScopeConstructor();
         targetScope = targetScope
@@ -167,7 +164,7 @@ public abstract class MetropolisHastingsArrayFunctions<A extends Variable<A>, B 
         // the tree to set all the intermediate variables etc.
         targetScope = targetScope.addComment("Set the sample value");
         targetScope.addTree((TreeBuilderInfo info) -> {
-            super.addSampleValueTree(funcData, compilationCtx);
+            super.addSampleValueTree(funcData);
         });
     }
 
@@ -176,19 +173,19 @@ public abstract class MetropolisHastingsArrayFunctions<A extends Variable<A>, B 
      * unsuccessful and needs to be rolled back.
      */
     @Override
-    protected IRTreeVoid calculateSampleValue(MetropolisHastingsArrayData<A, B> funcData,
-            CompilationContext compilationCtx) {
+    protected IRTreeVoid calculateSampleValue(MetropolisHastingsArrayData<A, B> funcData) {
         return updateSampleValue(funcData, true);
     }
 
     @Override
-    protected void setSampleValue(MetropolisHastingsArrayData<A, B> funcData, CompilationContext compilationCtx) {
-        ScopeConstructor sc = ScopeConstructor.construct(funcData.sampleDesc.sample, Tree.NoComment, compilationCtx);
+    protected void setSampleValue(MetropolisHastingsArrayData<A, B> funcData) {
+        ScopeConstructor sc = ScopeConstructor.construct(funcData.sampleDesc.sample, Tree.NoComment,
+                funcData.compilationCtx);
         sc = sc.addCondition(eq(funcData.valuePos, constant(1))).ifScopeConstructor();
         sc = sc.addIsolation("Update Sample and intermediate values");
 
         sc.addTree((TreeBuilderInfo info) -> {
-            funcData.sampleDesc.updateSample(updateSampleValue(funcData, false), compilationCtx);
+            funcData.sampleDesc.updateSample(updateSampleValue(funcData, false), info.compilationCtx);
         });
     }
 
@@ -196,8 +193,8 @@ public abstract class MetropolisHastingsArrayFunctions<A extends Variable<A>, B 
 
     @Override
     protected void saveBackTraceProbability(MetropolisHastingsArrayData<A, B> funcData,
-            IRTreeReturn<DoubleVariable> value, CompilationContext compilationCtx) {
-        compilationCtx.addTreeToScope(GlobalScope.scope, ifElse(eq(funcData.valuePos, constant(0)),
+            IRTreeReturn<DoubleVariable> value) {
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, ifElse(eq(funcData.valuePos, constant(0)),
                 store(originalProbabilityName, value, Tree.NoComment), "Save the probability of the original value.",
                 store(proposedProbabilityName, value, Tree.NoComment), "Save the probability of the proposed value."));
     }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsDoubleFunctions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsDoubleFunctions.java
@@ -1,7 +1,7 @@
 /*
  * Sandwood
  *
- * Copyright (c) 2019-2024, Oracle and/or its affiliates
+ * Copyright (c) 2019-2026, Oracle and/or its affiliates
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
@@ -50,8 +50,7 @@ public class MetropolisHastingsDoubleFunctions<B extends RandomVariable<DoubleVa
         extends MetropolisHastingsScalarFunctions<DoubleVariable, B> {
 
     @Override
-    protected void getProposedValue(MetropolisHastingsData<DoubleVariable, B> funcData,
-            CompilationContext compilationCtx) {
+    protected void getProposedValue(MetropolisHastingsData<DoubleVariable, B> funcData) {
         VariableDescription<DoubleVariable> varName = VariableNames.calcVarName("var", VariableType.DoubleVariable,
                 true);
 
@@ -60,7 +59,7 @@ public class MetropolisHastingsDoubleFunctions<B extends RandomVariable<DoubleVa
         IRTreeReturn<DoubleVariable> proposedVar = multiplyDD(
                 multiplyDD(load(funcData.originalValueName), load(funcData.originalValueName)),
                 multiplyDD(constant(fractionOfCurrentValue), constant(fractionOfCurrentValue)));
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(varName, proposedVar, "Calculate a proposed variance."));
 
         // Ensure it is not too small
@@ -68,11 +67,11 @@ public class MetropolisHastingsDoubleFunctions<B extends RandomVariable<DoubleVa
                 multiplyDD(constant(fractionOfCurrentValue), constant(fractionOfCurrentValue)));
         IRTreeVoid ifStmt = store(varName,
                 multiplyDD(constant(fractionOfCurrentValue), constant(fractionOfCurrentValue)), Tree.NoComment);
-        compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.ifElse(guard, ifStmt,
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.ifElse(guard, ifStmt,
                 "Ensure the variance is at least " + removeRounding(fractionOfCurrentValue * fractionOfCurrentValue)));
 
         // Sample a Gaussian distribution based on it to generate the new proposed value.
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(funcData.proposedValueName,
                         functionCallReturn(FunctionType.SAMPLE, VariableType.DoubleVariable, VariableType.Gaussian,
                                 load(funcData.originalValueName), load(varName)),

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsIntFunctions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsIntFunctions.java
@@ -1,7 +1,7 @@
 /*
  * Sandwood
  *
- * Copyright (c) 2019-2024, Oracle and/or its affiliates
+ * Copyright (c) 2019-2026, Oracle and/or its affiliates
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
@@ -62,8 +62,7 @@ public class MetropolisHastingsIntFunctions<B extends RandomVariable<IntVariable
      * Method to select a proposed value.
      */
     @Override
-    protected void getProposedValue(MetropolisHastingsData<IntVariable, B> funcData,
-            CompilationContext compilationCtx) {
+    protected void getProposedValue(MetropolisHastingsData<IntVariable, B> funcData) {
         VariableDescription<DoubleVariable> varName = VariableNames.calcVarName("var", VariableType.DoubleVariable,
                 true);
         VariableDescription<DoubleVariable> offsetName = VariableNames.calcVarName("offset",
@@ -74,17 +73,17 @@ public class MetropolisHastingsIntFunctions<B extends RandomVariable<IntVariable
         IRTreeReturn<DoubleVariable> proposedVar = multiplyID(
                 multiplyII(load(funcData.originalValueName), load(funcData.originalValueName)),
                 multiplyDD(constant(fractionOfCurrentValue), constant(fractionOfCurrentValue)));
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(varName, proposedVar, "Calculate a proposed variance."));
 
         // Ensure it is not too small
         IRTreeReturn<BooleanVariable> guard = lessThan(load(varName), constant(1.0));
         IRTreeVoid ifStmt = store(varName, constant(1.0), Tree.NoComment);
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
                 IRTree.ifElse(guard, ifStmt, "Ensure the variance is at least 1"));
 
         // Sample a Gaussian distribution based on it.
-        compilationCtx.addTreeToScope(GlobalScope.scope,
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(
                         offsetName, functionCallReturn(FunctionType.SAMPLE, VariableType.DoubleVariable,
                                 VariableType.Gaussian, constant(0.0), load(varName)),
@@ -95,14 +94,15 @@ public class MetropolisHastingsIntFunctions<B extends RandomVariable<IntVariable
         IRTreeReturn<DoubleVariable> ifValue = subtractDI(load(offsetName), constant(1));
         IRTreeReturn<DoubleVariable> elseValue = addDI(load(offsetName), constant(1));
         IRTreeReturn<DoubleVariable> offset = conditionalAssignment(guard, ifValue, elseValue);
-        compilationCtx.addTreeToScope(GlobalScope.scope, store(offsetName, offset, "Make sure the offset is not 0"));
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
+                store(offsetName, offset, "Make sure the offset is not 0"));
 
         // Construct the proposed value
         IRTreeReturn<IntVariable> proposedValueTree = addII(load(funcData.originalValueName),
                 castToInteger(load(offsetName)));
         IRTreeVoid proposedValueTreeInit = initializeVariable(funcData.proposedValueName, proposedValueTree,
                 "The proposed new value for the sample");
-        compilationCtx.addTreeToScope(GlobalScope.scope, proposedValueTreeInit);
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, proposedValueTreeInit);
     }
 
     @Override

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsScalarFunctions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsScalarFunctions.java
@@ -92,10 +92,10 @@ public abstract class MetropolisHastingsScalarFunctions<A extends ScalarVariable
      * 
      */
     @Override
-    protected ScopeConstructor getBackTraceScope(MetropolisHastingsData<A, B> funcData,
-            CompilationContext compilationCtx) {
-        ScopeConstructor targetScope = super.getBackTraceScope(funcData, compilationCtx);
-        IRTreeReturn<BooleanVariable> guard = or(TreeUtils.getIsConstrained(funcData.sampleDesc.sample, compilationCtx),
+    protected ScopeConstructor getBackTraceScope(MetropolisHastingsData<A, B> funcData) {
+        ScopeConstructor targetScope = super.getBackTraceScope(funcData);
+        IRTreeReturn<BooleanVariable> guard = or(
+                TreeUtils.getIsConstrained(funcData.sampleDesc.sample, funcData.compilationCtx),
                 eq(funcData.valuePos, constant(0)));
         targetScope = targetScope.addCondition(guard).ifScopeConstructor();
         funcData.sampleTargetScope = targetScope;
@@ -103,8 +103,7 @@ public abstract class MetropolisHastingsScalarFunctions<A extends ScalarVariable
     }
 
     @Override
-    protected ScopeConstructor getSampleTaskScope(MetropolisHastingsData<A, B> funcData,
-            CompilationContext compilationCtx) {
+    protected ScopeConstructor getSampleTaskScope(MetropolisHastingsData<A, B> funcData) {
         return funcData.sampleTargetScope;
     }
 
@@ -117,31 +116,30 @@ public abstract class MetropolisHastingsScalarFunctions<A extends ScalarVariable
      * TODO Make the parameters of the normal distribution generating the proposals user configurable.
      */
     @Override
-    protected void constructFunctionVariablesProb(CompilationContext compilationCtx,
-            MetropolisHastingsData<A, B> funcData) {
-        IRTreeReturn<A> originalValueInit = constructOriginal(funcData, compilationCtx);
+    protected void constructFunctionVariablesProb(MetropolisHastingsData<A, B> funcData) {
+        IRTreeReturn<A> originalValueInit = constructOriginal(funcData);
         IRTreeVoid originalValueTreeInit = initializeVariable(funcData.originalValueName, originalValueInit,
                 "The original value of the sample");
-        compilationCtx.addTreeToScope(GlobalScope.scope, originalValueTreeInit);
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, originalValueTreeInit);
 
         IRTreeReturn<DoubleVariable> probOriginalValue = constant(0.0);
         IRTreeVoid originalProbability = initializeVariable(originalProbabilityName, probOriginalValue,
                 "The probability of the random variable generating the originally sampled value");
-        compilationCtx.addTreeToScope(GlobalScope.scope, originalProbability);
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, originalProbability);
 
-        getProposedValue(funcData, compilationCtx);
+        getProposedValue(funcData);
 
         IRTreeReturn<DoubleVariable> probProposedValue = constant(0.0);
         IRTreeVoid proposedProbability = initializeVariable(proposedProbabilityName, probProposedValue,
                 "The probability of the random variable generating the new sample value.");
-        compilationCtx.addTreeToScope(GlobalScope.scope, proposedProbability);
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, proposedProbability);
     }
 
-    protected abstract void getProposedValue(MetropolisHastingsData<A, B> funcData, CompilationContext compilationCtx);
+    protected abstract void getProposedValue(MetropolisHastingsData<A, B> funcData);
 
     // No global state is required.
     @Override
-    protected void allocateGlobalStateProb(MetropolisHastingsData<A, B> funcData, CompilationContext compilationCtx) {}
+    protected void allocateGlobalStateProb(MetropolisHastingsData<A, B> funcData) {}
 
     /**
      * Method to back track through the trace from the original stored value to the sample task to construct the value
@@ -151,8 +149,7 @@ public abstract class MetropolisHastingsScalarFunctions<A extends ScalarVariable
      * @param compilationCtx
      * @return
      */
-    private IRTreeReturn<A> constructOriginal(MetropolisHastingsData<A, B> funcData,
-            CompilationContext compilationCtx) {
+    private IRTreeReturn<A> constructOriginal(MetropolisHastingsData<A, B> funcData) {
         TraceHandle trace = funcData.sampleDesc.sampleVarDesc.traceToSampleVariable;
         /*
          * The trace comes from the sample value and so does not have any arithmetic performed on it, instead at most it
@@ -166,7 +163,8 @@ public abstract class MetropolisHastingsScalarFunctions<A extends ScalarVariable
         DataflowTaskArgDesc d = trace.get(index--);
         ProducingDataflowTask<?> t = d.task;
 
-        IRTreeReturn<?> current = funcData.sampleDesc.sampleVarDesc.sampleVariable.getForwardIR(compilationCtx);
+        IRTreeReturn<?> current = funcData.sampleDesc.sampleVarDesc.sampleVariable
+                .getForwardIR(funcData.compilationCtx);
 
         while(true) {
             switch(t.getType()) {
@@ -174,7 +172,7 @@ public abstract class MetropolisHastingsScalarFunctions<A extends ScalarVariable
                     return (IRTreeReturn<A>) current;
 
                 default:
-                    current = t.getInverseIR(d.argPos, current, backTraceInfo, compilationCtx);
+                    current = t.getInverseIR(d.argPos, current, backTraceInfo, funcData.compilationCtx);
                     d = trace.get(index--);
                     t = d.task;
             }
@@ -193,11 +191,11 @@ public abstract class MetropolisHastingsScalarFunctions<A extends ScalarVariable
      */
 
     @Override
-    protected void addSampleValueTree(MetropolisHastingsData<A, B> funcData, CompilationContext compilationCtx) {
+    protected void addSampleValueTree(MetropolisHastingsData<A, B> funcData) {
         VariableDescription<DoubleVariable> ratioName = VariableNames.calcVarName("ratio", VariableType.DoubleVariable,
                 true);
         IRTreeReturn<DoubleVariable> ratio = subtractDD(load(proposedProbabilityName), load(originalProbabilityName));
-        compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(ratioName, ratio,
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(ratioName, ratio,
                 "The probability ration for the proposed value and the current value."));
 
         IRTreeReturn<DoubleVariable> bound = log(functionCallReturn(FunctionType.SAMPLE, VariableType.DoubleVariable,
@@ -211,7 +209,7 @@ public abstract class MetropolisHastingsScalarFunctions<A extends ScalarVariable
                 "Test if the probability of the sample is sufficient "
                         + "to keep the value. This needs to be less than or equal as otherwise if the proposed value is not possible and "
                         + "the random value is 0 an impossible value will be accepted.",
-                compilationCtx);
+                funcData.compilationCtx);
         targetScope = targetScope.addCondition(eq(funcData.valuePos, constant(1))).ifScopeConstructor();
         targetScope = targetScope.addCondition(guard).ifScopeConstructor();
         targetScope = targetScope.addComment("If it is not revert the changes.");
@@ -220,7 +218,7 @@ public abstract class MetropolisHastingsScalarFunctions<A extends ScalarVariable
         // the tree to set all the intermediate variables etc.
         targetScope = targetScope.addComment("Set the sample value");
         targetScope.addTree((TreeBuilderInfo info) -> {
-            super.addSampleValueTree(funcData, compilationCtx);
+            super.addSampleValueTree(funcData);
         });
     }
 
@@ -229,44 +227,42 @@ public abstract class MetropolisHastingsScalarFunctions<A extends ScalarVariable
      * unsuccessful.
      */
     @Override
-    protected IRTreeReturn<A> calculateSampleValue(CompilationContext compilationCtx,
-            MetropolisHastingsData<A, B> funcData) {
+    protected IRTreeReturn<A> calculateSampleValue(MetropolisHastingsData<A, B> funcData) {
         return load(funcData.originalValueName);
     }
 
     @Override
-    protected void setSampleValue(MetropolisHastingsData<A, B> funcData, CompilationContext compilationCtx) {
-        ScopeConstructor sc = ScopeConstructor.construct(funcData.sampleDesc.sample, Tree.NoComment, compilationCtx);
+    protected void setSampleValue(MetropolisHastingsData<A, B> funcData) {
+        ScopeConstructor sc = ScopeConstructor.construct(funcData.sampleDesc.sample, Tree.NoComment,
+                funcData.compilationCtx);
         IfElseScopeConstructors ifElse = sc.addCondition(eq(funcData.valuePos, constant(0)));
         ifElse.ifScopeConstructor().addTree((TreeBuilderInfo info) -> {
             IRTreeVoid t = setCurrentValue(load(funcData.originalValueName),
                     "Set the current value to the current state of the tree.");
-            compilationCtx.addTreeToScope(GlobalScope.scope, t);
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, t);
         });
 
         ScopeConstructor elseSC = ifElse.elseScopeConstructor();
         elseSC.addTree((TreeBuilderInfo info) -> {
             IRTreeVoid updateCurrent = setCurrentValue(load(funcData.proposedValueName), Tree.NoComment);
-            compilationCtx.addTreeToScope(GlobalScope.scope, updateCurrent);
+            info.compilationCtx.addTreeToScope(GlobalScope.scope, updateCurrent);
         });
 
         ScopeConstructor blockSC = elseSC.addComment("Update Sample and intermediate values");
         blockSC.addTree((TreeBuilderInfo) -> {
-            funcData.sampleDesc.updateSample(load(funcData.proposedValueName), compilationCtx);
+            funcData.sampleDesc.updateSample(load(funcData.proposedValueName), funcData.compilationCtx);
         });
     }
 
     @Override
-    protected void saveBackTraceProbability(MetropolisHastingsData<A, B> funcData, IRTreeReturn<DoubleVariable> value,
-            CompilationContext compilationCtx) {
-        compilationCtx.addTreeToScope(GlobalScope.scope, ifElse(eq(funcData.valuePos, constant(0)),
+    protected void saveBackTraceProbability(MetropolisHastingsData<A, B> funcData, IRTreeReturn<DoubleVariable> value) {
+        funcData.compilationCtx.addTreeToScope(GlobalScope.scope, ifElse(eq(funcData.valuePos, constant(0)),
                 store(originalProbabilityName, value, Tree.NoComment), "Save the probability of the original value.",
                 store(proposedProbabilityName, value, Tree.NoComment), "Save the probability of the proposed value."));
     }
 
     @Override
-    protected void addDistributionProbabilities(ScopeConstructor targetScope, MetropolisHastingsData<A, B> funcData,
-            CompilationContext compilationCtx) {
+    protected void addDistributionProbabilities(ScopeConstructor targetScope, MetropolisHastingsData<A, B> funcData) {
         throw new CompilerException("Distributions generation is not supported in Metropolis Hastings Inference.");
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/GetArrayTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/GetArrayTask.java
@@ -1,7 +1,7 @@
 /*
  * Sandwood
  *
- * Copyright (c) 2019-2025, Oracle and/or its affiliates
+ * Copyright (c) 2019-2026, Oracle and/or its affiliates
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
@@ -205,9 +205,9 @@ public class GetArrayTask<A extends Variable<A>> extends GetTask<ArrayVariable<A
 
             for(Set<TraceHandle> ts:ld.toPutTraces.values()) {
                 ScopeConstructor sci = sc.addBackConstraints(ts, Guards.NO_GUARDS, Traces.noDistributionTraces);
-                sci.addTree((TreeBuilderInfo t) -> {
-                    ArrayVariable<?> a = (ArrayVariable<?>) ((PutTask<?>) t.getTrace().get(0).task).value;
-                    compilationCtx.addTreeToScope(GlobalScope.scope,
+                sci.addTree((TreeBuilderInfo info) -> {
+                    ArrayVariable<?> a = (ArrayVariable<?>) ((PutTask<?>) info.getTrace().get(0).task).value;
+                    info.compilationCtx.addTreeToScope(GlobalScope.scope,
                             IRTree.store(lengthName, a.getLength(compilationCtx), Tree.NoComment));
                 });
             }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/Traces.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/Traces.java
@@ -205,9 +205,9 @@ public abstract class Traces {
                     // phase will remove it.
                     a = a.addIsolation();
                     a.addTree((TreeBuilderInfo info) -> {
-                        compilationCtx.setRequiredArrays(getRequiredArrays(v));
-                        populateValue(v, compilationCtx);
-                        compilationCtx.clearRequiredArrays();
+                        info.compilationCtx.setRequiredArrays(getRequiredArrays(v));
+                        populateValue(v, info.compilationCtx);
+                        info.compilationCtx.clearRequiredArrays();
                     });
                 }
             }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/guards/ScopeConstructor.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/guards/ScopeConstructor.java
@@ -105,7 +105,7 @@ public class ScopeConstructor {
 
     public enum Direction {
         FORWARDS,
-        BACKWARDS; 
+        BACKWARDS;
     }
 
     public enum Guards {
@@ -969,7 +969,7 @@ public class ScopeConstructor {
                 // array for it.
                 if(guardDesc.scopes.isEmpty()) {
                     VariableDescription<BooleanVariable> varDesc = guardDesc.varDesc;
-                    addTree((TreeBuilderInfo info) -> compilationCtx.addTreeToScope(GlobalScope.scope,
+                    addTree((TreeBuilderInfo info) -> info.compilationCtx.addTreeToScope(GlobalScope.scope,
                             initializeVariable(varDesc, constant(false),
                                     "Guard to check that at most one copy of the code is executed for a given set of loop iterations.")));
                 } else {
@@ -1514,7 +1514,7 @@ public class ScopeConstructor {
         ParForTask parallelScope = getParallelScope(tasks.get(getConstraintCount() - 1).scope());
         allocateGlobalState(guardDesc.scopes, globalGuardName, parallelScope);
 
-        addTree((TreeBuilderInfo info) -> compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(
+        addTree((TreeBuilderInfo info) -> info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(
                 VariableNames.altTypeName(guardDesc.varDesc, globalGuardName.type),
                 loadGlobalField(globalGuardName, parallelScope),
                 "Guard to check that at most one copy of the code is executed for a given random variable instance.")));
@@ -1526,7 +1526,7 @@ public class ScopeConstructor {
             List<IRTreeReturn<IntVariable>> indexes = constructGuardScopes(guardDesc.scopes);
 
             // Then use tree utils to place the value.
-            compilationCtx.addTreeToScope(GlobalScope.scope,
+            info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     TreeUtils.putIndirectValue(guardDesc.varDesc, indexes, constant(false), "Set the flags to false"));
         });
     }


### PR DESCRIPTION
### Description
Removing unrequired passing of the compilationCtx object when the value
can be retrieved from the function or treeBuilderInfo object.

### Motivation
The compilation context object is being passed into abstract methods at the same time as objects that contain a reference to the compilation context object. This creates duplication and potentially the possibility for inconsistencies.  For both reasons this simplification is performed.