### PR TITLE
ThreadID variable name bug

### DIFF
--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/guards/ScopeConstructor.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/guards/ScopeConstructor.java
@@ -1511,7 +1511,7 @@ public class ScopeConstructor {
                 .globalGuardName(guardDesc.varDesc,
                         VariableType.getType(VariableType.BooleanVariable, guardDesc.scopes.size()));
         // Get the parallel scope, null if this code is not executed in parallel.
-        ParForTask parallelScope = getParallelScope(tasks.get(getConstraintCount() - 1).scope());
+        ParForTask parallelScope = getParallelScope(tasks.get(0).scope());
         allocateGlobalState(guardDesc.scopes, globalGuardName, parallelScope);
 
         addTree((TreeBuilderInfo info) -> compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(

--- a/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/parser/CompilerTest.java
+++ b/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/parser/CompilerTest.java
@@ -81,7 +81,7 @@ class CompilerTest {
     }
 
     // Set temporary and target directories.
-    File targetDir;
+    private File targetDir;
 
     @ParameterizedTest
     @MethodSource("getFileNameArgs")

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$CoreInterface_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$CoreInterface_model.java
@@ -1,0 +1,94 @@
+package org.sandwood.compiler.tests.parser;
+
+interface LowDimMix$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
+
+	// Getter for N.
+	public int get$N();
+
+	// Getter for component.
+	public boolean[] get$component();
+
+	// Setter for component.
+	public void set$component(boolean[] cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample101.
+	public boolean get$fixedFlag$sample101();
+
+	// Setter for fixedFlag$sample101.
+	public void set$fixedFlag$sample101(boolean cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample20.
+	public boolean get$fixedFlag$sample20();
+
+	// Setter for fixedFlag$sample20.
+	public void set$fixedFlag$sample20(boolean cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample83.
+	public boolean get$fixedFlag$sample83();
+
+	// Setter for fixedFlag$sample83.
+	public void set$fixedFlag$sample83(boolean cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample88.
+	public boolean get$fixedFlag$sample88();
+
+	// Setter for fixedFlag$sample88.
+	public void set$fixedFlag$sample88(boolean cv$value, boolean allocated$);
+
+	// Getter for length$yObserved.
+	public int get$length$yObserved();
+
+	// Setter for length$yObserved.
+	public void set$length$yObserved(int cv$value, boolean allocated$);
+
+	// Getter for logProbability$component.
+	public double get$logProbability$component();
+
+	// Getter for logProbability$componentDistribution.
+	public double get$logProbability$componentDistribution();
+
+	// Getter for logProbability$mu.
+	public double get$logProbability$mu();
+
+	// Getter for logProbability$rawMu.
+	public double get$logProbability$rawMu();
+
+	// Getter for logProbability$sigma.
+	public double get$logProbability$sigma();
+
+	// Getter for logProbability$theta.
+	public double get$logProbability$theta();
+
+	// Getter for logProbability$y.
+	public double get$logProbability$y();
+
+	// Getter for mu.
+	public double[] get$mu();
+
+	// Getter for rawMu.
+	public double[] get$rawMu();
+
+	// Setter for rawMu.
+	public void set$rawMu(double[] cv$value, boolean allocated$);
+
+	// Getter for sigma.
+	public double[] get$sigma();
+
+	// Setter for sigma.
+	public void set$sigma(double[] cv$value, boolean allocated$);
+
+	// Getter for theta.
+	public double get$theta();
+
+	// Setter for theta.
+	public void set$theta(double cv$value, boolean allocated$);
+
+	// Getter for y.
+	public double[] get$y();
+
+	// Getter for yObserved.
+	public double[] get$yObserved();
+
+	// Setter for yObserved.
+	public void set$yObserved(double[] cv$value, boolean allocated$);
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$CoreInterface_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$CoreInterface_modelNoComments.java
@@ -1,0 +1,34 @@
+package org.sandwood.compiler.tests.parser;
+
+interface LowDimMix$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
+	public int get$N();
+	public boolean[] get$component();
+	public void set$component(boolean[] cv$value, boolean allocated$);
+	public boolean get$fixedFlag$sample101();
+	public void set$fixedFlag$sample101(boolean cv$value, boolean allocated$);
+	public boolean get$fixedFlag$sample20();
+	public void set$fixedFlag$sample20(boolean cv$value, boolean allocated$);
+	public boolean get$fixedFlag$sample83();
+	public void set$fixedFlag$sample83(boolean cv$value, boolean allocated$);
+	public boolean get$fixedFlag$sample88();
+	public void set$fixedFlag$sample88(boolean cv$value, boolean allocated$);
+	public int get$length$yObserved();
+	public void set$length$yObserved(int cv$value, boolean allocated$);
+	public double get$logProbability$component();
+	public double get$logProbability$componentDistribution();
+	public double get$logProbability$mu();
+	public double get$logProbability$rawMu();
+	public double get$logProbability$sigma();
+	public double get$logProbability$theta();
+	public double get$logProbability$y();
+	public double[] get$mu();
+	public double[] get$rawMu();
+	public void set$rawMu(double[] cv$value, boolean allocated$);
+	public double[] get$sigma();
+	public void set$sigma(double[] cv$value, boolean allocated$);
+	public double get$theta();
+	public void set$theta(double cv$value, boolean allocated$);
+	public double[] get$y();
+	public double[] get$yObserved();
+	public void set$yObserved(double[] cv$value, boolean allocated$);
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$CoreInterface_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$CoreInterface_modelSingle.java
@@ -1,0 +1,94 @@
+package org.sandwood.compiler.tests.parser;
+
+interface LowDimMix$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
+
+	// Getter for N.
+	public int get$N();
+
+	// Getter for component.
+	public boolean[] get$component();
+
+	// Setter for component.
+	public void set$component(boolean[] cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample101.
+	public boolean get$fixedFlag$sample101();
+
+	// Setter for fixedFlag$sample101.
+	public void set$fixedFlag$sample101(boolean cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample20.
+	public boolean get$fixedFlag$sample20();
+
+	// Setter for fixedFlag$sample20.
+	public void set$fixedFlag$sample20(boolean cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample83.
+	public boolean get$fixedFlag$sample83();
+
+	// Setter for fixedFlag$sample83.
+	public void set$fixedFlag$sample83(boolean cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample88.
+	public boolean get$fixedFlag$sample88();
+
+	// Setter for fixedFlag$sample88.
+	public void set$fixedFlag$sample88(boolean cv$value, boolean allocated$);
+
+	// Getter for length$yObserved.
+	public int get$length$yObserved();
+
+	// Setter for length$yObserved.
+	public void set$length$yObserved(int cv$value, boolean allocated$);
+
+	// Getter for logProbability$component.
+	public double get$logProbability$component();
+
+	// Getter for logProbability$componentDistribution.
+	public double get$logProbability$componentDistribution();
+
+	// Getter for logProbability$mu.
+	public double get$logProbability$mu();
+
+	// Getter for logProbability$rawMu.
+	public double get$logProbability$rawMu();
+
+	// Getter for logProbability$sigma.
+	public double get$logProbability$sigma();
+
+	// Getter for logProbability$theta.
+	public double get$logProbability$theta();
+
+	// Getter for logProbability$y.
+	public double get$logProbability$y();
+
+	// Getter for mu.
+	public double[] get$mu();
+
+	// Getter for rawMu.
+	public double[] get$rawMu();
+
+	// Setter for rawMu.
+	public void set$rawMu(double[] cv$value, boolean allocated$);
+
+	// Getter for sigma.
+	public double[] get$sigma();
+
+	// Setter for sigma.
+	public void set$sigma(double[] cv$value, boolean allocated$);
+
+	// Getter for theta.
+	public double get$theta();
+
+	// Setter for theta.
+	public void set$theta(double cv$value, boolean allocated$);
+
+	// Getter for y.
+	public double[] get$y();
+
+	// Getter for yObserved.
+	public double[] get$yObserved();
+
+	// Setter for yObserved.
+	public void set$yObserved(double[] cv$value, boolean allocated$);
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$CoreInterface_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$CoreInterface_optimisedModel.java
@@ -1,0 +1,94 @@
+package org.sandwood.compiler.tests.parser;
+
+interface LowDimMix$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
+
+	// Getter for N.
+	public int get$N();
+
+	// Getter for component.
+	public boolean[] get$component();
+
+	// Setter for component.
+	public void set$component(boolean[] cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample101.
+	public boolean get$fixedFlag$sample101();
+
+	// Setter for fixedFlag$sample101.
+	public void set$fixedFlag$sample101(boolean cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample20.
+	public boolean get$fixedFlag$sample20();
+
+	// Setter for fixedFlag$sample20.
+	public void set$fixedFlag$sample20(boolean cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample83.
+	public boolean get$fixedFlag$sample83();
+
+	// Setter for fixedFlag$sample83.
+	public void set$fixedFlag$sample83(boolean cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample88.
+	public boolean get$fixedFlag$sample88();
+
+	// Setter for fixedFlag$sample88.
+	public void set$fixedFlag$sample88(boolean cv$value, boolean allocated$);
+
+	// Getter for length$yObserved.
+	public int get$length$yObserved();
+
+	// Setter for length$yObserved.
+	public void set$length$yObserved(int cv$value, boolean allocated$);
+
+	// Getter for logProbability$component.
+	public double get$logProbability$component();
+
+	// Getter for logProbability$componentDistribution.
+	public double get$logProbability$componentDistribution();
+
+	// Getter for logProbability$mu.
+	public double get$logProbability$mu();
+
+	// Getter for logProbability$rawMu.
+	public double get$logProbability$rawMu();
+
+	// Getter for logProbability$sigma.
+	public double get$logProbability$sigma();
+
+	// Getter for logProbability$theta.
+	public double get$logProbability$theta();
+
+	// Getter for logProbability$y.
+	public double get$logProbability$y();
+
+	// Getter for mu.
+	public double[] get$mu();
+
+	// Getter for rawMu.
+	public double[] get$rawMu();
+
+	// Setter for rawMu.
+	public void set$rawMu(double[] cv$value, boolean allocated$);
+
+	// Getter for sigma.
+	public double[] get$sigma();
+
+	// Setter for sigma.
+	public void set$sigma(double[] cv$value, boolean allocated$);
+
+	// Getter for theta.
+	public double get$theta();
+
+	// Setter for theta.
+	public void set$theta(double cv$value, boolean allocated$);
+
+	// Getter for y.
+	public double[] get$y();
+
+	// Getter for yObserved.
+	public double[] get$yObserved();
+
+	// Setter for yObserved.
+	public void set$yObserved(double[] cv$value, boolean allocated$);
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$CoreInterface_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$CoreInterface_optimisedModelNoComments.java
@@ -1,0 +1,34 @@
+package org.sandwood.compiler.tests.parser;
+
+interface LowDimMix$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
+	public int get$N();
+	public boolean[] get$component();
+	public void set$component(boolean[] cv$value, boolean allocated$);
+	public boolean get$fixedFlag$sample101();
+	public void set$fixedFlag$sample101(boolean cv$value, boolean allocated$);
+	public boolean get$fixedFlag$sample20();
+	public void set$fixedFlag$sample20(boolean cv$value, boolean allocated$);
+	public boolean get$fixedFlag$sample83();
+	public void set$fixedFlag$sample83(boolean cv$value, boolean allocated$);
+	public boolean get$fixedFlag$sample88();
+	public void set$fixedFlag$sample88(boolean cv$value, boolean allocated$);
+	public int get$length$yObserved();
+	public void set$length$yObserved(int cv$value, boolean allocated$);
+	public double get$logProbability$component();
+	public double get$logProbability$componentDistribution();
+	public double get$logProbability$mu();
+	public double get$logProbability$rawMu();
+	public double get$logProbability$sigma();
+	public double get$logProbability$theta();
+	public double get$logProbability$y();
+	public double[] get$mu();
+	public double[] get$rawMu();
+	public void set$rawMu(double[] cv$value, boolean allocated$);
+	public double[] get$sigma();
+	public void set$sigma(double[] cv$value, boolean allocated$);
+	public double get$theta();
+	public void set$theta(double cv$value, boolean allocated$);
+	public double[] get$y();
+	public double[] get$yObserved();
+	public void set$yObserved(double[] cv$value, boolean allocated$);
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$CoreInterface_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$CoreInterface_optimisedModelSingle.java
@@ -1,0 +1,94 @@
+package org.sandwood.compiler.tests.parser;
+
+interface LowDimMix$CoreInterface extends org.sandwood.runtime.internal.model.CoreModel {
+
+	// Getter for N.
+	public int get$N();
+
+	// Getter for component.
+	public boolean[] get$component();
+
+	// Setter for component.
+	public void set$component(boolean[] cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample101.
+	public boolean get$fixedFlag$sample101();
+
+	// Setter for fixedFlag$sample101.
+	public void set$fixedFlag$sample101(boolean cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample20.
+	public boolean get$fixedFlag$sample20();
+
+	// Setter for fixedFlag$sample20.
+	public void set$fixedFlag$sample20(boolean cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample83.
+	public boolean get$fixedFlag$sample83();
+
+	// Setter for fixedFlag$sample83.
+	public void set$fixedFlag$sample83(boolean cv$value, boolean allocated$);
+
+	// Getter for fixedFlag$sample88.
+	public boolean get$fixedFlag$sample88();
+
+	// Setter for fixedFlag$sample88.
+	public void set$fixedFlag$sample88(boolean cv$value, boolean allocated$);
+
+	// Getter for length$yObserved.
+	public int get$length$yObserved();
+
+	// Setter for length$yObserved.
+	public void set$length$yObserved(int cv$value, boolean allocated$);
+
+	// Getter for logProbability$component.
+	public double get$logProbability$component();
+
+	// Getter for logProbability$componentDistribution.
+	public double get$logProbability$componentDistribution();
+
+	// Getter for logProbability$mu.
+	public double get$logProbability$mu();
+
+	// Getter for logProbability$rawMu.
+	public double get$logProbability$rawMu();
+
+	// Getter for logProbability$sigma.
+	public double get$logProbability$sigma();
+
+	// Getter for logProbability$theta.
+	public double get$logProbability$theta();
+
+	// Getter for logProbability$y.
+	public double get$logProbability$y();
+
+	// Getter for mu.
+	public double[] get$mu();
+
+	// Getter for rawMu.
+	public double[] get$rawMu();
+
+	// Setter for rawMu.
+	public void set$rawMu(double[] cv$value, boolean allocated$);
+
+	// Getter for sigma.
+	public double[] get$sigma();
+
+	// Setter for sigma.
+	public void set$sigma(double[] cv$value, boolean allocated$);
+
+	// Getter for theta.
+	public double get$theta();
+
+	// Setter for theta.
+	public void set$theta(double cv$value, boolean allocated$);
+
+	// Getter for y.
+	public double[] get$y();
+
+	// Getter for yObserved.
+	public double[] get$yObserved();
+
+	// Setter for yObserved.
+	public void set$yObserved(double[] cv$value, boolean allocated$);
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$MultiThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$MultiThreadCPU_model.java
@@ -1,0 +1,7509 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.random.internal.Rng;
+import org.sandwood.runtime.internal.numericTools.Conjugates;
+import org.sandwood.runtime.internal.numericTools.DistributionSampling;
+import org.sandwood.runtime.internal.numericTools.Gaussian;
+import org.sandwood.runtime.model.ExecutionTarget;
+
+final class LowDimMix$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements LowDimMix$CoreInterface {
+	
+	// Declare the variables for the model.
+	private int N;
+	private boolean[] component;
+	private boolean[] constrainedFlag$sample101;
+	private boolean[] constrainedFlag$sample20;
+	private boolean[] constrainedFlag$sample83;
+	private boolean constrainedFlag$sample88 = true;
+	private double[][] cv$var97$stateProbabilityGlobal;
+	private boolean fixedFlag$sample101 = false;
+	private boolean fixedFlag$sample20 = false;
+	private boolean fixedFlag$sample83 = false;
+	private boolean fixedFlag$sample88 = false;
+	private boolean fixedProbFlag$sample101 = false;
+	private boolean fixedProbFlag$sample138 = false;
+	private boolean fixedProbFlag$sample20 = false;
+	private boolean fixedProbFlag$sample83 = false;
+	private boolean fixedProbFlag$sample88 = false;
+	private boolean[][] guard$sample20if124$global;
+	private int length$yObserved;
+	private double logProbability$$evidence;
+	private double logProbability$$model;
+	private double logProbability$component;
+	private double logProbability$componentDistribution;
+	private double logProbability$mu;
+	private double logProbability$rawMu;
+	private double[] logProbability$sample138;
+	private double[] logProbability$sample20;
+	private double logProbability$sigma;
+	private double logProbability$theta;
+	private double logProbability$var79;
+	private double logProbability$var97;
+	private double logProbability$y;
+	private double[] mu;
+	private double[] rawMu;
+	private double[] sigma;
+	private boolean system$gibbsForward = true;
+	private double theta;
+	private double[] y;
+	private double[] yObserved;
+
+	public LowDimMix$MultiThreadCPU(ExecutionTarget target) {
+		super(target);
+	}
+
+	// Getter for N.
+	@Override
+	public final int get$N() {
+		return N;
+	}
+
+	// Getter for component.
+	@Override
+	public final boolean[] get$component() {
+		return component;
+	}
+
+	// Setter for component.
+	@Override
+	public final void set$component(boolean[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of component including if probabilities need
+		// to be updated.
+		component = cv$value;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on component.
+		fixedProbFlag$sample101 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on component.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for fixedFlag$sample101.
+	@Override
+	public final boolean get$fixedFlag$sample101() {
+		return fixedFlag$sample101;
+	}
+
+	// Setter for fixedFlag$sample101.
+	@Override
+	public final void set$fixedFlag$sample101(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample101 including if probabilities
+		// need to be updated.
+		fixedFlag$sample101 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+				constrainedFlag$sample101[index$constrainedFlag$sample101$1] = fixedFlag$sample101;
+		}
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedProbFlag$sample101);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample138 = (fixedFlag$sample101 && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample20.
+	@Override
+	public final boolean get$fixedFlag$sample20() {
+		return fixedFlag$sample20;
+	}
+
+	// Setter for fixedFlag$sample20.
+	@Override
+	public final void set$fixedFlag$sample20(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample20 including if probabilities
+		// need to be updated.
+		fixedFlag$sample20 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+				constrainedFlag$sample20[index$constrainedFlag$sample20$1] = fixedFlag$sample20;
+		}
+		
+		// Should the probability of sample 20 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample20 = (fixedFlag$sample20 && fixedProbFlag$sample20);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample138 = (fixedFlag$sample20 && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample83.
+	@Override
+	public final boolean get$fixedFlag$sample83() {
+		return fixedFlag$sample83;
+	}
+
+	// Setter for fixedFlag$sample83.
+	@Override
+	public final void set$fixedFlag$sample83(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample83 including if probabilities
+		// need to be updated.
+		fixedFlag$sample83 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+				constrainedFlag$sample83[index$constrainedFlag$sample83$1] = fixedFlag$sample83;
+		}
+		
+		// Should the probability of sample 83 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample83 = (fixedFlag$sample83 && fixedProbFlag$sample83);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample138 = (fixedFlag$sample83 && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample88.
+	@Override
+	public final boolean get$fixedFlag$sample88() {
+		return fixedFlag$sample88;
+	}
+
+	// Setter for fixedFlag$sample88.
+	@Override
+	public final void set$fixedFlag$sample88(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample88 including if probabilities
+		// need to be updated.
+		fixedFlag$sample88 = cv$value;
+		constrainedFlag$sample88 = (fixedFlag$sample88 || constrainedFlag$sample88);
+		
+		// Should the probability of sample 88 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample88 = (fixedFlag$sample88 && fixedProbFlag$sample88);
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample101 = (fixedFlag$sample88 && fixedProbFlag$sample101);
+	}
+
+	// Getter for length$yObserved.
+	@Override
+	public final int get$length$yObserved() {
+		return length$yObserved;
+	}
+
+	// Setter for length$yObserved.
+	@Override
+	public final void set$length$yObserved(int cv$value, boolean allocated$) {
+		length$yObserved = cv$value;
+	}
+
+	// Getter for logProbability$$evidence.
+	@Override
+	public final double get$logProbability$$evidence() {
+		return logProbability$$evidence;
+	}
+
+	// Getter for the probability of logProbability$$model.
+	@Override
+	public final double getCurrentLogProbability() {
+		return logProbability$$model;
+	}
+
+	// Getter for logProbability$component.
+	@Override
+	public final double get$logProbability$component() {
+		return logProbability$component;
+	}
+
+	// Getter for logProbability$componentDistribution.
+	@Override
+	public final double get$logProbability$componentDistribution() {
+		return logProbability$componentDistribution;
+	}
+
+	// Getter for logProbability$mu.
+	@Override
+	public final double get$logProbability$mu() {
+		return logProbability$mu;
+	}
+
+	// Getter for logProbability$rawMu.
+	@Override
+	public final double get$logProbability$rawMu() {
+		return logProbability$rawMu;
+	}
+
+	// Getter for logProbability$sigma.
+	@Override
+	public final double get$logProbability$sigma() {
+		return logProbability$sigma;
+	}
+
+	// Getter for logProbability$theta.
+	@Override
+	public final double get$logProbability$theta() {
+		return logProbability$theta;
+	}
+
+	// Getter for logProbability$y.
+	@Override
+	public final double get$logProbability$y() {
+		return logProbability$y;
+	}
+
+	// Getter for mu.
+	@Override
+	public final double[] get$mu() {
+		return mu;
+	}
+
+	// Getter for rawMu.
+	@Override
+	public final double[] get$rawMu() {
+		return rawMu;
+	}
+
+	// Setter for rawMu.
+	@Override
+	public final void set$rawMu(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of rawMu including if probabilities need to
+		// be updated.
+		rawMu = cv$value;
+		
+		// Unset the fixed probability flag for sample 20 as it depends on rawMu.
+		fixedProbFlag$sample20 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on rawMu.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for sigma.
+	@Override
+	public final double[] get$sigma() {
+		return sigma;
+	}
+
+	// Setter for sigma.
+	@Override
+	public final void set$sigma(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of sigma including if probabilities need to
+		// be updated.
+		sigma = cv$value;
+		
+		// Unset the fixed probability flag for sample 83 as it depends on sigma.
+		fixedProbFlag$sample83 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on sigma.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for theta.
+	@Override
+	public final double get$theta() {
+		return theta;
+	}
+
+	// Setter for theta.
+	@Override
+	public final void set$theta(double cv$value, boolean allocated$) {
+		// Set flags for all the side effects of theta including if probabilities need to
+		// be updated.
+		theta = cv$value;
+		
+		// Unset the fixed probability flag for sample 88 as it depends on theta.
+		fixedProbFlag$sample88 = false;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on theta.
+		fixedProbFlag$sample101 = false;
+	}
+
+	// Getter for y.
+	@Override
+	public final double[] get$y() {
+		return y;
+	}
+
+	// Getter for yObserved.
+	@Override
+	public final double[] get$yObserved() {
+		return yObserved;
+	}
+
+	// Setter for yObserved.
+	@Override
+	public final void set$yObserved(double[] cv$value, boolean allocated$) {
+		yObserved = cv$value;
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample101
+	private final void drawValueSample101(int var96, int threadID$cv$var96, Rng RNG$) {
+		component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample20
+	private final void drawValueSample20(int var19, int threadID$cv$var19, Rng RNG$) {
+		rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 41.
+		{
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20put43 = false;
+			{
+				if((var19 == 0)) {
+					if(!guard$sample20put43) {
+						// The body will execute, so should not be executed again
+						guard$sample20put43 = true;
+						{
+							double var39;
+							if((rawMu[0] < rawMu[1]))
+								var39 = rawMu[0];
+							else
+								var39 = rawMu[1];
+							mu[0] = var39;
+						}
+					}
+				}
+			}
+			{
+				if((var19 == 1)) {
+					if(!guard$sample20put43) {
+						// The body will execute, so should not be executed again
+						guard$sample20put43 = true;
+						{
+							double var39;
+							if((rawMu[0] < rawMu[1]))
+								var39 = rawMu[0];
+							else
+								var39 = rawMu[1];
+							mu[0] = var39;
+						}
+					}
+				}
+			}
+			{
+				if((rawMu[0] < rawMu[1])) {
+					if((var19 == 0)) {
+						if((rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put43) {
+								// The body will execute, so should not be executed again
+								guard$sample20put43 = true;
+								{
+									double var39;
+									if((rawMu[0] < rawMu[1]))
+										var39 = rawMu[0];
+									else
+										var39 = rawMu[1];
+									mu[0] = var39;
+								}
+							}
+						}
+					}
+				}
+			}
+			{
+				if(!(rawMu[0] < rawMu[1])) {
+					if((var19 == 1)) {
+						if(!(rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put43) {
+								// The body will execute, so should not be executed again
+								guard$sample20put43 = true;
+								{
+									double var39;
+									if((rawMu[0] < rawMu[1]))
+										var39 = rawMu[0];
+									else
+										var39 = rawMu[1];
+									mu[0] = var39;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 59.
+		{
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20put63 = false;
+			{
+				if((var19 == 0)) {
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						{
+							double var57;
+							if((rawMu[0] < rawMu[1]))
+								var57 = rawMu[1];
+							else
+								var57 = rawMu[0];
+							mu[1] = var57;
+						}
+					}
+				}
+			}
+			{
+				if((var19 == 1)) {
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						{
+							double var57;
+							if((rawMu[0] < rawMu[1]))
+								var57 = rawMu[1];
+							else
+								var57 = rawMu[0];
+							mu[1] = var57;
+						}
+					}
+				}
+			}
+			{
+				if((rawMu[0] < rawMu[1])) {
+					if((var19 == 1)) {
+						if((rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put63) {
+								// The body will execute, so should not be executed again
+								guard$sample20put63 = true;
+								{
+									double var57;
+									if((rawMu[0] < rawMu[1]))
+										var57 = rawMu[1];
+									else
+										var57 = rawMu[0];
+									mu[1] = var57;
+								}
+							}
+						}
+					}
+				}
+			}
+			{
+				if(!(rawMu[0] < rawMu[1])) {
+					if((var19 == 0)) {
+						if(!(rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put63) {
+								// The body will execute, so should not be executed again
+								guard$sample20put63 = true;
+								{
+									double var57;
+									if((rawMu[0] < rawMu[1]))
+										var57 = rawMu[1];
+									else
+										var57 = rawMu[0];
+									mu[1] = var57;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample83
+	private final void drawValueSample83(int var78) {
+		sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample88
+	private final void drawValueSample88() {
+		theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 101 drawn from componentDistribution. Inference was performed using
+	// variable marginalization.
+	private final void inferSample101(int var96, int threadID$cv$var96, Rng RNG$) {
+		if(true) {
+			constrainedFlag$sample101[((var96 - 0) / 1)] = false;
+			
+			// Calculate the number of states to evaluate.
+			int cv$numStates = 0;
+			{
+				// variable marginalization
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			
+			// Get a local reference to the scratch space.
+			double[] cv$stateProbabilityLocal = cv$var97$stateProbabilityGlobal[threadID$cv$var96];
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				// Initialize the summed probabilities to 0.
+				double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+				
+				// Initialize a counter to track the reached distributions.
+				double cv$reachedDistributionSourceRV = 0.0;
+				
+				// Initialize a log space accumulator to take the product of all the distribution
+				// probabilities.
+				double cv$accumulatedDistributionProbabilities = 0.0;
+				
+				// The value currently being tested
+				boolean cv$currentValue;
+				
+				// Value of the variable at this index
+				cv$currentValue = (cv$valuePos == 1);
+				
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				boolean var97 = cv$currentValue;
+				
+				// Guards to ensure that component is only updated when there is a valid path.
+				{
+					{
+						{
+							component[var96] = cv$currentValue;
+						}
+					}
+				}
+				{
+					// Record the reached probability density.
+					cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+					
+					// An accumulator to allow the value for each distribution to be constructed before
+					// it is added to the index probabilities.
+					double cv$accumulatedProbabilities = (Math.log(1.0) + (((0.0 <= theta) && (theta <= 1.0))?Math.log((cv$currentValue?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+					
+					// Processing conditional point124.
+					{
+						// Looking for a path between Sample 101 and consumer double 118.
+						{
+							{
+								for(int n = 0; n < N; n += 1) {
+									if((var96 == n)) {
+										{
+											{
+												{
+													if(component[n]) {
+														double traceTempVariable$componentMu$3_1 = mu[0];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentSigma;
+																							if(component[n])
+																								componentSigma = sigma[0];
+																							else
+																								componentSigma = sigma[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (componentSigma * componentSigma);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 20 and consumer double 118.
+											{
+												// Guard to check that at most one copy of the code is executed for a given random
+												// variable instance.
+												boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													if(!component[n]) {
+														double traceTempVariable$componentMu$30_1 = mu[1];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentSigma;
+																							if(component[n])
+																								componentSigma = sigma[0];
+																							else
+																								componentSigma = sigma[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (componentSigma * componentSigma);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 20 and consumer double 118.
+											{
+												// Guard to check that at most one copy of the code is executed for a given random
+												// variable instance.
+												boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					
+					// Processing conditional point135.
+					{
+						// Looking for a path between Sample 101 and consumer double 127.
+						{
+							{
+								for(int n = 0; n < N; n += 1) {
+									if((var96 == n)) {
+										{
+											{
+												{
+													if(component[n]) {
+														double traceTempVariable$componentSigma$58_1 = sigma[0];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentMu;
+																							if(component[n])
+																								componentMu = mu[0];
+																							else
+																								componentMu = mu[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 83 and consumer double 127.
+											{
+												{
+													for(int var78 = 0; var78 < 2; var78 += 1) {
+														if(component[n]) {
+															if((var78 == 0)) {
+																if(component[n]) {
+																	// Processing sample task 83 of consumer random variable null.
+																	{
+																		{
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							// Constructing a random variable input for use later.
+																							double var63 = (2.0 * 2.0);
+																							
+																							// Record the probability of sample task 83 generating output with current configuration.
+																							if(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 83 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													if(!component[n]) {
+														double traceTempVariable$componentSigma$63_1 = sigma[1];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentMu;
+																							if(component[n])
+																								componentMu = mu[0];
+																							else
+																								componentMu = mu[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 83 and consumer double 127.
+											{
+												{
+													for(int var78 = 0; var78 < 2; var78 += 1) {
+														if(!component[n]) {
+															if((var78 == 1)) {
+																if(!component[n]) {
+																	// Processing sample task 83 of consumer random variable null.
+																	{
+																		{
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							// Constructing a random variable input for use later.
+																							double var63 = (2.0 * 2.0);
+																							
+																							// Record the probability of sample task 83 generating output with current configuration.
+																							if(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 83 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					
+					// Add the values for the source and any standard consumers for this configuration
+					// of arguments to the source.
+					if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+						cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+					else {
+						// If the second value is -infinity.
+						if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+							cv$stateProbabilityValue = cv$accumulatedProbabilities;
+						else
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+					}
+				}
+				
+				// Save the calculated index value into the array of index value probabilities
+				cv$stateProbabilityLocal[cv$valuePos] = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+			}
+			if(constrainedFlag$sample101[((var96 - 0) / 1)]) {
+				// The sum of all the probabilities in log space
+				double cv$logSum = 0.0;
+				
+				// Sum all the values
+				{
+					// Initialize the max to the first element.
+					double cv$lseMax = cv$stateProbabilityLocal[0];
+					
+					// Find max value.
+					for(int cv$lseIndex = 1; cv$lseIndex < cv$numStates; cv$lseIndex += 1) {
+						double cv$lseElementValue = cv$stateProbabilityLocal[cv$lseIndex];
+						if((cv$lseMax < cv$lseElementValue))
+							cv$lseMax = cv$lseElementValue;
+					}
+					
+					// If the maximum value is -infinity return -infinity.
+					if((cv$lseMax == Double.NEGATIVE_INFINITY))
+						cv$logSum = Double.NEGATIVE_INFINITY;
+					
+					// Sum the values in the array.
+					else {
+						// Initialize the sum of the array elements
+						double cv$lseSum = 0.0;
+						
+						// Offset values, move to normal space, and sum.
+						for(int cv$lseIndex = 0; cv$lseIndex < cv$numStates; cv$lseIndex += 1)
+							cv$lseSum = (cv$lseSum + Math.exp((cv$stateProbabilityLocal[cv$lseIndex] - cv$lseMax)));
+						
+						// Increment the value of the target, moving the value back into log space.
+						cv$logSum = (cv$logSum + (Math.log(cv$lseSum) + cv$lseMax));
+					}
+				}
+				
+				// If all the sum is zero, just share the probability evenly.
+				if((cv$logSum == Double.NEGATIVE_INFINITY)) {
+					// Normalize log space values and move to normal space
+					for(int cv$indexName = 0; cv$indexName < cv$numStates; cv$indexName += 1)
+						cv$stateProbabilityLocal[cv$indexName] = (1.0 / cv$numStates);
+				} else {
+					// Normalize log space values and move to normal space
+					for(int cv$indexName = 0; cv$indexName < cv$numStates; cv$indexName += 1)
+						cv$stateProbabilityLocal[cv$indexName] = Math.exp((cv$stateProbabilityLocal[cv$indexName] - cv$logSum));
+				}
+				
+				// Set array values that are not computed for the input to negative infinity.
+				for(int cv$indexName = cv$numStates; cv$indexName < cv$stateProbabilityLocal.length; cv$indexName += 1)
+					cv$stateProbabilityLocal[cv$indexName] = Double.NEGATIVE_INFINITY;
+				
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				boolean var97 = (DistributionSampling.sampleCategorical(RNG$, cv$stateProbabilityLocal, cv$numStates) == 1);
+				
+				// Guards to ensure that component is only updated when there is a valid path.
+				{
+					{
+						{
+							component[var96] = var97;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 20 drawn from Gaussian 7. Inference was performed using Metropolis-Hastings.
+	private final void inferSample20(int var19, int threadID$cv$var19, Rng RNG$) {
+		if(true) {
+			constrainedFlag$sample20[((var19 - 0) / 1)] = false;
+			
+			// Calculate the number of states to evaluate.
+			int cv$numStates = 0;
+			{
+				// Metropolis-Hastings
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			
+			// The original value of the sample
+			double cv$originalValue = rawMu[var19];
+			
+			// The probability of the random variable generating the originally sampled value
+			double cv$originalProbability = 0.0;
+			
+			// Calculate a proposed variance.
+			double cv$var = ((cv$originalValue * cv$originalValue) * (0.1 * 0.1));
+			
+			// Ensure the variance is at least 0.01
+			if((cv$var < (0.1 * 0.1)))
+				cv$var = (0.1 * 0.1);
+			
+			// The proposed new value for the sample
+			double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+			
+			// The probability of the random variable generating the new sample value.
+			double cv$proposedProbability = 0.0;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				if((constrainedFlag$sample20[((var19 - 0) / 1)] || (cv$valuePos == 0))) {
+					// Initialize the summed probabilities to 0.
+					double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+					
+					// Initialize a counter to track the reached distributions.
+					double cv$reachedDistributionSourceRV = 0.0;
+					
+					// Initialize a log space accumulator to take the product of all the distribution
+					// probabilities.
+					double cv$accumulatedDistributionProbabilities = 0.0;
+					
+					// The value currently being tested
+					double cv$currentValue;
+					if((cv$valuePos == 0))
+						// Set the current value to the current state of the tree.
+						cv$currentValue = cv$originalValue;
+					else {
+						cv$currentValue = cv$proposedValue;
+						
+						// Update Sample and intermediate values
+						// 
+						// Write out the value of the sample to a temporary variable prior to updating the
+						// intermediate variables.
+						double var20 = cv$proposedValue;
+						
+						// Guards to ensure that rawMu is only updated when there is a valid path.
+						{
+							{
+								{
+									rawMu[var19] = cv$currentValue;
+								}
+							}
+						}
+						
+						// Guards to ensure that mu is only updated when there is a valid path.
+						// 
+						// Looking for a path between Sample 20 and consumer double[] 41.
+						{
+							// Guard to check that at most one copy of the code is executed for a given set of
+							// loop iterations.
+							boolean guard$sample20put43 = false;
+							{
+								if((var19 == 0)) {
+									if(!guard$sample20put43) {
+										// The body will execute, so should not be executed again
+										guard$sample20put43 = true;
+										{
+											double var39;
+											if((rawMu[0] < rawMu[1]))
+												var39 = rawMu[0];
+											else
+												var39 = rawMu[1];
+											mu[0] = var39;
+										}
+									}
+								}
+							}
+							{
+								if((var19 == 1)) {
+									if(!guard$sample20put43) {
+										// The body will execute, so should not be executed again
+										guard$sample20put43 = true;
+										{
+											double var39;
+											if((rawMu[0] < rawMu[1]))
+												var39 = rawMu[0];
+											else
+												var39 = rawMu[1];
+											mu[0] = var39;
+										}
+									}
+								}
+							}
+							{
+								if((rawMu[0] < rawMu[1])) {
+									if((var19 == 0)) {
+										if((rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put43) {
+												// The body will execute, so should not be executed again
+												guard$sample20put43 = true;
+												{
+													double var39;
+													if((rawMu[0] < rawMu[1]))
+														var39 = rawMu[0];
+													else
+														var39 = rawMu[1];
+													mu[0] = var39;
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								if(!(rawMu[0] < rawMu[1])) {
+									if((var19 == 1)) {
+										if(!(rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put43) {
+												// The body will execute, so should not be executed again
+												guard$sample20put43 = true;
+												{
+													double var39;
+													if((rawMu[0] < rawMu[1]))
+														var39 = rawMu[0];
+													else
+														var39 = rawMu[1];
+													mu[0] = var39;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Guards to ensure that mu is only updated when there is a valid path.
+						// 
+						// Looking for a path between Sample 20 and consumer double[] 59.
+						{
+							// Guard to check that at most one copy of the code is executed for a given set of
+							// loop iterations.
+							boolean guard$sample20put63 = false;
+							{
+								if((var19 == 0)) {
+									if(!guard$sample20put63) {
+										// The body will execute, so should not be executed again
+										guard$sample20put63 = true;
+										{
+											double var57;
+											if((rawMu[0] < rawMu[1]))
+												var57 = rawMu[1];
+											else
+												var57 = rawMu[0];
+											mu[1] = var57;
+										}
+									}
+								}
+							}
+							{
+								if((var19 == 1)) {
+									if(!guard$sample20put63) {
+										// The body will execute, so should not be executed again
+										guard$sample20put63 = true;
+										{
+											double var57;
+											if((rawMu[0] < rawMu[1]))
+												var57 = rawMu[1];
+											else
+												var57 = rawMu[0];
+											mu[1] = var57;
+										}
+									}
+								}
+							}
+							{
+								if((rawMu[0] < rawMu[1])) {
+									if((var19 == 1)) {
+										if((rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put63) {
+												// The body will execute, so should not be executed again
+												guard$sample20put63 = true;
+												{
+													double var57;
+													if((rawMu[0] < rawMu[1]))
+														var57 = rawMu[1];
+													else
+														var57 = rawMu[0];
+													mu[1] = var57;
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								if(!(rawMu[0] < rawMu[1])) {
+									if((var19 == 0)) {
+										if(!(rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put63) {
+												// The body will execute, so should not be executed again
+												guard$sample20put63 = true;
+												{
+													double var57;
+													if((rawMu[0] < rawMu[1]))
+														var57 = rawMu[1];
+													else
+														var57 = rawMu[0];
+													mu[1] = var57;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					{
+						// Record the reached probability density.
+						cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+						
+						// Constructing a random variable input for use later.
+						double var6 = (2.0 * 2.0);
+						
+						// An accumulator to allow the value for each distribution to be constructed before
+						// it is added to the index probabilities.
+						double cv$accumulatedProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((cv$currentValue - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+						
+						// Processing random variable 129.
+						{
+							// Looking for a path between Sample 20 and consumer Gaussian 129.
+							{
+								{
+									double traceTempVariable$var36$10_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$10_2 = traceTempVariable$var36$10_1;
+												double traceTempVariable$var115$10_3 = traceTempVariable$var39$10_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((0 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$10_5 = traceTempVariable$var115$10_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var36$11_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$11_2 = traceTempVariable$var36$11_1;
+												double traceTempVariable$var117$11_3 = traceTempVariable$var39$11_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((0 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$11_5 = traceTempVariable$var117$11_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var38$12_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$12_2 = traceTempVariable$var38$12_1;
+												double traceTempVariable$var115$12_3 = traceTempVariable$var39$12_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((0 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$12_5 = traceTempVariable$var115$12_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var38$13_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$13_2 = traceTempVariable$var38$13_1;
+												double traceTempVariable$var117$13_3 = traceTempVariable$var39$13_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((0 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$13_5 = traceTempVariable$var117$13_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var54$14_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$14_2 = traceTempVariable$var54$14_1;
+												double traceTempVariable$var115$14_3 = traceTempVariable$var57$14_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((1 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$14_5 = traceTempVariable$var115$14_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var54$15_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$15_2 = traceTempVariable$var54$15_1;
+												double traceTempVariable$var117$15_3 = traceTempVariable$var57$15_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((1 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$15_5 = traceTempVariable$var117$15_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var56$16_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$16_2 = traceTempVariable$var56$16_1;
+												double traceTempVariable$var115$16_3 = traceTempVariable$var57$16_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((1 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$16_5 = traceTempVariable$var115$16_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var56$17_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$17_2 = traceTempVariable$var56$17_1;
+												double traceTempVariable$var117$17_3 = traceTempVariable$var57$17_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((1 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$17_5 = traceTempVariable$var117$17_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Processing conditional point41.
+						{
+							// Looking for a path between Sample 20 and consumer double 39.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20if41 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20if41) {
+											// The body will execute, so should not be executed again
+											guard$sample20if41 = true;
+											{
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$36_1 = rawMu[0];
+															double traceTempVariable$var115$36_2 = traceTempVariable$var39$36_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$36_4 = traceTempVariable$var115$36_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$38_1 = rawMu[0];
+															double traceTempVariable$var117$38_2 = traceTempVariable$var39$38_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$38_4 = traceTempVariable$var117$38_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$48_1 = 0; index$var19$48_1 < 2; index$var19$48_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$48_1 == 0)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$52_1 = rawMu[1];
+															double traceTempVariable$var115$52_2 = traceTempVariable$var39$52_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$52_4 = traceTempVariable$var115$52_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$54_1 = rawMu[1];
+															double traceTempVariable$var117$54_2 = traceTempVariable$var39$54_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$54_4 = traceTempVariable$var117$54_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$64_1 = 0; index$var19$64_1 < 2; index$var19$64_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$64_1 == 1)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20if41) {
+											// The body will execute, so should not be executed again
+											guard$sample20if41 = true;
+											{
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$37_1 = rawMu[0];
+															double traceTempVariable$var115$37_2 = traceTempVariable$var39$37_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$37_4 = traceTempVariable$var115$37_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$39_1 = rawMu[0];
+															double traceTempVariable$var117$39_2 = traceTempVariable$var39$39_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$39_4 = traceTempVariable$var117$39_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$49_1 = 0; index$var19$49_1 < 2; index$var19$49_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$49_1 == 0)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$53_1 = rawMu[1];
+															double traceTempVariable$var115$53_2 = traceTempVariable$var39$53_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$53_4 = traceTempVariable$var115$53_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$55_1 = rawMu[1];
+															double traceTempVariable$var117$55_2 = traceTempVariable$var39$55_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$55_4 = traceTempVariable$var117$55_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$65_1 = 0; index$var19$65_1 < 2; index$var19$65_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$65_1 == 1)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Processing conditional point61.
+						{
+							// Looking for a path between Sample 20 and consumer double 57.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20if61 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20if61) {
+											// The body will execute, so should not be executed again
+											guard$sample20if61 = true;
+											{
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$70_1 = rawMu[1];
+															double traceTempVariable$var115$70_2 = traceTempVariable$var57$70_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$70_4 = traceTempVariable$var115$70_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$72_1 = rawMu[1];
+															double traceTempVariable$var117$72_2 = traceTempVariable$var57$72_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$72_4 = traceTempVariable$var117$72_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$82_1 = 0; index$var19$82_1 < 2; index$var19$82_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$82_1 == 1)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$86_1 = rawMu[0];
+															double traceTempVariable$var115$86_2 = traceTempVariable$var57$86_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$86_4 = traceTempVariable$var115$86_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$88_1 = rawMu[0];
+															double traceTempVariable$var117$88_2 = traceTempVariable$var57$88_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$88_4 = traceTempVariable$var117$88_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$98_1 = 0; index$var19$98_1 < 2; index$var19$98_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$98_1 == 0)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20if61) {
+											// The body will execute, so should not be executed again
+											guard$sample20if61 = true;
+											{
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$71_1 = rawMu[1];
+															double traceTempVariable$var115$71_2 = traceTempVariable$var57$71_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$71_4 = traceTempVariable$var115$71_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$73_1 = rawMu[1];
+															double traceTempVariable$var117$73_2 = traceTempVariable$var57$73_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$73_4 = traceTempVariable$var117$73_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$83_1 = 0; index$var19$83_1 < 2; index$var19$83_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$83_1 == 1)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$87_1 = rawMu[0];
+															double traceTempVariable$var115$87_2 = traceTempVariable$var57$87_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$87_4 = traceTempVariable$var115$87_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$89_1 = rawMu[0];
+															double traceTempVariable$var117$89_2 = traceTempVariable$var57$89_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$89_4 = traceTempVariable$var117$89_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$99_1 = 0; index$var19$99_1 < 2; index$var19$99_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$99_1 == 0)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Add the values for the source and any standard consumers for this configuration
+						// of arguments to the source.
+						if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+						else {
+							// If the second value is -infinity.
+							if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+								cv$stateProbabilityValue = cv$accumulatedProbabilities;
+							else
+								cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// Save the probability of the original value.
+					if((cv$valuePos == 0))
+						cv$originalProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// Save the probability of the proposed value.
+					else
+						cv$proposedProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// The probability ration for the proposed value and the current value.
+					double cv$ratio = (cv$proposedProbability - cv$originalProbability);
+					
+					// Test if the probability of the sample is sufficient to keep the value. This needs
+					// to be less than or equal as otherwise if the proposed value is not possible and
+					// the random value is 0 an impossible value will be accepted.
+					if((cv$valuePos == 1)) {
+						if(((cv$ratio <= Math.log((0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$))))) || Double.isNaN(cv$ratio))) {
+							// If it is not revert the changes.
+							// 
+							// Set the sample value
+							// Write out the value of the sample to a temporary variable prior to updating the
+							// intermediate variables.
+							double var20 = cv$originalValue;
+							
+							// Guards to ensure that rawMu is only updated when there is a valid path.
+							{
+								{
+									{
+										rawMu[var19] = var20;
+									}
+								}
+							}
+							
+							// Guards to ensure that mu is only updated when there is a valid path.
+							// 
+							// Looking for a path between Sample 20 and consumer double[] 41.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20put43 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20put43) {
+											// The body will execute, so should not be executed again
+											guard$sample20put43 = true;
+											{
+												double var39;
+												if((rawMu[0] < rawMu[1]))
+													var39 = rawMu[0];
+												else
+													var39 = rawMu[1];
+												mu[0] = var39;
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20put43) {
+											// The body will execute, so should not be executed again
+											guard$sample20put43 = true;
+											{
+												double var39;
+												if((rawMu[0] < rawMu[1]))
+													var39 = rawMu[0];
+												else
+													var39 = rawMu[1];
+												mu[0] = var39;
+											}
+										}
+									}
+								}
+								{
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put43) {
+													// The body will execute, so should not be executed again
+													guard$sample20put43 = true;
+													{
+														double var39;
+														if((rawMu[0] < rawMu[1]))
+															var39 = rawMu[0];
+														else
+															var39 = rawMu[1];
+														mu[0] = var39;
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put43) {
+													// The body will execute, so should not be executed again
+													guard$sample20put43 = true;
+													{
+														double var39;
+														if((rawMu[0] < rawMu[1]))
+															var39 = rawMu[0];
+														else
+															var39 = rawMu[1];
+														mu[0] = var39;
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+							
+							// Guards to ensure that mu is only updated when there is a valid path.
+							// 
+							// Looking for a path between Sample 20 and consumer double[] 59.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20put63 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20put63) {
+											// The body will execute, so should not be executed again
+											guard$sample20put63 = true;
+											{
+												double var57;
+												if((rawMu[0] < rawMu[1]))
+													var57 = rawMu[1];
+												else
+													var57 = rawMu[0];
+												mu[1] = var57;
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20put63) {
+											// The body will execute, so should not be executed again
+											guard$sample20put63 = true;
+											{
+												double var57;
+												if((rawMu[0] < rawMu[1]))
+													var57 = rawMu[1];
+												else
+													var57 = rawMu[0];
+												mu[1] = var57;
+											}
+										}
+									}
+								}
+								{
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put63) {
+													// The body will execute, so should not be executed again
+													guard$sample20put63 = true;
+													{
+														double var57;
+														if((rawMu[0] < rawMu[1]))
+															var57 = rawMu[1];
+														else
+															var57 = rawMu[0];
+														mu[1] = var57;
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put63) {
+													// The body will execute, so should not be executed again
+													guard$sample20put63 = true;
+													{
+														double var57;
+														if((rawMu[0] < rawMu[1]))
+															var57 = rawMu[1];
+														else
+															var57 = rawMu[0];
+														mu[1] = var57;
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 83 drawn from TruncatedGaussian 66. Inference was performed using
+	// Metropolis-Hastings.
+	private final void inferSample83(int var78) {
+		if(true) {
+			constrainedFlag$sample83[((var78 - 0) / 1)] = false;
+			
+			// Calculate the number of states to evaluate.
+			int cv$numStates = 0;
+			{
+				// Metropolis-Hastings
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			
+			// The original value of the sample
+			double cv$originalValue = sigma[var78];
+			
+			// The probability of the random variable generating the originally sampled value
+			double cv$originalProbability = 0.0;
+			
+			// Calculate a proposed variance.
+			double cv$var = ((cv$originalValue * cv$originalValue) * (0.1 * 0.1));
+			
+			// Ensure the variance is at least 0.01
+			if((cv$var < (0.1 * 0.1)))
+				cv$var = (0.1 * 0.1);
+			
+			// The proposed new value for the sample
+			double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+			
+			// The probability of the random variable generating the new sample value.
+			double cv$proposedProbability = 0.0;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				if((constrainedFlag$sample83[((var78 - 0) / 1)] || (cv$valuePos == 0))) {
+					// Initialize the summed probabilities to 0.
+					double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+					
+					// Initialize a counter to track the reached distributions.
+					double cv$reachedDistributionSourceRV = 0.0;
+					
+					// Initialize a log space accumulator to take the product of all the distribution
+					// probabilities.
+					double cv$accumulatedDistributionProbabilities = 0.0;
+					
+					// The value currently being tested
+					double cv$currentValue;
+					if((cv$valuePos == 0))
+						// Set the current value to the current state of the tree.
+						cv$currentValue = cv$originalValue;
+					else {
+						cv$currentValue = cv$proposedValue;
+						
+						// Update Sample and intermediate values
+						// 
+						// Write out the value of the sample to a temporary variable prior to updating the
+						// intermediate variables.
+						double var79 = cv$proposedValue;
+						
+						// Guards to ensure that sigma is only updated when there is a valid path.
+						{
+							{
+								{
+									sigma[var78] = cv$currentValue;
+								}
+							}
+						}
+					}
+					{
+						// Record the reached probability density.
+						cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+						
+						// Constructing a random variable input for use later.
+						double var63 = (2.0 * 2.0);
+						
+						// An accumulator to allow the value for each distribution to be constructed before
+						// it is added to the index probabilities.
+						double cv$accumulatedProbabilities = (Math.log(1.0) + (((((0.0 <= cv$currentValue) && (cv$currentValue <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((cv$currentValue - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+						
+						// Processing random variable 129.
+						{
+							// Looking for a path between Sample 83 and consumer Gaussian 129.
+							{
+								{
+									double traceTempVariable$var124$2_1 = cv$currentValue;
+									for(int n = 0; n < N; n += 1) {
+										if(component[n]) {
+											if((var78 == 0)) {
+												if(component[n]) {
+													double traceTempVariable$componentSigma$2_3 = traceTempVariable$var124$2_1;
+													
+													// Processing sample task 138 of consumer random variable null.
+													{
+														{
+															// Flag recording if this sample task of the consuming random variable is constrained.
+															boolean cv$sampleConstrained = true;
+															if(cv$sampleConstrained) {
+																// Mark that the sample has observed constrained data.
+																constrainedFlag$sample83[((var78 - 0) / 1)] = true;
+																
+																// Set an accumulator to sum the probabilities for each possible configuration of
+																// inputs.
+																double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																
+																// Set an accumulator to record the consumer distributions not seen. Initially set
+																// to 1 as seen values will be deducted from this value.
+																double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																{
+																	{
+																		{
+																			{
+																				{
+																					double componentMu;
+																					if(component[n])
+																						componentMu = mu[0];
+																					else
+																						componentMu = mu[1];
+																					
+																					// Constructing a random variable input for use later.
+																					double var128 = (traceTempVariable$componentSigma$2_3 * traceTempVariable$componentSigma$2_3);
+																					
+																					// Record the probability of sample task 138 generating output with current configuration.
+																					if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																						else
+																							cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																					}
+																					
+																					// Recorded the probability of reaching sample task 138 with the current configuration.
+																					cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																				}
+																			}
+																		}
+																	}
+																}
+																
+																// A check to ensure rounding of floating point values can never result in a negative
+																// value.
+																cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																
+																// Multiply (log space add) in the probability of the sample task to the overall probability
+																// for this configuration of the source random variable.
+																if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																	cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																else {
+																	// If the second value is -infinity.
+																	if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																		cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																	else
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var126$3_1 = cv$currentValue;
+									for(int n = 0; n < N; n += 1) {
+										if(!component[n]) {
+											if((var78 == 1)) {
+												if(!component[n]) {
+													double traceTempVariable$componentSigma$3_3 = traceTempVariable$var126$3_1;
+													
+													// Processing sample task 138 of consumer random variable null.
+													{
+														{
+															// Flag recording if this sample task of the consuming random variable is constrained.
+															boolean cv$sampleConstrained = true;
+															if(cv$sampleConstrained) {
+																// Mark that the sample has observed constrained data.
+																constrainedFlag$sample83[((var78 - 0) / 1)] = true;
+																
+																// Set an accumulator to sum the probabilities for each possible configuration of
+																// inputs.
+																double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																
+																// Set an accumulator to record the consumer distributions not seen. Initially set
+																// to 1 as seen values will be deducted from this value.
+																double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																{
+																	{
+																		{
+																			{
+																				{
+																					double componentMu;
+																					if(component[n])
+																						componentMu = mu[0];
+																					else
+																						componentMu = mu[1];
+																					
+																					// Constructing a random variable input for use later.
+																					double var128 = (traceTempVariable$componentSigma$3_3 * traceTempVariable$componentSigma$3_3);
+																					
+																					// Record the probability of sample task 138 generating output with current configuration.
+																					if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																						else
+																							cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																					}
+																					
+																					// Recorded the probability of reaching sample task 138 with the current configuration.
+																					cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																				}
+																			}
+																		}
+																	}
+																}
+																
+																// A check to ensure rounding of floating point values can never result in a negative
+																// value.
+																cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																
+																// Multiply (log space add) in the probability of the sample task to the overall probability
+																// for this configuration of the source random variable.
+																if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																	cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																else {
+																	// If the second value is -infinity.
+																	if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																		cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																	else
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Add the values for the source and any standard consumers for this configuration
+						// of arguments to the source.
+						if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+						else {
+							// If the second value is -infinity.
+							if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+								cv$stateProbabilityValue = cv$accumulatedProbabilities;
+							else
+								cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// Save the probability of the original value.
+					if((cv$valuePos == 0))
+						cv$originalProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// Save the probability of the proposed value.
+					else
+						cv$proposedProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// The probability ration for the proposed value and the current value.
+					double cv$ratio = (cv$proposedProbability - cv$originalProbability);
+					
+					// Test if the probability of the sample is sufficient to keep the value. This needs
+					// to be less than or equal as otherwise if the proposed value is not possible and
+					// the random value is 0 an impossible value will be accepted.
+					if((cv$valuePos == 1)) {
+						if(((cv$ratio <= Math.log((0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$))))) || Double.isNaN(cv$ratio))) {
+							// If it is not revert the changes.
+							// 
+							// Set the sample value
+							// Write out the value of the sample to a temporary variable prior to updating the
+							// intermediate variables.
+							double var79 = cv$originalValue;
+							
+							// Guards to ensure that sigma is only updated when there is a valid path.
+							{
+								{
+									{
+										sigma[var78] = var79;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 88 drawn from Beta 83. Inference was performed using a Beta to Bernoulli/Binomial
+	// conjugate prior.
+	private final void inferSample88() {
+		if(true) {
+			constrainedFlag$sample88 = false;
+			
+			// Local variable to record the number of true samples.
+			int cv$sum = 0;
+			
+			// Local variable to record the number of samples.
+			int cv$count = 0;
+			{
+				// Processing random variable 85.
+				{
+					{
+						{
+							// Processing sample task 101 of consumer random variable componentDistribution.
+							{
+								{
+									for(int var96 = 0; var96 < N; var96 += 1) {
+										// Flag recording if this sample task of the consuming random variable is constrained.
+										boolean cv$sampleConstrained = (fixedFlag$sample101 || constrainedFlag$sample101[((var96 - 0) / 1)]);
+										if(cv$sampleConstrained) {
+											// Mark that the sample has observed constrained data.
+											constrainedFlag$sample88 = true;
+											{
+												{
+													{
+														{
+															{
+																// Include the value sampled by task 101 from random variable componentDistribution.
+																// Increment the number of samples.
+																cv$count = (cv$count + 1);
+																
+																// If the sample value was positive increase the count
+																if(component[var96])
+																	cv$sum = (cv$sum + 1);
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			if(constrainedFlag$sample88)
+				// Write out the new value of the sample.
+				theta = Conjugates.sampleConjugateBetaBinomial(RNG$, 5.0, 5.0, cv$sum, cv$count);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample101 using sampled
+	// values.
+	private final void logProbabilityValue$sample101() {
+		// Determine if we need to calculate the values for sample task 101 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample101) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						boolean cv$sampleValue = component[var96];
+						{
+							{
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= theta) && (theta <= 1.0))?Math.log((cv$sampleValue?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$componentDistribution = cv$sampleAccumulator;
+			
+			// Store the random variable instance probability
+			logProbability$var97 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			logProbability$component = (logProbability$component + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedFlag$sample88);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1)
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var97;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			logProbability$componentDistribution = cv$rvAccumulator;
+			
+			// Update the variable probability
+			logProbability$component = (logProbability$component + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample138 using sampled
+	// values.
+	private final void logProbabilityValue$sample138() {
+		// Determine if we need to calculate the values for sample task 138 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample138) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1) {
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				double cv$sampleAccumulator = 0.0;
+				
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						double cv$sampleValue = y[n];
+						{
+							{
+								double componentMu;
+								if(component[n])
+									componentMu = mu[0];
+								else
+									componentMu = mu[1];
+								double componentSigma;
+								if(component[n])
+									componentSigma = sigma[0];
+								else
+									componentSigma = sigma[1];
+								double var128 = (componentSigma * componentSigma);
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+				
+				// Store the sample task probability
+				logProbability$sample138[((n - 0) / 1)] = cv$sampleProbability;
+			}
+			
+			// Update the variable probability
+			logProbability$y = (logProbability$y + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample138 = ((fixedFlag$sample20 && fixedFlag$sample83) && fixedFlag$sample101);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1) {
+				double cv$rvAccumulator = 0.0;
+				double cv$sampleValue = logProbability$sample138[((n - 0) / 1)];
+				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			}
+			
+			// Update the variable probability
+			logProbability$y = (logProbability$y + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample20 using sampled
+	// values.
+	private final void logProbabilityValue$sample20() {
+		// Determine if we need to calculate the values for sample task 20 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample20) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						double cv$sampleValue = rawMu[var19];
+						{
+							{
+								double var3 = 0.0;
+								double var6 = (2.0 * 2.0);
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var3) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+								
+								// Looking for a path between Put 21 and consumer double 39.
+								{
+									// Guard to check that at most one copy of the code is executed for a given set of
+									// loop iterations.
+									boolean guard$put21if41 = false;
+									{
+										if((var19 == 0)) {
+											if(!guard$put21if41)
+												// The body will execute, so should not be executed again
+												guard$put21if41 = true;
+										}
+									}
+									{
+										if((var19 == 1)) {
+											if(!guard$put21if41)
+												// The body will execute, so should not be executed again
+												guard$put21if41 = true;
+										}
+									}
+								}
+								
+								// Looking for a path between Put 21 and consumer double 57.
+								{
+									// Guard to check that at most one copy of the code is executed for a given set of
+									// loop iterations.
+									boolean guard$put21if61 = false;
+									{
+										if((var19 == 0)) {
+											if(!guard$put21if61)
+												// The body will execute, so should not be executed again
+												guard$put21if61 = true;
+										}
+									}
+									{
+										if((var19 == 1)) {
+											if(!guard$put21if61)
+												// The body will execute, so should not be executed again
+												guard$put21if61 = true;
+										}
+									}
+								}
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				
+				// Store the sample task probability
+				logProbability$sample20[((var19 - 0) / 1)] = cv$sampleProbability;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Update the variable probability
+			logProbability$rawMu = (logProbability$rawMu + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample20 = fixedFlag$sample20;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				double cv$sampleValue = logProbability$sample20[((var19 - 0) / 1)];
+				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Update the variable probability
+			logProbability$rawMu = (logProbability$rawMu + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample83 using sampled
+	// values.
+	private final void logProbabilityValue$sample83() {
+		// Determine if we need to calculate the values for sample task 83 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample83) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var78 = 0; var78 < 2; var78 += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						double cv$sampleValue = sigma[var78];
+						{
+							{
+								double var60 = 0.0;
+								double var63 = (2.0 * 2.0);
+								double var64 = 0.0;
+								double var65 = 1.0E100;
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + (((((var64 <= cv$sampleValue) && (cv$sampleValue <= var65)) && (var64 < var65)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var60) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((var65 - var60) / Math.sqrt(var63))) - Gaussian.cdf(((var64 - var60) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Store the random variable instance probability
+			logProbability$var79 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			logProbability$sigma = (logProbability$sigma + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample83 = fixedFlag$sample83;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var78 = 0; var78 < 2; var78 += 1)
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var79;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Update the variable probability
+			logProbability$sigma = (logProbability$sigma + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample88 using sampled
+	// values.
+	private final void logProbabilityValue$sample88() {
+		// Determine if we need to calculate the values for sample task 88 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample88) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				{
+					// The sample value to calculate the probability of generating
+					double cv$sampleValue = theta;
+					{
+						{
+							double var81 = 5.0;
+							double var82 = 5.0;
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var81, var82));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						}
+					}
+				}
+			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Store the sample task probability
+			logProbability$theta = cv$sampleProbability;
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample88 = fixedFlag$sample88;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			double cv$sampleValue = logProbability$theta;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Method to allocate space temporary variables used by the inference methods. Allocating
+	// here prevents repeated allocation and deallocation, and makes the code more amenable
+	// to GPU execution.
+	@Override
+	public final void allocateScratch() {
+		// Allocate scratch space.
+		// Constructor for cv$var97$stateProbabilityGlobal
+		{
+			// Allocation of cv$var97$stateProbabilityGlobal for multithreaded execution
+			{
+				// Get the thread count.
+				int cv$threadCount = threadCount();
+				
+				// Allocate an array to hold a copy per thread
+				cv$var97$stateProbabilityGlobal = new double[cv$threadCount][];
+				
+				// Populate the array with a copy per thread
+				for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
+					cv$var97$stateProbabilityGlobal[cv$index] = new double[2];
+			}
+		}
+		
+		// Constructor for guard$sample20if124$global
+		{
+			// Calculate the largest index of var19 that is possible and allocate an array to
+			// hold the guard for each of these.
+			int cv$max_var19 = 0;
+			cv$max_var19 = Math.max(cv$max_var19, ((2 - 0) / 1));
+			
+			// Allocation of guard$sample20if124$global for multithreaded execution
+			{
+				// Get the thread count.
+				int cv$threadCount = threadCount();
+				
+				// Allocate an array to hold a copy per thread
+				guard$sample20if124$global = new boolean[cv$threadCount][];
+				
+				// Populate the array with a copy per thread
+				for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
+					guard$sample20if124$global[cv$index] = new boolean[cv$max_var19];
+			}
+		}
+	}
+
+	// Method to allocate space for model inputs and outputs.
+	@Override
+	public final void allocator() {
+		// If rawMu has not been set already allocate space.
+		if(!fixedFlag$sample20) {
+			// Constructor for rawMu
+			{
+				rawMu = new double[2];
+			}
+		}
+		
+		// Constructor for mu
+		{
+			mu = new double[2];
+		}
+		
+		// If sigma has not been set already allocate space.
+		if(!fixedFlag$sample83) {
+			// Constructor for sigma
+			{
+				sigma = new double[2];
+			}
+		}
+		
+		// If component has not been set already allocate space.
+		if(!fixedFlag$sample101) {
+			// Constructor for component
+			{
+				component = new boolean[length$yObserved];
+			}
+		}
+		
+		// Constructor for y
+		{
+			y = new double[length$yObserved];
+		}
+		
+		// Constructor for constrainedFlag$sample101
+		{
+			constrainedFlag$sample101 = new boolean[((((length$yObserved - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for constrainedFlag$sample20
+		{
+			constrainedFlag$sample20 = new boolean[((((2 - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for constrainedFlag$sample83
+		{
+			constrainedFlag$sample83 = new boolean[((((2 - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for logProbability$sample20
+		{
+			logProbability$sample20 = new double[((((2 - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for logProbability$sample138
+		{
+			logProbability$sample138 = new double[((((length$yObserved - 1) - 0) / 1) + 1)];
+		}
+		
+		// Allocate scratch space
+		allocateScratch();
+	}
+
+	// Method to execute the model code conventionally.
+	@Override
+	public final void forwardGeneration() {
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[0];
+		} else {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[1];
+		}
+		if(!fixedFlag$sample20)
+			mu[0] = var39;
+		double var57 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[1];
+		} else {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[0];
+		}
+		if(!fixedFlag$sample20)
+			mu[1] = var57;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$n, int forEnd$n, int threadID$n, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int n = forStart$n; n < forEnd$n; n += 1) {
+						double componentMu;
+						if(component[n])
+							componentMu = mu[0];
+						else
+							componentMu = mu[1];
+						double componentSigma;
+						if(component[n])
+							componentSigma = sigma[0];
+						else
+							componentSigma = sigma[1];
+						y[n] = ((Math.sqrt((componentSigma * componentSigma)) * DistributionSampling.sampleGaussian(RNG$1)) + componentMu);
+					}
+			}
+		);
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are calculated
+	// and stored.
+	@Override
+	public final void forwardGenerationDistributionsNoOutputsPrime() {
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+	}
+
+	// Method to execute the model code conventionally with priming of fixed intermediate
+	// variables.
+	@Override
+	public final void forwardGenerationPrime() {
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$n, int forEnd$n, int threadID$n, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int n = forStart$n; n < forEnd$n; n += 1) {
+						double componentMu;
+						if(component[n])
+							componentMu = mu[0];
+						else
+							componentMu = mu[1];
+						double componentSigma;
+						if(component[n])
+							componentSigma = sigma[0];
+						else
+							componentSigma = sigma[1];
+						y[n] = ((Math.sqrt((componentSigma * componentSigma)) * DistributionSampling.sampleGaussian(RNG$1)) + componentMu);
+					}
+			}
+		);
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Distributions are collapsed to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputs() {
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[0];
+		} else {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[1];
+		}
+		if(!fixedFlag$sample20)
+			mu[0] = var39;
+		double var57 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[1];
+		} else {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[0];
+		}
+		if(!fixedFlag$sample20)
+			mu[1] = var57;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are collapsed
+	// to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputsPrime() {
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+	}
+
+	// Method to execute one round of Gibbs sampling.
+	@Override
+	public final void gibbsRound() {
+		// Infer the samples in chronological order.
+		if(system$gibbsForward) {
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+							if(!fixedFlag$sample20)
+								inferSample20(var19, threadID$var19, RNG$1);
+						}
+				}
+			);
+			for(int var78 = 0; var78 < 2; var78 += 1) {
+				if(!fixedFlag$sample83)
+					inferSample83(var78);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+							if(!fixedFlag$sample101)
+								inferSample101(var96, threadID$var96, RNG$1);
+						}
+				}
+			);
+		}
+		// Infer the samples in reverse chronological order.
+		else {
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+							if(!fixedFlag$sample101)
+								inferSample101(var96, threadID$var96, RNG$1);
+						}
+				}
+			);
+			if(!fixedFlag$sample88)
+				inferSample88();
+			for(int var78 = (2 - ((((2 - 1) - 0) % 1) + 1)); var78 >= ((0 - 1) + 1); var78 -= 1) {
+				if(!fixedFlag$sample83)
+					inferSample83(var78);
+			}
+			
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+							if(!fixedFlag$sample20)
+								inferSample20(var19, threadID$var19, RNG$1);
+						}
+				}
+			);
+		}
+		
+		// Reverse the direction of execution for the next iteration
+		system$gibbsForward = !system$gibbsForward;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!constrainedFlag$sample20[((var19 - 0) / 1)])
+							drawValueSample20(var19, threadID$var19, RNG$1);
+					}
+			}
+		);
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!constrainedFlag$sample83[((var78 - 0) / 1)])
+				drawValueSample83(var78);
+		}
+		if(!constrainedFlag$sample88)
+			drawValueSample88();
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!constrainedFlag$sample101[((var96 - 0) / 1)])
+							drawValueSample101(var96, threadID$var96, RNG$1);
+					}
+			}
+		);
+	}
+
+	// A method to initialize all the probabilities in the model to 0/Log(1) ready for
+	// the current probabilities to be calculated by calculating the probability of each
+	// sample task, and its effect on the rest of the model.
+	private final void initializeLogProbabilityFields() {
+		// Set the probabilities of the random variable, and the model as a whole to ready
+		// them to be reconstructed by the probability calls for each sample. Sample probabilities
+		// are only reset for samples that are not fixed at a value that has already been
+		// calculated.
+		logProbability$$model = 0.0;
+		logProbability$$evidence = 0.0;
+		logProbability$rawMu = 0.0;
+		logProbability$mu = 0.0;
+		if(!fixedProbFlag$sample20) {
+			for(int var19 = 0; var19 < 2; var19 += 1)
+				logProbability$sample20[((var19 - 0) / 1)] = Double.NaN;
+		}
+		logProbability$sigma = 0.0;
+		if(!fixedProbFlag$sample83)
+			logProbability$var79 = Double.NaN;
+		if(!fixedProbFlag$sample88)
+			logProbability$theta = Double.NaN;
+		logProbability$componentDistribution = Double.NaN;
+		logProbability$component = 0.0;
+		if(!fixedProbFlag$sample101)
+			logProbability$var97 = Double.NaN;
+		logProbability$y = 0.0;
+		if(!fixedProbFlag$sample138) {
+			for(int n = 0; n < N; n += 1)
+				logProbability$sample138[((n - 0) / 1)] = Double.NaN;
+		}
+	}
+
+	// Method for initializing the model into a valid state before commencing inference
+	// etc.
+	@Override
+	public final void initializeModel() {
+		N = length$yObserved;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+			constrainedFlag$sample101[index$constrainedFlag$sample101$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+			constrainedFlag$sample20[index$constrainedFlag$sample20$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+			constrainedFlag$sample83[index$constrainedFlag$sample83$1] = true;
+	}
+
+	// Construct the evidence probabilities.
+	@Override
+	public final void logEvidenceProbabilities() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Call each method in turn to generate the new probability values.
+		if(fixedFlag$sample20)
+			logProbabilityValue$sample20();
+		if(fixedFlag$sample83)
+			logProbabilityValue$sample83();
+		if(fixedFlag$sample88)
+			logProbabilityValue$sample88();
+		if(fixedFlag$sample101)
+			logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model uses distributions
+	// when possible.
+	@Override
+	public final void logModelProbabilitiesDist() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model only uses values.
+	@Override
+	public final void logModelProbabilitiesVal() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to propagate observed values back into the model.
+	@Override
+	public final void propagateObservedValues() {
+		// Deep copy between arrays
+		double[] cv$source1 = yObserved;
+		double[] cv$target1 = y;
+		int cv$length1 = cv$target1.length;
+		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1)
+			cv$target1[cv$index1] = cv$source1[cv$index1];
+	}
+
+	// A method to set array values that depend on the output of a sample task, but are
+	// not directly set by the sample task. This method is called to propagate set values
+	// through the model. Any non-fixed sample values may be sampled to random variables
+	// as part of this process.
+	@Override
+	public final void setIntermediates() {
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+	}
+
+	@Override
+	public String modelCode() {
+		return "/*\n"
+		     + " * Sandwood\n"
+		     + " *\n"
+		     + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+		     + " * \n"
+		     + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+		     + " */\n"
+		     + "\n"
+		     + "package org.sandwood.compiler.tests.parser;\n"
+		     + "\n"
+		     + "public model LowDimMix(double[] yObserved) {\n"
+		     + "    int N = yObserved.length;\n"
+		     + "\n"
+		     + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+		     + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+		     + "    // the constant normalisation factor for the ordered constraint.\n"
+		     + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+		     + "    double[] mu = new double[2];\n"
+		     + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+		     + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+		     + "\n"
+		     + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+		     + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+		     + "\n"
+		     + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+		     + "    double theta = beta(5.0, 5.0).sample();\n"
+		     + "\n"
+		     + "    // Stan likelihood:\n"
+		     + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+		     + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+		     + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+		     + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+		     + "    boolean[] component = componentDistribution.sample(N);\n"
+		     + "    double[] y = new double[N];\n"
+		     + "\n"
+		     + "    for(int n = 0; n < N; n++) {\n"
+		     + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+		     + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+		     + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+		     + "    }\n"
+		     + "\n"
+		     + "    y.observe(yObserved);\n"
+		     + "}\n"
+		     + "";
+	}
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$MultiThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$MultiThreadCPU_modelNoComments.java
@@ -1,0 +1,5291 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.random.internal.Rng;
+import org.sandwood.runtime.internal.numericTools.Conjugates;
+import org.sandwood.runtime.internal.numericTools.DistributionSampling;
+import org.sandwood.runtime.internal.numericTools.Gaussian;
+import org.sandwood.runtime.model.ExecutionTarget;
+
+final class LowDimMix$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements LowDimMix$CoreInterface {
+	private int N;
+	private boolean[] component;
+	private boolean[] constrainedFlag$sample101;
+	private boolean[] constrainedFlag$sample20;
+	private boolean[] constrainedFlag$sample83;
+	private boolean constrainedFlag$sample88 = true;
+	private double[][] cv$var97$stateProbabilityGlobal;
+	private boolean fixedFlag$sample101 = false;
+	private boolean fixedFlag$sample20 = false;
+	private boolean fixedFlag$sample83 = false;
+	private boolean fixedFlag$sample88 = false;
+	private boolean fixedProbFlag$sample101 = false;
+	private boolean fixedProbFlag$sample138 = false;
+	private boolean fixedProbFlag$sample20 = false;
+	private boolean fixedProbFlag$sample83 = false;
+	private boolean fixedProbFlag$sample88 = false;
+	private boolean[][] guard$sample20if124$global;
+	private int length$yObserved;
+	private double logProbability$$evidence;
+	private double logProbability$$model;
+	private double logProbability$component;
+	private double logProbability$componentDistribution;
+	private double logProbability$mu;
+	private double logProbability$rawMu;
+	private double[] logProbability$sample138;
+	private double[] logProbability$sample20;
+	private double logProbability$sigma;
+	private double logProbability$theta;
+	private double logProbability$var79;
+	private double logProbability$var97;
+	private double logProbability$y;
+	private double[] mu;
+	private double[] rawMu;
+	private double[] sigma;
+	private boolean system$gibbsForward = true;
+	private double theta;
+	private double[] y;
+	private double[] yObserved;
+
+	public LowDimMix$MultiThreadCPU(ExecutionTarget target) {
+		super(target);
+	}
+
+	@Override
+	public final int get$N() {
+		return N;
+	}
+
+	@Override
+	public final boolean[] get$component() {
+		return component;
+	}
+
+	@Override
+	public final void set$component(boolean[] cv$value, boolean allocated$) {
+		component = cv$value;
+		fixedProbFlag$sample101 = false;
+		fixedProbFlag$sample138 = false;
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample101() {
+		return fixedFlag$sample101;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample101(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample101 = cv$value;
+		if(allocated$) {
+			for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+				constrainedFlag$sample101[index$constrainedFlag$sample101$1] = fixedFlag$sample101;
+		}
+		fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedProbFlag$sample101);
+		fixedProbFlag$sample138 = (fixedFlag$sample101 && fixedProbFlag$sample138);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample20() {
+		return fixedFlag$sample20;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample20(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample20 = cv$value;
+		if(allocated$) {
+			for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+				constrainedFlag$sample20[index$constrainedFlag$sample20$1] = fixedFlag$sample20;
+		}
+		fixedProbFlag$sample20 = (fixedFlag$sample20 && fixedProbFlag$sample20);
+		fixedProbFlag$sample138 = (fixedFlag$sample20 && fixedProbFlag$sample138);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample83() {
+		return fixedFlag$sample83;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample83(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample83 = cv$value;
+		if(allocated$) {
+			for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+				constrainedFlag$sample83[index$constrainedFlag$sample83$1] = fixedFlag$sample83;
+		}
+		fixedProbFlag$sample83 = (fixedFlag$sample83 && fixedProbFlag$sample83);
+		fixedProbFlag$sample138 = (fixedFlag$sample83 && fixedProbFlag$sample138);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample88() {
+		return fixedFlag$sample88;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample88(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample88 = cv$value;
+		constrainedFlag$sample88 = (fixedFlag$sample88 || constrainedFlag$sample88);
+		fixedProbFlag$sample88 = (fixedFlag$sample88 && fixedProbFlag$sample88);
+		fixedProbFlag$sample101 = (fixedFlag$sample88 && fixedProbFlag$sample101);
+	}
+
+	@Override
+	public final int get$length$yObserved() {
+		return length$yObserved;
+	}
+
+	@Override
+	public final void set$length$yObserved(int cv$value, boolean allocated$) {
+		length$yObserved = cv$value;
+	}
+
+	@Override
+	public final double get$logProbability$$evidence() {
+		return logProbability$$evidence;
+	}
+
+	@Override
+	public final double getCurrentLogProbability() {
+		return logProbability$$model;
+	}
+
+	@Override
+	public final double get$logProbability$component() {
+		return logProbability$component;
+	}
+
+	@Override
+	public final double get$logProbability$componentDistribution() {
+		return logProbability$componentDistribution;
+	}
+
+	@Override
+	public final double get$logProbability$mu() {
+		return logProbability$mu;
+	}
+
+	@Override
+	public final double get$logProbability$rawMu() {
+		return logProbability$rawMu;
+	}
+
+	@Override
+	public final double get$logProbability$sigma() {
+		return logProbability$sigma;
+	}
+
+	@Override
+	public final double get$logProbability$theta() {
+		return logProbability$theta;
+	}
+
+	@Override
+	public final double get$logProbability$y() {
+		return logProbability$y;
+	}
+
+	@Override
+	public final double[] get$mu() {
+		return mu;
+	}
+
+	@Override
+	public final double[] get$rawMu() {
+		return rawMu;
+	}
+
+	@Override
+	public final void set$rawMu(double[] cv$value, boolean allocated$) {
+		rawMu = cv$value;
+		fixedProbFlag$sample20 = false;
+		fixedProbFlag$sample138 = false;
+	}
+
+	@Override
+	public final double[] get$sigma() {
+		return sigma;
+	}
+
+	@Override
+	public final void set$sigma(double[] cv$value, boolean allocated$) {
+		sigma = cv$value;
+		fixedProbFlag$sample83 = false;
+		fixedProbFlag$sample138 = false;
+	}
+
+	@Override
+	public final double get$theta() {
+		return theta;
+	}
+
+	@Override
+	public final void set$theta(double cv$value, boolean allocated$) {
+		theta = cv$value;
+		fixedProbFlag$sample88 = false;
+		fixedProbFlag$sample101 = false;
+	}
+
+	@Override
+	public final double[] get$y() {
+		return y;
+	}
+
+	@Override
+	public final double[] get$yObserved() {
+		return yObserved;
+	}
+
+	@Override
+	public final void set$yObserved(double[] cv$value, boolean allocated$) {
+		yObserved = cv$value;
+	}
+
+	private final void drawValueSample101(int var96, int threadID$cv$var96, Rng RNG$) {
+		component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+	}
+
+	private final void drawValueSample20(int var19, int threadID$cv$var19, Rng RNG$) {
+		rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		{
+			boolean guard$sample20put43 = false;
+			{
+				if((var19 == 0)) {
+					if(!guard$sample20put43) {
+						guard$sample20put43 = true;
+						{
+							double var39;
+							if((rawMu[0] < rawMu[1]))
+								var39 = rawMu[0];
+							else
+								var39 = rawMu[1];
+							mu[0] = var39;
+						}
+					}
+				}
+			}
+			{
+				if((var19 == 1)) {
+					if(!guard$sample20put43) {
+						guard$sample20put43 = true;
+						{
+							double var39;
+							if((rawMu[0] < rawMu[1]))
+								var39 = rawMu[0];
+							else
+								var39 = rawMu[1];
+							mu[0] = var39;
+						}
+					}
+				}
+			}
+			{
+				if((rawMu[0] < rawMu[1])) {
+					if((var19 == 0)) {
+						if((rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put43) {
+								guard$sample20put43 = true;
+								{
+									double var39;
+									if((rawMu[0] < rawMu[1]))
+										var39 = rawMu[0];
+									else
+										var39 = rawMu[1];
+									mu[0] = var39;
+								}
+							}
+						}
+					}
+				}
+			}
+			{
+				if(!(rawMu[0] < rawMu[1])) {
+					if((var19 == 1)) {
+						if(!(rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put43) {
+								guard$sample20put43 = true;
+								{
+									double var39;
+									if((rawMu[0] < rawMu[1]))
+										var39 = rawMu[0];
+									else
+										var39 = rawMu[1];
+									mu[0] = var39;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		{
+			boolean guard$sample20put63 = false;
+			{
+				if((var19 == 0)) {
+					if(!guard$sample20put63) {
+						guard$sample20put63 = true;
+						{
+							double var57;
+							if((rawMu[0] < rawMu[1]))
+								var57 = rawMu[1];
+							else
+								var57 = rawMu[0];
+							mu[1] = var57;
+						}
+					}
+				}
+			}
+			{
+				if((var19 == 1)) {
+					if(!guard$sample20put63) {
+						guard$sample20put63 = true;
+						{
+							double var57;
+							if((rawMu[0] < rawMu[1]))
+								var57 = rawMu[1];
+							else
+								var57 = rawMu[0];
+							mu[1] = var57;
+						}
+					}
+				}
+			}
+			{
+				if((rawMu[0] < rawMu[1])) {
+					if((var19 == 1)) {
+						if((rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put63) {
+								guard$sample20put63 = true;
+								{
+									double var57;
+									if((rawMu[0] < rawMu[1]))
+										var57 = rawMu[1];
+									else
+										var57 = rawMu[0];
+									mu[1] = var57;
+								}
+							}
+						}
+					}
+				}
+			}
+			{
+				if(!(rawMu[0] < rawMu[1])) {
+					if((var19 == 0)) {
+						if(!(rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put63) {
+								guard$sample20put63 = true;
+								{
+									double var57;
+									if((rawMu[0] < rawMu[1]))
+										var57 = rawMu[1];
+									else
+										var57 = rawMu[0];
+									mu[1] = var57;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private final void drawValueSample83(int var78) {
+		sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+	}
+
+	private final void drawValueSample88() {
+		theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+	}
+
+	private final void inferSample101(int var96, int threadID$cv$var96, Rng RNG$) {
+		if(true) {
+			constrainedFlag$sample101[((var96 - 0) / 1)] = false;
+			int cv$numStates = 0;
+			{
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			double[] cv$stateProbabilityLocal = cv$var97$stateProbabilityGlobal[threadID$cv$var96];
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+				double cv$reachedDistributionSourceRV = 0.0;
+				double cv$accumulatedDistributionProbabilities = 0.0;
+				boolean cv$currentValue;
+				cv$currentValue = (cv$valuePos == 1);
+				boolean var97 = cv$currentValue;
+				{
+					{
+						{
+							component[var96] = cv$currentValue;
+						}
+					}
+				}
+				{
+					cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+					double cv$accumulatedProbabilities = (Math.log(1.0) + (((0.0 <= theta) && (theta <= 1.0))?Math.log((cv$currentValue?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+					{
+						{
+							{
+								for(int n = 0; n < N; n += 1) {
+									if((var96 == n)) {
+										{
+											{
+												{
+													if(component[n]) {
+														double traceTempVariable$componentMu$3_1 = mu[0];
+														{
+															{
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentSigma;
+																							if(component[n])
+																								componentSigma = sigma[0];
+																							else
+																								componentSigma = sigma[1];
+																							double var128 = (componentSigma * componentSigma);
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													if(!component[n]) {
+														double traceTempVariable$componentMu$30_1 = mu[1];
+														{
+															{
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentSigma;
+																							if(component[n])
+																								componentSigma = sigma[0];
+																							else
+																								componentSigma = sigma[1];
+																							double var128 = (componentSigma * componentSigma);
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					{
+						{
+							{
+								for(int n = 0; n < N; n += 1) {
+									if((var96 == n)) {
+										{
+											{
+												{
+													if(component[n]) {
+														double traceTempVariable$componentSigma$58_1 = sigma[0];
+														{
+															{
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentMu;
+																							if(component[n])
+																								componentMu = mu[0];
+																							else
+																								componentMu = mu[1];
+																							double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													for(int var78 = 0; var78 < 2; var78 += 1) {
+														if(component[n]) {
+															if((var78 == 0)) {
+																if(component[n]) {
+																	{
+																		{
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							double var63 = (2.0 * 2.0);
+																							if(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)));
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													if(!component[n]) {
+														double traceTempVariable$componentSigma$63_1 = sigma[1];
+														{
+															{
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentMu;
+																							if(component[n])
+																								componentMu = mu[0];
+																							else
+																								componentMu = mu[1];
+																							double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													for(int var78 = 0; var78 < 2; var78 += 1) {
+														if(!component[n]) {
+															if((var78 == 1)) {
+																if(!component[n]) {
+																	{
+																		{
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							double var63 = (2.0 * 2.0);
+																							if(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)));
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+						cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+					else {
+						if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+							cv$stateProbabilityValue = cv$accumulatedProbabilities;
+						else
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+					}
+				}
+				cv$stateProbabilityLocal[cv$valuePos] = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+			}
+			if(constrainedFlag$sample101[((var96 - 0) / 1)]) {
+				double cv$logSum = 0.0;
+				{
+					double cv$lseMax = cv$stateProbabilityLocal[0];
+					for(int cv$lseIndex = 1; cv$lseIndex < cv$numStates; cv$lseIndex += 1) {
+						double cv$lseElementValue = cv$stateProbabilityLocal[cv$lseIndex];
+						if((cv$lseMax < cv$lseElementValue))
+							cv$lseMax = cv$lseElementValue;
+					}
+					if((cv$lseMax == Double.NEGATIVE_INFINITY))
+						cv$logSum = Double.NEGATIVE_INFINITY;
+					else {
+						double cv$lseSum = 0.0;
+						for(int cv$lseIndex = 0; cv$lseIndex < cv$numStates; cv$lseIndex += 1)
+							cv$lseSum = (cv$lseSum + Math.exp((cv$stateProbabilityLocal[cv$lseIndex] - cv$lseMax)));
+						cv$logSum = (cv$logSum + (Math.log(cv$lseSum) + cv$lseMax));
+					}
+				}
+				if((cv$logSum == Double.NEGATIVE_INFINITY)) {
+					for(int cv$indexName = 0; cv$indexName < cv$numStates; cv$indexName += 1)
+						cv$stateProbabilityLocal[cv$indexName] = (1.0 / cv$numStates);
+				} else {
+					for(int cv$indexName = 0; cv$indexName < cv$numStates; cv$indexName += 1)
+						cv$stateProbabilityLocal[cv$indexName] = Math.exp((cv$stateProbabilityLocal[cv$indexName] - cv$logSum));
+				}
+				for(int cv$indexName = cv$numStates; cv$indexName < cv$stateProbabilityLocal.length; cv$indexName += 1)
+					cv$stateProbabilityLocal[cv$indexName] = Double.NEGATIVE_INFINITY;
+				boolean var97 = (DistributionSampling.sampleCategorical(RNG$, cv$stateProbabilityLocal, cv$numStates) == 1);
+				{
+					{
+						{
+							component[var96] = var97;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private final void inferSample20(int var19, int threadID$cv$var19, Rng RNG$) {
+		if(true) {
+			constrainedFlag$sample20[((var19 - 0) / 1)] = false;
+			int cv$numStates = 0;
+			{
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			double cv$originalValue = rawMu[var19];
+			double cv$originalProbability = 0.0;
+			double cv$var = ((cv$originalValue * cv$originalValue) * (0.1 * 0.1));
+			if((cv$var < (0.1 * 0.1)))
+				cv$var = (0.1 * 0.1);
+			double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+			double cv$proposedProbability = 0.0;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				if((constrainedFlag$sample20[((var19 - 0) / 1)] || (cv$valuePos == 0))) {
+					double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+					double cv$reachedDistributionSourceRV = 0.0;
+					double cv$accumulatedDistributionProbabilities = 0.0;
+					double cv$currentValue;
+					if((cv$valuePos == 0))
+						cv$currentValue = cv$originalValue;
+					else {
+						cv$currentValue = cv$proposedValue;
+						double var20 = cv$proposedValue;
+						{
+							{
+								{
+									rawMu[var19] = cv$currentValue;
+								}
+							}
+						}
+						{
+							boolean guard$sample20put43 = false;
+							{
+								if((var19 == 0)) {
+									if(!guard$sample20put43) {
+										guard$sample20put43 = true;
+										{
+											double var39;
+											if((rawMu[0] < rawMu[1]))
+												var39 = rawMu[0];
+											else
+												var39 = rawMu[1];
+											mu[0] = var39;
+										}
+									}
+								}
+							}
+							{
+								if((var19 == 1)) {
+									if(!guard$sample20put43) {
+										guard$sample20put43 = true;
+										{
+											double var39;
+											if((rawMu[0] < rawMu[1]))
+												var39 = rawMu[0];
+											else
+												var39 = rawMu[1];
+											mu[0] = var39;
+										}
+									}
+								}
+							}
+							{
+								if((rawMu[0] < rawMu[1])) {
+									if((var19 == 0)) {
+										if((rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put43) {
+												guard$sample20put43 = true;
+												{
+													double var39;
+													if((rawMu[0] < rawMu[1]))
+														var39 = rawMu[0];
+													else
+														var39 = rawMu[1];
+													mu[0] = var39;
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								if(!(rawMu[0] < rawMu[1])) {
+									if((var19 == 1)) {
+										if(!(rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put43) {
+												guard$sample20put43 = true;
+												{
+													double var39;
+													if((rawMu[0] < rawMu[1]))
+														var39 = rawMu[0];
+													else
+														var39 = rawMu[1];
+													mu[0] = var39;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						{
+							boolean guard$sample20put63 = false;
+							{
+								if((var19 == 0)) {
+									if(!guard$sample20put63) {
+										guard$sample20put63 = true;
+										{
+											double var57;
+											if((rawMu[0] < rawMu[1]))
+												var57 = rawMu[1];
+											else
+												var57 = rawMu[0];
+											mu[1] = var57;
+										}
+									}
+								}
+							}
+							{
+								if((var19 == 1)) {
+									if(!guard$sample20put63) {
+										guard$sample20put63 = true;
+										{
+											double var57;
+											if((rawMu[0] < rawMu[1]))
+												var57 = rawMu[1];
+											else
+												var57 = rawMu[0];
+											mu[1] = var57;
+										}
+									}
+								}
+							}
+							{
+								if((rawMu[0] < rawMu[1])) {
+									if((var19 == 1)) {
+										if((rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put63) {
+												guard$sample20put63 = true;
+												{
+													double var57;
+													if((rawMu[0] < rawMu[1]))
+														var57 = rawMu[1];
+													else
+														var57 = rawMu[0];
+													mu[1] = var57;
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								if(!(rawMu[0] < rawMu[1])) {
+									if((var19 == 0)) {
+										if(!(rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put63) {
+												guard$sample20put63 = true;
+												{
+													double var57;
+													if((rawMu[0] < rawMu[1]))
+														var57 = rawMu[1];
+													else
+														var57 = rawMu[0];
+													mu[1] = var57;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					{
+						cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+						double var6 = (2.0 * 2.0);
+						double cv$accumulatedProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((cv$currentValue - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+						{
+							{
+								{
+									double traceTempVariable$var36$10_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$10_2 = traceTempVariable$var36$10_1;
+												double traceTempVariable$var115$10_3 = traceTempVariable$var39$10_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((0 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$10_5 = traceTempVariable$var115$10_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var36$11_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$11_2 = traceTempVariable$var36$11_1;
+												double traceTempVariable$var117$11_3 = traceTempVariable$var39$11_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((0 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$11_5 = traceTempVariable$var117$11_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var38$12_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$12_2 = traceTempVariable$var38$12_1;
+												double traceTempVariable$var115$12_3 = traceTempVariable$var39$12_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((0 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$12_5 = traceTempVariable$var115$12_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var38$13_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$13_2 = traceTempVariable$var38$13_1;
+												double traceTempVariable$var117$13_3 = traceTempVariable$var39$13_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((0 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$13_5 = traceTempVariable$var117$13_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var54$14_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$14_2 = traceTempVariable$var54$14_1;
+												double traceTempVariable$var115$14_3 = traceTempVariable$var57$14_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((1 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$14_5 = traceTempVariable$var115$14_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var54$15_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$15_2 = traceTempVariable$var54$15_1;
+												double traceTempVariable$var117$15_3 = traceTempVariable$var57$15_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((1 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$15_5 = traceTempVariable$var117$15_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var56$16_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$16_2 = traceTempVariable$var56$16_1;
+												double traceTempVariable$var115$16_3 = traceTempVariable$var57$16_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((1 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$16_5 = traceTempVariable$var115$16_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var56$17_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$17_2 = traceTempVariable$var56$17_1;
+												double traceTempVariable$var117$17_3 = traceTempVariable$var57$17_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((1 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$17_5 = traceTempVariable$var117$17_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						{
+							{
+								boolean guard$sample20if41 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20if41) {
+											guard$sample20if41 = true;
+											{
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$36_1 = rawMu[0];
+															double traceTempVariable$var115$36_2 = traceTempVariable$var39$36_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$36_4 = traceTempVariable$var115$36_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$38_1 = rawMu[0];
+															double traceTempVariable$var117$38_2 = traceTempVariable$var39$38_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$38_4 = traceTempVariable$var117$38_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$48_1 = 0; index$var19$48_1 < 2; index$var19$48_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$48_1 == 0)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$52_1 = rawMu[1];
+															double traceTempVariable$var115$52_2 = traceTempVariable$var39$52_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$52_4 = traceTempVariable$var115$52_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$54_1 = rawMu[1];
+															double traceTempVariable$var117$54_2 = traceTempVariable$var39$54_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$54_4 = traceTempVariable$var117$54_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$64_1 = 0; index$var19$64_1 < 2; index$var19$64_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$64_1 == 1)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20if41) {
+											guard$sample20if41 = true;
+											{
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$37_1 = rawMu[0];
+															double traceTempVariable$var115$37_2 = traceTempVariable$var39$37_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$37_4 = traceTempVariable$var115$37_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$39_1 = rawMu[0];
+															double traceTempVariable$var117$39_2 = traceTempVariable$var39$39_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$39_4 = traceTempVariable$var117$39_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$49_1 = 0; index$var19$49_1 < 2; index$var19$49_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$49_1 == 0)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$53_1 = rawMu[1];
+															double traceTempVariable$var115$53_2 = traceTempVariable$var39$53_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$53_4 = traceTempVariable$var115$53_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$55_1 = rawMu[1];
+															double traceTempVariable$var117$55_2 = traceTempVariable$var39$55_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$55_4 = traceTempVariable$var117$55_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$65_1 = 0; index$var19$65_1 < 2; index$var19$65_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$65_1 == 1)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						{
+							{
+								boolean guard$sample20if61 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20if61) {
+											guard$sample20if61 = true;
+											{
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$70_1 = rawMu[1];
+															double traceTempVariable$var115$70_2 = traceTempVariable$var57$70_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$70_4 = traceTempVariable$var115$70_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$72_1 = rawMu[1];
+															double traceTempVariable$var117$72_2 = traceTempVariable$var57$72_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$72_4 = traceTempVariable$var117$72_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$82_1 = 0; index$var19$82_1 < 2; index$var19$82_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$82_1 == 1)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$86_1 = rawMu[0];
+															double traceTempVariable$var115$86_2 = traceTempVariable$var57$86_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$86_4 = traceTempVariable$var115$86_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$88_1 = rawMu[0];
+															double traceTempVariable$var117$88_2 = traceTempVariable$var57$88_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$88_4 = traceTempVariable$var117$88_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$98_1 = 0; index$var19$98_1 < 2; index$var19$98_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$98_1 == 0)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20if61) {
+											guard$sample20if61 = true;
+											{
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$71_1 = rawMu[1];
+															double traceTempVariable$var115$71_2 = traceTempVariable$var57$71_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$71_4 = traceTempVariable$var115$71_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$73_1 = rawMu[1];
+															double traceTempVariable$var117$73_2 = traceTempVariable$var57$73_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$73_4 = traceTempVariable$var117$73_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$83_1 = 0; index$var19$83_1 < 2; index$var19$83_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$83_1 == 1)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$87_1 = rawMu[0];
+															double traceTempVariable$var115$87_2 = traceTempVariable$var57$87_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$87_4 = traceTempVariable$var115$87_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$89_1 = rawMu[0];
+															double traceTempVariable$var117$89_2 = traceTempVariable$var57$89_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$89_4 = traceTempVariable$var117$89_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$99_1 = 0; index$var19$99_1 < 2; index$var19$99_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$99_1 == 0)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+						else {
+							if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+								cv$stateProbabilityValue = cv$accumulatedProbabilities;
+							else
+								cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+						}
+					}
+					if((cv$valuePos == 0))
+						cv$originalProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					else
+						cv$proposedProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					double cv$ratio = (cv$proposedProbability - cv$originalProbability);
+					if((cv$valuePos == 1)) {
+						if(((cv$ratio <= Math.log((0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$))))) || Double.isNaN(cv$ratio))) {
+							double var20 = cv$originalValue;
+							{
+								{
+									{
+										rawMu[var19] = var20;
+									}
+								}
+							}
+							{
+								boolean guard$sample20put43 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20put43) {
+											guard$sample20put43 = true;
+											{
+												double var39;
+												if((rawMu[0] < rawMu[1]))
+													var39 = rawMu[0];
+												else
+													var39 = rawMu[1];
+												mu[0] = var39;
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20put43) {
+											guard$sample20put43 = true;
+											{
+												double var39;
+												if((rawMu[0] < rawMu[1]))
+													var39 = rawMu[0];
+												else
+													var39 = rawMu[1];
+												mu[0] = var39;
+											}
+										}
+									}
+								}
+								{
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put43) {
+													guard$sample20put43 = true;
+													{
+														double var39;
+														if((rawMu[0] < rawMu[1]))
+															var39 = rawMu[0];
+														else
+															var39 = rawMu[1];
+														mu[0] = var39;
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put43) {
+													guard$sample20put43 = true;
+													{
+														double var39;
+														if((rawMu[0] < rawMu[1]))
+															var39 = rawMu[0];
+														else
+															var39 = rawMu[1];
+														mu[0] = var39;
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								boolean guard$sample20put63 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20put63) {
+											guard$sample20put63 = true;
+											{
+												double var57;
+												if((rawMu[0] < rawMu[1]))
+													var57 = rawMu[1];
+												else
+													var57 = rawMu[0];
+												mu[1] = var57;
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20put63) {
+											guard$sample20put63 = true;
+											{
+												double var57;
+												if((rawMu[0] < rawMu[1]))
+													var57 = rawMu[1];
+												else
+													var57 = rawMu[0];
+												mu[1] = var57;
+											}
+										}
+									}
+								}
+								{
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put63) {
+													guard$sample20put63 = true;
+													{
+														double var57;
+														if((rawMu[0] < rawMu[1]))
+															var57 = rawMu[1];
+														else
+															var57 = rawMu[0];
+														mu[1] = var57;
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put63) {
+													guard$sample20put63 = true;
+													{
+														double var57;
+														if((rawMu[0] < rawMu[1]))
+															var57 = rawMu[1];
+														else
+															var57 = rawMu[0];
+														mu[1] = var57;
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private final void inferSample83(int var78) {
+		if(true) {
+			constrainedFlag$sample83[((var78 - 0) / 1)] = false;
+			int cv$numStates = 0;
+			{
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			double cv$originalValue = sigma[var78];
+			double cv$originalProbability = 0.0;
+			double cv$var = ((cv$originalValue * cv$originalValue) * (0.1 * 0.1));
+			if((cv$var < (0.1 * 0.1)))
+				cv$var = (0.1 * 0.1);
+			double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+			double cv$proposedProbability = 0.0;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				if((constrainedFlag$sample83[((var78 - 0) / 1)] || (cv$valuePos == 0))) {
+					double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+					double cv$reachedDistributionSourceRV = 0.0;
+					double cv$accumulatedDistributionProbabilities = 0.0;
+					double cv$currentValue;
+					if((cv$valuePos == 0))
+						cv$currentValue = cv$originalValue;
+					else {
+						cv$currentValue = cv$proposedValue;
+						double var79 = cv$proposedValue;
+						{
+							{
+								{
+									sigma[var78] = cv$currentValue;
+								}
+							}
+						}
+					}
+					{
+						cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+						double var63 = (2.0 * 2.0);
+						double cv$accumulatedProbabilities = (Math.log(1.0) + (((((0.0 <= cv$currentValue) && (cv$currentValue <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((cv$currentValue - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+						{
+							{
+								{
+									double traceTempVariable$var124$2_1 = cv$currentValue;
+									for(int n = 0; n < N; n += 1) {
+										if(component[n]) {
+											if((var78 == 0)) {
+												if(component[n]) {
+													double traceTempVariable$componentSigma$2_3 = traceTempVariable$var124$2_1;
+													{
+														{
+															boolean cv$sampleConstrained = true;
+															if(cv$sampleConstrained) {
+																constrainedFlag$sample83[((var78 - 0) / 1)] = true;
+																double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																{
+																	{
+																		{
+																			{
+																				{
+																					double componentMu;
+																					if(component[n])
+																						componentMu = mu[0];
+																					else
+																						componentMu = mu[1];
+																					double var128 = (traceTempVariable$componentSigma$2_3 * traceTempVariable$componentSigma$2_3);
+																					if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																						else
+																							cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																				}
+																			}
+																		}
+																	}
+																}
+																cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																	cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																else {
+																	if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																		cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																	else
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var126$3_1 = cv$currentValue;
+									for(int n = 0; n < N; n += 1) {
+										if(!component[n]) {
+											if((var78 == 1)) {
+												if(!component[n]) {
+													double traceTempVariable$componentSigma$3_3 = traceTempVariable$var126$3_1;
+													{
+														{
+															boolean cv$sampleConstrained = true;
+															if(cv$sampleConstrained) {
+																constrainedFlag$sample83[((var78 - 0) / 1)] = true;
+																double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																{
+																	{
+																		{
+																			{
+																				{
+																					double componentMu;
+																					if(component[n])
+																						componentMu = mu[0];
+																					else
+																						componentMu = mu[1];
+																					double var128 = (traceTempVariable$componentSigma$3_3 * traceTempVariable$componentSigma$3_3);
+																					if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																						else
+																							cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																				}
+																			}
+																		}
+																	}
+																}
+																cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																	cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																else {
+																	if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																		cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																	else
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+						else {
+							if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+								cv$stateProbabilityValue = cv$accumulatedProbabilities;
+							else
+								cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+						}
+					}
+					if((cv$valuePos == 0))
+						cv$originalProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					else
+						cv$proposedProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					double cv$ratio = (cv$proposedProbability - cv$originalProbability);
+					if((cv$valuePos == 1)) {
+						if(((cv$ratio <= Math.log((0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$))))) || Double.isNaN(cv$ratio))) {
+							double var79 = cv$originalValue;
+							{
+								{
+									{
+										sigma[var78] = var79;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private final void inferSample88() {
+		if(true) {
+			constrainedFlag$sample88 = false;
+			int cv$sum = 0;
+			int cv$count = 0;
+			{
+				{
+					{
+						{
+							{
+								{
+									for(int var96 = 0; var96 < N; var96 += 1) {
+										boolean cv$sampleConstrained = (fixedFlag$sample101 || constrainedFlag$sample101[((var96 - 0) / 1)]);
+										if(cv$sampleConstrained) {
+											constrainedFlag$sample88 = true;
+											{
+												{
+													{
+														{
+															{
+																cv$count = (cv$count + 1);
+																if(component[var96])
+																	cv$sum = (cv$sum + 1);
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			if(constrainedFlag$sample88)
+				theta = Conjugates.sampleConjugateBetaBinomial(RNG$, 5.0, 5.0, cv$sum, cv$count);
+		}
+	}
+
+	private final void logProbabilityValue$sample101() {
+		if(!fixedProbFlag$sample101) {
+			double cv$accumulator = 0.0;
+			double cv$sampleAccumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1) {
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						boolean cv$sampleValue = component[var96];
+						{
+							{
+								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= theta) && (theta <= 1.0))?Math.log((cv$sampleValue?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				cv$sampleReached = true;
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$componentDistribution = cv$sampleAccumulator;
+			logProbability$var97 = cv$sampleAccumulator;
+			logProbability$component = (logProbability$component + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedFlag$sample88);
+		} else {
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1)
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var97;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			logProbability$componentDistribution = cv$rvAccumulator;
+			logProbability$component = (logProbability$component + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	private final void logProbabilityValue$sample138() {
+		if(!fixedProbFlag$sample138) {
+			double cv$accumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1) {
+				double cv$sampleAccumulator = 0.0;
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						double cv$sampleValue = y[n];
+						{
+							{
+								double componentMu;
+								if(component[n])
+									componentMu = mu[0];
+								else
+									componentMu = mu[1];
+								double componentSigma;
+								if(component[n])
+									componentSigma = sigma[0];
+								else
+									componentSigma = sigma[1];
+								double var128 = (componentSigma * componentSigma);
+								double cv$weightedProbability = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				cv$sampleReached = true;
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+				logProbability$sample138[((n - 0) / 1)] = cv$sampleProbability;
+			}
+			logProbability$y = (logProbability$y + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			fixedProbFlag$sample138 = ((fixedFlag$sample20 && fixedFlag$sample83) && fixedFlag$sample101);
+		} else {
+			double cv$accumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1) {
+				double cv$rvAccumulator = 0.0;
+				double cv$sampleValue = logProbability$sample138[((n - 0) / 1)];
+				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+				cv$sampleReached = true;
+				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			}
+			logProbability$y = (logProbability$y + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	private final void logProbabilityValue$sample20() {
+		if(!fixedProbFlag$sample20) {
+			double cv$accumulator = 0.0;
+			double cv$sampleAccumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						double cv$sampleValue = rawMu[var19];
+						{
+							{
+								double var3 = 0.0;
+								double var6 = (2.0 * 2.0);
+								double cv$weightedProbability = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var3) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+								{
+									boolean guard$put21if41 = false;
+									{
+										if((var19 == 0)) {
+											if(!guard$put21if41)
+												guard$put21if41 = true;
+										}
+									}
+									{
+										if((var19 == 1)) {
+											if(!guard$put21if41)
+												guard$put21if41 = true;
+										}
+									}
+								}
+								{
+									boolean guard$put21if61 = false;
+									{
+										if((var19 == 0)) {
+											if(!guard$put21if61)
+												guard$put21if61 = true;
+										}
+									}
+									{
+										if((var19 == 1)) {
+											if(!guard$put21if61)
+												guard$put21if61 = true;
+										}
+									}
+								}
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				cv$sampleReached = true;
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				logProbability$sample20[((var19 - 0) / 1)] = cv$sampleProbability;
+				boolean cv$guard$mu = false;
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if((rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+				}
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if((rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$rawMu = (logProbability$rawMu + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			fixedProbFlag$sample20 = fixedFlag$sample20;
+		} else {
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				double cv$sampleValue = logProbability$sample20[((var19 - 0) / 1)];
+				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+				cv$sampleReached = true;
+				boolean cv$guard$mu = false;
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if((rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+				}
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if((rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			logProbability$rawMu = (logProbability$rawMu + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	private final void logProbabilityValue$sample83() {
+		if(!fixedProbFlag$sample83) {
+			double cv$accumulator = 0.0;
+			double cv$sampleAccumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int var78 = 0; var78 < 2; var78 += 1) {
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						double cv$sampleValue = sigma[var78];
+						{
+							{
+								double var60 = 0.0;
+								double var63 = (2.0 * 2.0);
+								double var64 = 0.0;
+								double var65 = 1.0E100;
+								double cv$weightedProbability = (Math.log(1.0) + (((((var64 <= cv$sampleValue) && (cv$sampleValue <= var65)) && (var64 < var65)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var60) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((var65 - var60) / Math.sqrt(var63))) - Gaussian.cdf(((var64 - var60) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				cv$sampleReached = true;
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var79 = cv$sampleAccumulator;
+			logProbability$sigma = (logProbability$sigma + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			fixedProbFlag$sample83 = fixedFlag$sample83;
+		} else {
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int var78 = 0; var78 < 2; var78 += 1)
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var79;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			logProbability$sigma = (logProbability$sigma + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	private final void logProbabilityValue$sample88() {
+		if(!fixedProbFlag$sample88) {
+			double cv$accumulator = 0.0;
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				{
+					double cv$sampleValue = theta;
+					{
+						{
+							double var81 = 5.0;
+							double var82 = 5.0;
+							double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var81, var82));
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						}
+					}
+				}
+			}
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$theta = cv$sampleProbability;
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			fixedProbFlag$sample88 = fixedFlag$sample88;
+		} else {
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			double cv$sampleValue = logProbability$theta;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	@Override
+	public final void allocateScratch() {
+		{
+			{
+				int cv$threadCount = threadCount();
+				cv$var97$stateProbabilityGlobal = new double[cv$threadCount][];
+				for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
+					cv$var97$stateProbabilityGlobal[cv$index] = new double[2];
+			}
+		}
+		{
+			int cv$max_var19 = 0;
+			cv$max_var19 = Math.max(cv$max_var19, ((2 - 0) / 1));
+			{
+				int cv$threadCount = threadCount();
+				guard$sample20if124$global = new boolean[cv$threadCount][];
+				for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
+					guard$sample20if124$global[cv$index] = new boolean[cv$max_var19];
+			}
+		}
+	}
+
+	@Override
+	public final void allocator() {
+		if(!fixedFlag$sample20) {
+			{
+				rawMu = new double[2];
+			}
+		}
+		{
+			mu = new double[2];
+		}
+		if(!fixedFlag$sample83) {
+			{
+				sigma = new double[2];
+			}
+		}
+		if(!fixedFlag$sample101) {
+			{
+				component = new boolean[length$yObserved];
+			}
+		}
+		{
+			y = new double[length$yObserved];
+		}
+		{
+			constrainedFlag$sample101 = new boolean[((((length$yObserved - 1) - 0) / 1) + 1)];
+		}
+		{
+			constrainedFlag$sample20 = new boolean[((((2 - 1) - 0) / 1) + 1)];
+		}
+		{
+			constrainedFlag$sample83 = new boolean[((((2 - 1) - 0) / 1) + 1)];
+		}
+		{
+			logProbability$sample20 = new double[((((2 - 1) - 0) / 1) + 1)];
+		}
+		{
+			logProbability$sample138 = new double[((((length$yObserved - 1) - 0) / 1) + 1)];
+		}
+		allocateScratch();
+	}
+
+	@Override
+	public final void forwardGeneration() {
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[0];
+		} else {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[1];
+		}
+		if(!fixedFlag$sample20)
+			mu[0] = var39;
+		double var57 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[1];
+		} else {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[0];
+		}
+		if(!fixedFlag$sample20)
+			mu[1] = var57;
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$n, int forEnd$n, int threadID$n, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int n = forStart$n; n < forEnd$n; n += 1) {
+						double componentMu;
+						if(component[n])
+							componentMu = mu[0];
+						else
+							componentMu = mu[1];
+						double componentSigma;
+						if(component[n])
+							componentSigma = sigma[0];
+						else
+							componentSigma = sigma[1];
+						y[n] = ((Math.sqrt((componentSigma * componentSigma)) * DistributionSampling.sampleGaussian(RNG$1)) + componentMu);
+					}
+			}
+		);
+	}
+
+	@Override
+	public final void forwardGenerationDistributionsNoOutputsPrime() {
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+	}
+
+	@Override
+	public final void forwardGenerationPrime() {
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$n, int forEnd$n, int threadID$n, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int n = forStart$n; n < forEnd$n; n += 1) {
+						double componentMu;
+						if(component[n])
+							componentMu = mu[0];
+						else
+							componentMu = mu[1];
+						double componentSigma;
+						if(component[n])
+							componentSigma = sigma[0];
+						else
+							componentSigma = sigma[1];
+						y[n] = ((Math.sqrt((componentSigma * componentSigma)) * DistributionSampling.sampleGaussian(RNG$1)) + componentMu);
+					}
+			}
+		);
+	}
+
+	@Override
+	public final void forwardGenerationValuesNoOutputs() {
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[0];
+		} else {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[1];
+		}
+		if(!fixedFlag$sample20)
+			mu[0] = var39;
+		double var57 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[1];
+		} else {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[0];
+		}
+		if(!fixedFlag$sample20)
+			mu[1] = var57;
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+	}
+
+	@Override
+	public final void forwardGenerationValuesNoOutputsPrime() {
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+	}
+
+	@Override
+	public final void gibbsRound() {
+		if(system$gibbsForward) {
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+							if(!fixedFlag$sample20)
+								inferSample20(var19, threadID$var19, RNG$1);
+						}
+				}
+			);
+			for(int var78 = 0; var78 < 2; var78 += 1) {
+				if(!fixedFlag$sample83)
+					inferSample83(var78);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+							if(!fixedFlag$sample101)
+								inferSample101(var96, threadID$var96, RNG$1);
+						}
+				}
+			);
+		} else {
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+							if(!fixedFlag$sample101)
+								inferSample101(var96, threadID$var96, RNG$1);
+						}
+				}
+			);
+			if(!fixedFlag$sample88)
+				inferSample88();
+			for(int var78 = (2 - ((((2 - 1) - 0) % 1) + 1)); var78 >= ((0 - 1) + 1); var78 -= 1) {
+				if(!fixedFlag$sample83)
+					inferSample83(var78);
+			}
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+							if(!fixedFlag$sample20)
+								inferSample20(var19, threadID$var19, RNG$1);
+						}
+				}
+			);
+		}
+		system$gibbsForward = !system$gibbsForward;
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!constrainedFlag$sample20[((var19 - 0) / 1)])
+							drawValueSample20(var19, threadID$var19, RNG$1);
+					}
+			}
+		);
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!constrainedFlag$sample83[((var78 - 0) / 1)])
+				drawValueSample83(var78);
+		}
+		if(!constrainedFlag$sample88)
+			drawValueSample88();
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!constrainedFlag$sample101[((var96 - 0) / 1)])
+							drawValueSample101(var96, threadID$var96, RNG$1);
+					}
+			}
+		);
+	}
+
+	private final void initializeLogProbabilityFields() {
+		logProbability$$model = 0.0;
+		logProbability$$evidence = 0.0;
+		logProbability$rawMu = 0.0;
+		logProbability$mu = 0.0;
+		if(!fixedProbFlag$sample20) {
+			for(int var19 = 0; var19 < 2; var19 += 1)
+				logProbability$sample20[((var19 - 0) / 1)] = Double.NaN;
+		}
+		logProbability$sigma = 0.0;
+		if(!fixedProbFlag$sample83)
+			logProbability$var79 = Double.NaN;
+		if(!fixedProbFlag$sample88)
+			logProbability$theta = Double.NaN;
+		logProbability$componentDistribution = Double.NaN;
+		logProbability$component = 0.0;
+		if(!fixedProbFlag$sample101)
+			logProbability$var97 = Double.NaN;
+		logProbability$y = 0.0;
+		if(!fixedProbFlag$sample138) {
+			for(int n = 0; n < N; n += 1)
+				logProbability$sample138[((n - 0) / 1)] = Double.NaN;
+		}
+	}
+
+	@Override
+	public final void initializeModel() {
+		N = length$yObserved;
+		for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+			constrainedFlag$sample101[index$constrainedFlag$sample101$1] = true;
+		for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+			constrainedFlag$sample20[index$constrainedFlag$sample20$1] = true;
+		for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+			constrainedFlag$sample83[index$constrainedFlag$sample83$1] = true;
+	}
+
+	@Override
+	public final void logEvidenceProbabilities() {
+		initializeLogProbabilityFields();
+		if(fixedFlag$sample20)
+			logProbabilityValue$sample20();
+		if(fixedFlag$sample83)
+			logProbabilityValue$sample83();
+		if(fixedFlag$sample88)
+			logProbabilityValue$sample88();
+		if(fixedFlag$sample101)
+			logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	@Override
+	public final void logModelProbabilitiesDist() {
+		initializeLogProbabilityFields();
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	@Override
+	public final void logModelProbabilitiesVal() {
+		initializeLogProbabilityFields();
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	@Override
+	public final void propagateObservedValues() {
+		double[] cv$source1 = yObserved;
+		double[] cv$target1 = y;
+		int cv$length1 = cv$target1.length;
+		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1)
+			cv$target1[cv$index1] = cv$source1[cv$index1];
+	}
+
+	@Override
+	public final void setIntermediates() {
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+	}
+
+	@Override
+	public String modelCode() {
+		return "/*\n"
+		     + " * Sandwood\n"
+		     + " *\n"
+		     + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+		     + " * \n"
+		     + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+		     + " */\n"
+		     + "\n"
+		     + "package org.sandwood.compiler.tests.parser;\n"
+		     + "\n"
+		     + "public model LowDimMix(double[] yObserved) {\n"
+		     + "    int N = yObserved.length;\n"
+		     + "\n"
+		     + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+		     + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+		     + "    // the constant normalisation factor for the ordered constraint.\n"
+		     + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+		     + "    double[] mu = new double[2];\n"
+		     + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+		     + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+		     + "\n"
+		     + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+		     + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+		     + "\n"
+		     + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+		     + "    double theta = beta(5.0, 5.0).sample();\n"
+		     + "\n"
+		     + "    // Stan likelihood:\n"
+		     + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+		     + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+		     + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+		     + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+		     + "    boolean[] component = componentDistribution.sample(N);\n"
+		     + "    double[] y = new double[N];\n"
+		     + "\n"
+		     + "    for(int n = 0; n < N; n++) {\n"
+		     + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+		     + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+		     + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+		     + "    }\n"
+		     + "\n"
+		     + "    y.observe(yObserved);\n"
+		     + "}\n"
+		     + "";
+	}
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$MultiThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$MultiThreadCPU_modelSingle.java
@@ -1,0 +1,7514 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.random.internal.Rng;
+import org.sandwood.runtime.internal.numericTools.Conjugates;
+import org.sandwood.runtime.internal.numericTools.DistributionSampling;
+import org.sandwood.runtime.internal.numericTools.Gaussian;
+import org.sandwood.runtime.model.ExecutionTarget;
+
+final class LowDimMix$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements LowDimMix$CoreInterface {
+	
+	// Declare the variables for the model.
+	private int N;
+	private boolean[] component;
+	private boolean[] constrainedFlag$sample101;
+	private boolean[] constrainedFlag$sample20;
+	private boolean[] constrainedFlag$sample83;
+	private boolean constrainedFlag$sample88 = true;
+	private double[][] cv$var97$stateProbabilityGlobal;
+	private boolean fixedFlag$sample101 = false;
+	private boolean fixedFlag$sample20 = false;
+	private boolean fixedFlag$sample83 = false;
+	private boolean fixedFlag$sample88 = false;
+	private boolean fixedProbFlag$sample101 = false;
+	private boolean fixedProbFlag$sample138 = false;
+	private boolean fixedProbFlag$sample20 = false;
+	private boolean fixedProbFlag$sample83 = false;
+	private boolean fixedProbFlag$sample88 = false;
+	private boolean[][] guard$sample20if124$global;
+	private int length$yObserved;
+	private double logProbability$$evidence;
+	private double logProbability$$model;
+	private double logProbability$component;
+	private double logProbability$componentDistribution;
+	private double logProbability$mu;
+	private double logProbability$rawMu;
+	private double[] logProbability$sample20;
+	private double logProbability$sigma;
+	private double logProbability$theta;
+	private double logProbability$var130;
+	private double logProbability$var79;
+	private double logProbability$var97;
+	private double logProbability$y;
+	private double[] mu;
+	private double[] rawMu;
+	private double[] sigma;
+	private boolean system$gibbsForward = true;
+	private double theta;
+	private double[] y;
+	private double[] yObserved;
+
+	public LowDimMix$MultiThreadCPU(ExecutionTarget target) {
+		super(target);
+	}
+
+	// Getter for N.
+	@Override
+	public final int get$N() {
+		return N;
+	}
+
+	// Getter for component.
+	@Override
+	public final boolean[] get$component() {
+		return component;
+	}
+
+	// Setter for component.
+	@Override
+	public final void set$component(boolean[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of component including if probabilities need
+		// to be updated.
+		component = cv$value;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on component.
+		fixedProbFlag$sample101 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on component.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for fixedFlag$sample101.
+	@Override
+	public final boolean get$fixedFlag$sample101() {
+		return fixedFlag$sample101;
+	}
+
+	// Setter for fixedFlag$sample101.
+	@Override
+	public final void set$fixedFlag$sample101(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample101 including if probabilities
+		// need to be updated.
+		fixedFlag$sample101 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+				constrainedFlag$sample101[index$constrainedFlag$sample101$1] = fixedFlag$sample101;
+		}
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedProbFlag$sample101);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample138 = (fixedFlag$sample101 && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample20.
+	@Override
+	public final boolean get$fixedFlag$sample20() {
+		return fixedFlag$sample20;
+	}
+
+	// Setter for fixedFlag$sample20.
+	@Override
+	public final void set$fixedFlag$sample20(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample20 including if probabilities
+		// need to be updated.
+		fixedFlag$sample20 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+				constrainedFlag$sample20[index$constrainedFlag$sample20$1] = fixedFlag$sample20;
+		}
+		
+		// Should the probability of sample 20 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample20 = (fixedFlag$sample20 && fixedProbFlag$sample20);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample138 = (fixedFlag$sample20 && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample83.
+	@Override
+	public final boolean get$fixedFlag$sample83() {
+		return fixedFlag$sample83;
+	}
+
+	// Setter for fixedFlag$sample83.
+	@Override
+	public final void set$fixedFlag$sample83(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample83 including if probabilities
+		// need to be updated.
+		fixedFlag$sample83 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+				constrainedFlag$sample83[index$constrainedFlag$sample83$1] = fixedFlag$sample83;
+		}
+		
+		// Should the probability of sample 83 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample83 = (fixedFlag$sample83 && fixedProbFlag$sample83);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample138 = (fixedFlag$sample83 && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample88.
+	@Override
+	public final boolean get$fixedFlag$sample88() {
+		return fixedFlag$sample88;
+	}
+
+	// Setter for fixedFlag$sample88.
+	@Override
+	public final void set$fixedFlag$sample88(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample88 including if probabilities
+		// need to be updated.
+		fixedFlag$sample88 = cv$value;
+		constrainedFlag$sample88 = (fixedFlag$sample88 || constrainedFlag$sample88);
+		
+		// Should the probability of sample 88 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample88 = (fixedFlag$sample88 && fixedProbFlag$sample88);
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample101 = (fixedFlag$sample88 && fixedProbFlag$sample101);
+	}
+
+	// Getter for length$yObserved.
+	@Override
+	public final int get$length$yObserved() {
+		return length$yObserved;
+	}
+
+	// Setter for length$yObserved.
+	@Override
+	public final void set$length$yObserved(int cv$value, boolean allocated$) {
+		length$yObserved = cv$value;
+	}
+
+	// Getter for logProbability$$evidence.
+	@Override
+	public final double get$logProbability$$evidence() {
+		return logProbability$$evidence;
+	}
+
+	// Getter for the probability of logProbability$$model.
+	@Override
+	public final double getCurrentLogProbability() {
+		return logProbability$$model;
+	}
+
+	// Getter for logProbability$component.
+	@Override
+	public final double get$logProbability$component() {
+		return logProbability$component;
+	}
+
+	// Getter for logProbability$componentDistribution.
+	@Override
+	public final double get$logProbability$componentDistribution() {
+		return logProbability$componentDistribution;
+	}
+
+	// Getter for logProbability$mu.
+	@Override
+	public final double get$logProbability$mu() {
+		return logProbability$mu;
+	}
+
+	// Getter for logProbability$rawMu.
+	@Override
+	public final double get$logProbability$rawMu() {
+		return logProbability$rawMu;
+	}
+
+	// Getter for logProbability$sigma.
+	@Override
+	public final double get$logProbability$sigma() {
+		return logProbability$sigma;
+	}
+
+	// Getter for logProbability$theta.
+	@Override
+	public final double get$logProbability$theta() {
+		return logProbability$theta;
+	}
+
+	// Getter for logProbability$y.
+	@Override
+	public final double get$logProbability$y() {
+		return logProbability$y;
+	}
+
+	// Getter for mu.
+	@Override
+	public final double[] get$mu() {
+		return mu;
+	}
+
+	// Getter for rawMu.
+	@Override
+	public final double[] get$rawMu() {
+		return rawMu;
+	}
+
+	// Setter for rawMu.
+	@Override
+	public final void set$rawMu(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of rawMu including if probabilities need to
+		// be updated.
+		rawMu = cv$value;
+		
+		// Unset the fixed probability flag for sample 20 as it depends on rawMu.
+		fixedProbFlag$sample20 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on rawMu.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for sigma.
+	@Override
+	public final double[] get$sigma() {
+		return sigma;
+	}
+
+	// Setter for sigma.
+	@Override
+	public final void set$sigma(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of sigma including if probabilities need to
+		// be updated.
+		sigma = cv$value;
+		
+		// Unset the fixed probability flag for sample 83 as it depends on sigma.
+		fixedProbFlag$sample83 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on sigma.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for theta.
+	@Override
+	public final double get$theta() {
+		return theta;
+	}
+
+	// Setter for theta.
+	@Override
+	public final void set$theta(double cv$value, boolean allocated$) {
+		// Set flags for all the side effects of theta including if probabilities need to
+		// be updated.
+		theta = cv$value;
+		
+		// Unset the fixed probability flag for sample 88 as it depends on theta.
+		fixedProbFlag$sample88 = false;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on theta.
+		fixedProbFlag$sample101 = false;
+	}
+
+	// Getter for y.
+	@Override
+	public final double[] get$y() {
+		return y;
+	}
+
+	// Getter for yObserved.
+	@Override
+	public final double[] get$yObserved() {
+		return yObserved;
+	}
+
+	// Setter for yObserved.
+	@Override
+	public final void set$yObserved(double[] cv$value, boolean allocated$) {
+		yObserved = cv$value;
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample101
+	private final void drawValueSample101(int var96, int threadID$cv$var96, Rng RNG$) {
+		component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample20
+	private final void drawValueSample20(int var19, int threadID$cv$var19, Rng RNG$) {
+		rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 41.
+		{
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20put43 = false;
+			{
+				if((var19 == 0)) {
+					if(!guard$sample20put43) {
+						// The body will execute, so should not be executed again
+						guard$sample20put43 = true;
+						{
+							double var39;
+							if((rawMu[0] < rawMu[1]))
+								var39 = rawMu[0];
+							else
+								var39 = rawMu[1];
+							mu[0] = var39;
+						}
+					}
+				}
+			}
+			{
+				if((var19 == 1)) {
+					if(!guard$sample20put43) {
+						// The body will execute, so should not be executed again
+						guard$sample20put43 = true;
+						{
+							double var39;
+							if((rawMu[0] < rawMu[1]))
+								var39 = rawMu[0];
+							else
+								var39 = rawMu[1];
+							mu[0] = var39;
+						}
+					}
+				}
+			}
+			{
+				if((rawMu[0] < rawMu[1])) {
+					if((var19 == 0)) {
+						if((rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put43) {
+								// The body will execute, so should not be executed again
+								guard$sample20put43 = true;
+								{
+									double var39;
+									if((rawMu[0] < rawMu[1]))
+										var39 = rawMu[0];
+									else
+										var39 = rawMu[1];
+									mu[0] = var39;
+								}
+							}
+						}
+					}
+				}
+			}
+			{
+				if(!(rawMu[0] < rawMu[1])) {
+					if((var19 == 1)) {
+						if(!(rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put43) {
+								// The body will execute, so should not be executed again
+								guard$sample20put43 = true;
+								{
+									double var39;
+									if((rawMu[0] < rawMu[1]))
+										var39 = rawMu[0];
+									else
+										var39 = rawMu[1];
+									mu[0] = var39;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 59.
+		{
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20put63 = false;
+			{
+				if((var19 == 0)) {
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						{
+							double var57;
+							if((rawMu[0] < rawMu[1]))
+								var57 = rawMu[1];
+							else
+								var57 = rawMu[0];
+							mu[1] = var57;
+						}
+					}
+				}
+			}
+			{
+				if((var19 == 1)) {
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						{
+							double var57;
+							if((rawMu[0] < rawMu[1]))
+								var57 = rawMu[1];
+							else
+								var57 = rawMu[0];
+							mu[1] = var57;
+						}
+					}
+				}
+			}
+			{
+				if((rawMu[0] < rawMu[1])) {
+					if((var19 == 1)) {
+						if((rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put63) {
+								// The body will execute, so should not be executed again
+								guard$sample20put63 = true;
+								{
+									double var57;
+									if((rawMu[0] < rawMu[1]))
+										var57 = rawMu[1];
+									else
+										var57 = rawMu[0];
+									mu[1] = var57;
+								}
+							}
+						}
+					}
+				}
+			}
+			{
+				if(!(rawMu[0] < rawMu[1])) {
+					if((var19 == 0)) {
+						if(!(rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put63) {
+								// The body will execute, so should not be executed again
+								guard$sample20put63 = true;
+								{
+									double var57;
+									if((rawMu[0] < rawMu[1]))
+										var57 = rawMu[1];
+									else
+										var57 = rawMu[0];
+									mu[1] = var57;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample83
+	private final void drawValueSample83(int var78) {
+		sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample88
+	private final void drawValueSample88() {
+		theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 101 drawn from componentDistribution. Inference was performed using
+	// variable marginalization.
+	private final void inferSample101(int var96, int threadID$cv$var96, Rng RNG$) {
+		if(true) {
+			constrainedFlag$sample101[((var96 - 0) / 1)] = false;
+			
+			// Calculate the number of states to evaluate.
+			int cv$numStates = 0;
+			{
+				// variable marginalization
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			
+			// Get a local reference to the scratch space.
+			double[] cv$stateProbabilityLocal = cv$var97$stateProbabilityGlobal[threadID$cv$var96];
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				// Initialize the summed probabilities to 0.
+				double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+				
+				// Initialize a counter to track the reached distributions.
+				double cv$reachedDistributionSourceRV = 0.0;
+				
+				// Initialize a log space accumulator to take the product of all the distribution
+				// probabilities.
+				double cv$accumulatedDistributionProbabilities = 0.0;
+				
+				// The value currently being tested
+				boolean cv$currentValue;
+				
+				// Value of the variable at this index
+				cv$currentValue = (cv$valuePos == 1);
+				
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				boolean var97 = cv$currentValue;
+				
+				// Guards to ensure that component is only updated when there is a valid path.
+				{
+					{
+						{
+							component[var96] = cv$currentValue;
+						}
+					}
+				}
+				{
+					// Record the reached probability density.
+					cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+					
+					// An accumulator to allow the value for each distribution to be constructed before
+					// it is added to the index probabilities.
+					double cv$accumulatedProbabilities = (Math.log(1.0) + (((0.0 <= theta) && (theta <= 1.0))?Math.log((cv$currentValue?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+					
+					// Processing conditional point124.
+					{
+						// Looking for a path between Sample 101 and consumer double 118.
+						{
+							{
+								for(int n = 0; n < N; n += 1) {
+									if((var96 == n)) {
+										{
+											{
+												{
+													if(component[n]) {
+														double traceTempVariable$componentMu$3_1 = mu[0];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentSigma;
+																							if(component[n])
+																								componentSigma = sigma[0];
+																							else
+																								componentSigma = sigma[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (componentSigma * componentSigma);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 20 and consumer double 118.
+											{
+												// Guard to check that at most one copy of the code is executed for a given random
+												// variable instance.
+												boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													if(!component[n]) {
+														double traceTempVariable$componentMu$30_1 = mu[1];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentSigma;
+																							if(component[n])
+																								componentSigma = sigma[0];
+																							else
+																								componentSigma = sigma[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (componentSigma * componentSigma);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 20 and consumer double 118.
+											{
+												// Guard to check that at most one copy of the code is executed for a given random
+												// variable instance.
+												boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					
+					// Processing conditional point135.
+					{
+						// Looking for a path between Sample 101 and consumer double 127.
+						{
+							{
+								for(int n = 0; n < N; n += 1) {
+									if((var96 == n)) {
+										{
+											{
+												{
+													if(component[n]) {
+														double traceTempVariable$componentSigma$58_1 = sigma[0];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentMu;
+																							if(component[n])
+																								componentMu = mu[0];
+																							else
+																								componentMu = mu[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 83 and consumer double 127.
+											{
+												{
+													for(int var78 = 0; var78 < 2; var78 += 1) {
+														if(component[n]) {
+															if((var78 == 0)) {
+																if(component[n]) {
+																	// Processing sample task 83 of consumer random variable null.
+																	{
+																		{
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							// Constructing a random variable input for use later.
+																							double var63 = (2.0 * 2.0);
+																							
+																							// Record the probability of sample task 83 generating output with current configuration.
+																							if(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 83 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													if(!component[n]) {
+														double traceTempVariable$componentSigma$63_1 = sigma[1];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentMu;
+																							if(component[n])
+																								componentMu = mu[0];
+																							else
+																								componentMu = mu[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 83 and consumer double 127.
+											{
+												{
+													for(int var78 = 0; var78 < 2; var78 += 1) {
+														if(!component[n]) {
+															if((var78 == 1)) {
+																if(!component[n]) {
+																	// Processing sample task 83 of consumer random variable null.
+																	{
+																		{
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							// Constructing a random variable input for use later.
+																							double var63 = (2.0 * 2.0);
+																							
+																							// Record the probability of sample task 83 generating output with current configuration.
+																							if(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 83 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					
+					// Add the values for the source and any standard consumers for this configuration
+					// of arguments to the source.
+					if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+						cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+					else {
+						// If the second value is -infinity.
+						if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+							cv$stateProbabilityValue = cv$accumulatedProbabilities;
+						else
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+					}
+				}
+				
+				// Save the calculated index value into the array of index value probabilities
+				cv$stateProbabilityLocal[cv$valuePos] = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+			}
+			if(constrainedFlag$sample101[((var96 - 0) / 1)]) {
+				// The sum of all the probabilities in log space
+				double cv$logSum = 0.0;
+				
+				// Sum all the values
+				{
+					// Initialize the max to the first element.
+					double cv$lseMax = cv$stateProbabilityLocal[0];
+					
+					// Find max value.
+					for(int cv$lseIndex = 1; cv$lseIndex < cv$numStates; cv$lseIndex += 1) {
+						double cv$lseElementValue = cv$stateProbabilityLocal[cv$lseIndex];
+						if((cv$lseMax < cv$lseElementValue))
+							cv$lseMax = cv$lseElementValue;
+					}
+					
+					// If the maximum value is -infinity return -infinity.
+					if((cv$lseMax == Double.NEGATIVE_INFINITY))
+						cv$logSum = Double.NEGATIVE_INFINITY;
+					
+					// Sum the values in the array.
+					else {
+						// Initialize the sum of the array elements
+						double cv$lseSum = 0.0;
+						
+						// Offset values, move to normal space, and sum.
+						for(int cv$lseIndex = 0; cv$lseIndex < cv$numStates; cv$lseIndex += 1)
+							cv$lseSum = (cv$lseSum + Math.exp((cv$stateProbabilityLocal[cv$lseIndex] - cv$lseMax)));
+						
+						// Increment the value of the target, moving the value back into log space.
+						cv$logSum = (cv$logSum + (Math.log(cv$lseSum) + cv$lseMax));
+					}
+				}
+				
+				// If all the sum is zero, just share the probability evenly.
+				if((cv$logSum == Double.NEGATIVE_INFINITY)) {
+					// Normalize log space values and move to normal space
+					for(int cv$indexName = 0; cv$indexName < cv$numStates; cv$indexName += 1)
+						cv$stateProbabilityLocal[cv$indexName] = (1.0 / cv$numStates);
+				} else {
+					// Normalize log space values and move to normal space
+					for(int cv$indexName = 0; cv$indexName < cv$numStates; cv$indexName += 1)
+						cv$stateProbabilityLocal[cv$indexName] = Math.exp((cv$stateProbabilityLocal[cv$indexName] - cv$logSum));
+				}
+				
+				// Set array values that are not computed for the input to negative infinity.
+				for(int cv$indexName = cv$numStates; cv$indexName < cv$stateProbabilityLocal.length; cv$indexName += 1)
+					cv$stateProbabilityLocal[cv$indexName] = Double.NEGATIVE_INFINITY;
+				
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				boolean var97 = (DistributionSampling.sampleCategorical(RNG$, cv$stateProbabilityLocal, cv$numStates) == 1);
+				
+				// Guards to ensure that component is only updated when there is a valid path.
+				{
+					{
+						{
+							component[var96] = var97;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 20 drawn from Gaussian 7. Inference was performed using Metropolis-Hastings.
+	private final void inferSample20(int var19, int threadID$cv$var19, Rng RNG$) {
+		if(true) {
+			constrainedFlag$sample20[((var19 - 0) / 1)] = false;
+			
+			// Calculate the number of states to evaluate.
+			int cv$numStates = 0;
+			{
+				// Metropolis-Hastings
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			
+			// The original value of the sample
+			double cv$originalValue = rawMu[var19];
+			
+			// The probability of the random variable generating the originally sampled value
+			double cv$originalProbability = 0.0;
+			
+			// Calculate a proposed variance.
+			double cv$var = ((cv$originalValue * cv$originalValue) * (0.1 * 0.1));
+			
+			// Ensure the variance is at least 0.01
+			if((cv$var < (0.1 * 0.1)))
+				cv$var = (0.1 * 0.1);
+			
+			// The proposed new value for the sample
+			double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+			
+			// The probability of the random variable generating the new sample value.
+			double cv$proposedProbability = 0.0;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				if((constrainedFlag$sample20[((var19 - 0) / 1)] || (cv$valuePos == 0))) {
+					// Initialize the summed probabilities to 0.
+					double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+					
+					// Initialize a counter to track the reached distributions.
+					double cv$reachedDistributionSourceRV = 0.0;
+					
+					// Initialize a log space accumulator to take the product of all the distribution
+					// probabilities.
+					double cv$accumulatedDistributionProbabilities = 0.0;
+					
+					// The value currently being tested
+					double cv$currentValue;
+					if((cv$valuePos == 0))
+						// Set the current value to the current state of the tree.
+						cv$currentValue = cv$originalValue;
+					else {
+						cv$currentValue = cv$proposedValue;
+						
+						// Update Sample and intermediate values
+						// 
+						// Write out the value of the sample to a temporary variable prior to updating the
+						// intermediate variables.
+						double var20 = cv$proposedValue;
+						
+						// Guards to ensure that rawMu is only updated when there is a valid path.
+						{
+							{
+								{
+									rawMu[var19] = cv$currentValue;
+								}
+							}
+						}
+						
+						// Guards to ensure that mu is only updated when there is a valid path.
+						// 
+						// Looking for a path between Sample 20 and consumer double[] 41.
+						{
+							// Guard to check that at most one copy of the code is executed for a given set of
+							// loop iterations.
+							boolean guard$sample20put43 = false;
+							{
+								if((var19 == 0)) {
+									if(!guard$sample20put43) {
+										// The body will execute, so should not be executed again
+										guard$sample20put43 = true;
+										{
+											double var39;
+											if((rawMu[0] < rawMu[1]))
+												var39 = rawMu[0];
+											else
+												var39 = rawMu[1];
+											mu[0] = var39;
+										}
+									}
+								}
+							}
+							{
+								if((var19 == 1)) {
+									if(!guard$sample20put43) {
+										// The body will execute, so should not be executed again
+										guard$sample20put43 = true;
+										{
+											double var39;
+											if((rawMu[0] < rawMu[1]))
+												var39 = rawMu[0];
+											else
+												var39 = rawMu[1];
+											mu[0] = var39;
+										}
+									}
+								}
+							}
+							{
+								if((rawMu[0] < rawMu[1])) {
+									if((var19 == 0)) {
+										if((rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put43) {
+												// The body will execute, so should not be executed again
+												guard$sample20put43 = true;
+												{
+													double var39;
+													if((rawMu[0] < rawMu[1]))
+														var39 = rawMu[0];
+													else
+														var39 = rawMu[1];
+													mu[0] = var39;
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								if(!(rawMu[0] < rawMu[1])) {
+									if((var19 == 1)) {
+										if(!(rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put43) {
+												// The body will execute, so should not be executed again
+												guard$sample20put43 = true;
+												{
+													double var39;
+													if((rawMu[0] < rawMu[1]))
+														var39 = rawMu[0];
+													else
+														var39 = rawMu[1];
+													mu[0] = var39;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Guards to ensure that mu is only updated when there is a valid path.
+						// 
+						// Looking for a path between Sample 20 and consumer double[] 59.
+						{
+							// Guard to check that at most one copy of the code is executed for a given set of
+							// loop iterations.
+							boolean guard$sample20put63 = false;
+							{
+								if((var19 == 0)) {
+									if(!guard$sample20put63) {
+										// The body will execute, so should not be executed again
+										guard$sample20put63 = true;
+										{
+											double var57;
+											if((rawMu[0] < rawMu[1]))
+												var57 = rawMu[1];
+											else
+												var57 = rawMu[0];
+											mu[1] = var57;
+										}
+									}
+								}
+							}
+							{
+								if((var19 == 1)) {
+									if(!guard$sample20put63) {
+										// The body will execute, so should not be executed again
+										guard$sample20put63 = true;
+										{
+											double var57;
+											if((rawMu[0] < rawMu[1]))
+												var57 = rawMu[1];
+											else
+												var57 = rawMu[0];
+											mu[1] = var57;
+										}
+									}
+								}
+							}
+							{
+								if((rawMu[0] < rawMu[1])) {
+									if((var19 == 1)) {
+										if((rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put63) {
+												// The body will execute, so should not be executed again
+												guard$sample20put63 = true;
+												{
+													double var57;
+													if((rawMu[0] < rawMu[1]))
+														var57 = rawMu[1];
+													else
+														var57 = rawMu[0];
+													mu[1] = var57;
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								if(!(rawMu[0] < rawMu[1])) {
+									if((var19 == 0)) {
+										if(!(rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put63) {
+												// The body will execute, so should not be executed again
+												guard$sample20put63 = true;
+												{
+													double var57;
+													if((rawMu[0] < rawMu[1]))
+														var57 = rawMu[1];
+													else
+														var57 = rawMu[0];
+													mu[1] = var57;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					{
+						// Record the reached probability density.
+						cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+						
+						// Constructing a random variable input for use later.
+						double var6 = (2.0 * 2.0);
+						
+						// An accumulator to allow the value for each distribution to be constructed before
+						// it is added to the index probabilities.
+						double cv$accumulatedProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((cv$currentValue - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+						
+						// Processing random variable 129.
+						{
+							// Looking for a path between Sample 20 and consumer Gaussian 129.
+							{
+								{
+									double traceTempVariable$var36$10_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$10_2 = traceTempVariable$var36$10_1;
+												double traceTempVariable$var115$10_3 = traceTempVariable$var39$10_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((0 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$10_5 = traceTempVariable$var115$10_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var36$11_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$11_2 = traceTempVariable$var36$11_1;
+												double traceTempVariable$var117$11_3 = traceTempVariable$var39$11_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((0 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$11_5 = traceTempVariable$var117$11_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var38$12_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$12_2 = traceTempVariable$var38$12_1;
+												double traceTempVariable$var115$12_3 = traceTempVariable$var39$12_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((0 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$12_5 = traceTempVariable$var115$12_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var38$13_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$13_2 = traceTempVariable$var38$13_1;
+												double traceTempVariable$var117$13_3 = traceTempVariable$var39$13_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((0 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$13_5 = traceTempVariable$var117$13_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var54$14_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$14_2 = traceTempVariable$var54$14_1;
+												double traceTempVariable$var115$14_3 = traceTempVariable$var57$14_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((1 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$14_5 = traceTempVariable$var115$14_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var54$15_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$15_2 = traceTempVariable$var54$15_1;
+												double traceTempVariable$var117$15_3 = traceTempVariable$var57$15_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((1 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$15_5 = traceTempVariable$var117$15_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var56$16_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$16_2 = traceTempVariable$var56$16_1;
+												double traceTempVariable$var115$16_3 = traceTempVariable$var57$16_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((1 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$16_5 = traceTempVariable$var115$16_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var56$17_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$17_2 = traceTempVariable$var56$17_1;
+												double traceTempVariable$var117$17_3 = traceTempVariable$var57$17_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((1 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$17_5 = traceTempVariable$var117$17_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Processing conditional point41.
+						{
+							// Looking for a path between Sample 20 and consumer double 39.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20if41 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20if41) {
+											// The body will execute, so should not be executed again
+											guard$sample20if41 = true;
+											{
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$36_1 = rawMu[0];
+															double traceTempVariable$var115$36_2 = traceTempVariable$var39$36_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$36_4 = traceTempVariable$var115$36_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$38_1 = rawMu[0];
+															double traceTempVariable$var117$38_2 = traceTempVariable$var39$38_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$38_4 = traceTempVariable$var117$38_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$48_1 = 0; index$var19$48_1 < 2; index$var19$48_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$48_1 == 0)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$52_1 = rawMu[1];
+															double traceTempVariable$var115$52_2 = traceTempVariable$var39$52_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$52_4 = traceTempVariable$var115$52_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$54_1 = rawMu[1];
+															double traceTempVariable$var117$54_2 = traceTempVariable$var39$54_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$54_4 = traceTempVariable$var117$54_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$64_1 = 0; index$var19$64_1 < 2; index$var19$64_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$64_1 == 1)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20if41) {
+											// The body will execute, so should not be executed again
+											guard$sample20if41 = true;
+											{
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$37_1 = rawMu[0];
+															double traceTempVariable$var115$37_2 = traceTempVariable$var39$37_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$37_4 = traceTempVariable$var115$37_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$39_1 = rawMu[0];
+															double traceTempVariable$var117$39_2 = traceTempVariable$var39$39_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$39_4 = traceTempVariable$var117$39_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$49_1 = 0; index$var19$49_1 < 2; index$var19$49_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$49_1 == 0)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$53_1 = rawMu[1];
+															double traceTempVariable$var115$53_2 = traceTempVariable$var39$53_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$53_4 = traceTempVariable$var115$53_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$55_1 = rawMu[1];
+															double traceTempVariable$var117$55_2 = traceTempVariable$var39$55_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$55_4 = traceTempVariable$var117$55_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$65_1 = 0; index$var19$65_1 < 2; index$var19$65_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$65_1 == 1)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Processing conditional point61.
+						{
+							// Looking for a path between Sample 20 and consumer double 57.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20if61 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20if61) {
+											// The body will execute, so should not be executed again
+											guard$sample20if61 = true;
+											{
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$70_1 = rawMu[1];
+															double traceTempVariable$var115$70_2 = traceTempVariable$var57$70_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$70_4 = traceTempVariable$var115$70_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$72_1 = rawMu[1];
+															double traceTempVariable$var117$72_2 = traceTempVariable$var57$72_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$72_4 = traceTempVariable$var117$72_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$82_1 = 0; index$var19$82_1 < 2; index$var19$82_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$82_1 == 1)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$86_1 = rawMu[0];
+															double traceTempVariable$var115$86_2 = traceTempVariable$var57$86_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$86_4 = traceTempVariable$var115$86_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$88_1 = rawMu[0];
+															double traceTempVariable$var117$88_2 = traceTempVariable$var57$88_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$88_4 = traceTempVariable$var117$88_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$98_1 = 0; index$var19$98_1 < 2; index$var19$98_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$98_1 == 0)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20if61) {
+											// The body will execute, so should not be executed again
+											guard$sample20if61 = true;
+											{
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$71_1 = rawMu[1];
+															double traceTempVariable$var115$71_2 = traceTempVariable$var57$71_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$71_4 = traceTempVariable$var115$71_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$73_1 = rawMu[1];
+															double traceTempVariable$var117$73_2 = traceTempVariable$var57$73_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$73_4 = traceTempVariable$var117$73_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$83_1 = 0; index$var19$83_1 < 2; index$var19$83_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$83_1 == 1)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$87_1 = rawMu[0];
+															double traceTempVariable$var115$87_2 = traceTempVariable$var57$87_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$87_4 = traceTempVariable$var115$87_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$89_1 = rawMu[0];
+															double traceTempVariable$var117$89_2 = traceTempVariable$var57$89_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$89_4 = traceTempVariable$var117$89_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$99_1 = 0; index$var19$99_1 < 2; index$var19$99_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$99_1 == 0)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Add the values for the source and any standard consumers for this configuration
+						// of arguments to the source.
+						if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+						else {
+							// If the second value is -infinity.
+							if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+								cv$stateProbabilityValue = cv$accumulatedProbabilities;
+							else
+								cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// Save the probability of the original value.
+					if((cv$valuePos == 0))
+						cv$originalProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// Save the probability of the proposed value.
+					else
+						cv$proposedProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// The probability ration for the proposed value and the current value.
+					double cv$ratio = (cv$proposedProbability - cv$originalProbability);
+					
+					// Test if the probability of the sample is sufficient to keep the value. This needs
+					// to be less than or equal as otherwise if the proposed value is not possible and
+					// the random value is 0 an impossible value will be accepted.
+					if((cv$valuePos == 1)) {
+						if(((cv$ratio <= Math.log((0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$))))) || Double.isNaN(cv$ratio))) {
+							// If it is not revert the changes.
+							// 
+							// Set the sample value
+							// Write out the value of the sample to a temporary variable prior to updating the
+							// intermediate variables.
+							double var20 = cv$originalValue;
+							
+							// Guards to ensure that rawMu is only updated when there is a valid path.
+							{
+								{
+									{
+										rawMu[var19] = var20;
+									}
+								}
+							}
+							
+							// Guards to ensure that mu is only updated when there is a valid path.
+							// 
+							// Looking for a path between Sample 20 and consumer double[] 41.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20put43 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20put43) {
+											// The body will execute, so should not be executed again
+											guard$sample20put43 = true;
+											{
+												double var39;
+												if((rawMu[0] < rawMu[1]))
+													var39 = rawMu[0];
+												else
+													var39 = rawMu[1];
+												mu[0] = var39;
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20put43) {
+											// The body will execute, so should not be executed again
+											guard$sample20put43 = true;
+											{
+												double var39;
+												if((rawMu[0] < rawMu[1]))
+													var39 = rawMu[0];
+												else
+													var39 = rawMu[1];
+												mu[0] = var39;
+											}
+										}
+									}
+								}
+								{
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put43) {
+													// The body will execute, so should not be executed again
+													guard$sample20put43 = true;
+													{
+														double var39;
+														if((rawMu[0] < rawMu[1]))
+															var39 = rawMu[0];
+														else
+															var39 = rawMu[1];
+														mu[0] = var39;
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put43) {
+													// The body will execute, so should not be executed again
+													guard$sample20put43 = true;
+													{
+														double var39;
+														if((rawMu[0] < rawMu[1]))
+															var39 = rawMu[0];
+														else
+															var39 = rawMu[1];
+														mu[0] = var39;
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+							
+							// Guards to ensure that mu is only updated when there is a valid path.
+							// 
+							// Looking for a path between Sample 20 and consumer double[] 59.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20put63 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20put63) {
+											// The body will execute, so should not be executed again
+											guard$sample20put63 = true;
+											{
+												double var57;
+												if((rawMu[0] < rawMu[1]))
+													var57 = rawMu[1];
+												else
+													var57 = rawMu[0];
+												mu[1] = var57;
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20put63) {
+											// The body will execute, so should not be executed again
+											guard$sample20put63 = true;
+											{
+												double var57;
+												if((rawMu[0] < rawMu[1]))
+													var57 = rawMu[1];
+												else
+													var57 = rawMu[0];
+												mu[1] = var57;
+											}
+										}
+									}
+								}
+								{
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put63) {
+													// The body will execute, so should not be executed again
+													guard$sample20put63 = true;
+													{
+														double var57;
+														if((rawMu[0] < rawMu[1]))
+															var57 = rawMu[1];
+														else
+															var57 = rawMu[0];
+														mu[1] = var57;
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put63) {
+													// The body will execute, so should not be executed again
+													guard$sample20put63 = true;
+													{
+														double var57;
+														if((rawMu[0] < rawMu[1]))
+															var57 = rawMu[1];
+														else
+															var57 = rawMu[0];
+														mu[1] = var57;
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 83 drawn from TruncatedGaussian 66. Inference was performed using
+	// Metropolis-Hastings.
+	private final void inferSample83(int var78) {
+		if(true) {
+			constrainedFlag$sample83[((var78 - 0) / 1)] = false;
+			
+			// Calculate the number of states to evaluate.
+			int cv$numStates = 0;
+			{
+				// Metropolis-Hastings
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			
+			// The original value of the sample
+			double cv$originalValue = sigma[var78];
+			
+			// The probability of the random variable generating the originally sampled value
+			double cv$originalProbability = 0.0;
+			
+			// Calculate a proposed variance.
+			double cv$var = ((cv$originalValue * cv$originalValue) * (0.1 * 0.1));
+			
+			// Ensure the variance is at least 0.01
+			if((cv$var < (0.1 * 0.1)))
+				cv$var = (0.1 * 0.1);
+			
+			// The proposed new value for the sample
+			double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+			
+			// The probability of the random variable generating the new sample value.
+			double cv$proposedProbability = 0.0;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				if((constrainedFlag$sample83[((var78 - 0) / 1)] || (cv$valuePos == 0))) {
+					// Initialize the summed probabilities to 0.
+					double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+					
+					// Initialize a counter to track the reached distributions.
+					double cv$reachedDistributionSourceRV = 0.0;
+					
+					// Initialize a log space accumulator to take the product of all the distribution
+					// probabilities.
+					double cv$accumulatedDistributionProbabilities = 0.0;
+					
+					// The value currently being tested
+					double cv$currentValue;
+					if((cv$valuePos == 0))
+						// Set the current value to the current state of the tree.
+						cv$currentValue = cv$originalValue;
+					else {
+						cv$currentValue = cv$proposedValue;
+						
+						// Update Sample and intermediate values
+						// 
+						// Write out the value of the sample to a temporary variable prior to updating the
+						// intermediate variables.
+						double var79 = cv$proposedValue;
+						
+						// Guards to ensure that sigma is only updated when there is a valid path.
+						{
+							{
+								{
+									sigma[var78] = cv$currentValue;
+								}
+							}
+						}
+					}
+					{
+						// Record the reached probability density.
+						cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+						
+						// Constructing a random variable input for use later.
+						double var63 = (2.0 * 2.0);
+						
+						// An accumulator to allow the value for each distribution to be constructed before
+						// it is added to the index probabilities.
+						double cv$accumulatedProbabilities = (Math.log(1.0) + (((((0.0 <= cv$currentValue) && (cv$currentValue <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((cv$currentValue - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+						
+						// Processing random variable 129.
+						{
+							// Looking for a path between Sample 83 and consumer Gaussian 129.
+							{
+								{
+									double traceTempVariable$var124$2_1 = cv$currentValue;
+									for(int n = 0; n < N; n += 1) {
+										if(component[n]) {
+											if((var78 == 0)) {
+												if(component[n]) {
+													double traceTempVariable$componentSigma$2_3 = traceTempVariable$var124$2_1;
+													
+													// Processing sample task 138 of consumer random variable null.
+													{
+														{
+															// Flag recording if this sample task of the consuming random variable is constrained.
+															boolean cv$sampleConstrained = true;
+															if(cv$sampleConstrained) {
+																// Mark that the sample has observed constrained data.
+																constrainedFlag$sample83[((var78 - 0) / 1)] = true;
+																
+																// Set an accumulator to sum the probabilities for each possible configuration of
+																// inputs.
+																double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																
+																// Set an accumulator to record the consumer distributions not seen. Initially set
+																// to 1 as seen values will be deducted from this value.
+																double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																{
+																	{
+																		{
+																			{
+																				{
+																					double componentMu;
+																					if(component[n])
+																						componentMu = mu[0];
+																					else
+																						componentMu = mu[1];
+																					
+																					// Constructing a random variable input for use later.
+																					double var128 = (traceTempVariable$componentSigma$2_3 * traceTempVariable$componentSigma$2_3);
+																					
+																					// Record the probability of sample task 138 generating output with current configuration.
+																					if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																						else
+																							cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																					}
+																					
+																					// Recorded the probability of reaching sample task 138 with the current configuration.
+																					cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																				}
+																			}
+																		}
+																	}
+																}
+																
+																// A check to ensure rounding of floating point values can never result in a negative
+																// value.
+																cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																
+																// Multiply (log space add) in the probability of the sample task to the overall probability
+																// for this configuration of the source random variable.
+																if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																	cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																else {
+																	// If the second value is -infinity.
+																	if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																		cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																	else
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var126$3_1 = cv$currentValue;
+									for(int n = 0; n < N; n += 1) {
+										if(!component[n]) {
+											if((var78 == 1)) {
+												if(!component[n]) {
+													double traceTempVariable$componentSigma$3_3 = traceTempVariable$var126$3_1;
+													
+													// Processing sample task 138 of consumer random variable null.
+													{
+														{
+															// Flag recording if this sample task of the consuming random variable is constrained.
+															boolean cv$sampleConstrained = true;
+															if(cv$sampleConstrained) {
+																// Mark that the sample has observed constrained data.
+																constrainedFlag$sample83[((var78 - 0) / 1)] = true;
+																
+																// Set an accumulator to sum the probabilities for each possible configuration of
+																// inputs.
+																double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																
+																// Set an accumulator to record the consumer distributions not seen. Initially set
+																// to 1 as seen values will be deducted from this value.
+																double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																{
+																	{
+																		{
+																			{
+																				{
+																					double componentMu;
+																					if(component[n])
+																						componentMu = mu[0];
+																					else
+																						componentMu = mu[1];
+																					
+																					// Constructing a random variable input for use later.
+																					double var128 = (traceTempVariable$componentSigma$3_3 * traceTempVariable$componentSigma$3_3);
+																					
+																					// Record the probability of sample task 138 generating output with current configuration.
+																					if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																						else
+																							cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																					}
+																					
+																					// Recorded the probability of reaching sample task 138 with the current configuration.
+																					cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																				}
+																			}
+																		}
+																	}
+																}
+																
+																// A check to ensure rounding of floating point values can never result in a negative
+																// value.
+																cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																
+																// Multiply (log space add) in the probability of the sample task to the overall probability
+																// for this configuration of the source random variable.
+																if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																	cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																else {
+																	// If the second value is -infinity.
+																	if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																		cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																	else
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Add the values for the source and any standard consumers for this configuration
+						// of arguments to the source.
+						if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+						else {
+							// If the second value is -infinity.
+							if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+								cv$stateProbabilityValue = cv$accumulatedProbabilities;
+							else
+								cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// Save the probability of the original value.
+					if((cv$valuePos == 0))
+						cv$originalProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// Save the probability of the proposed value.
+					else
+						cv$proposedProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// The probability ration for the proposed value and the current value.
+					double cv$ratio = (cv$proposedProbability - cv$originalProbability);
+					
+					// Test if the probability of the sample is sufficient to keep the value. This needs
+					// to be less than or equal as otherwise if the proposed value is not possible and
+					// the random value is 0 an impossible value will be accepted.
+					if((cv$valuePos == 1)) {
+						if(((cv$ratio <= Math.log((0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$))))) || Double.isNaN(cv$ratio))) {
+							// If it is not revert the changes.
+							// 
+							// Set the sample value
+							// Write out the value of the sample to a temporary variable prior to updating the
+							// intermediate variables.
+							double var79 = cv$originalValue;
+							
+							// Guards to ensure that sigma is only updated when there is a valid path.
+							{
+								{
+									{
+										sigma[var78] = var79;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 88 drawn from Beta 83. Inference was performed using a Beta to Bernoulli/Binomial
+	// conjugate prior.
+	private final void inferSample88() {
+		if(true) {
+			constrainedFlag$sample88 = false;
+			
+			// Local variable to record the number of true samples.
+			int cv$sum = 0;
+			
+			// Local variable to record the number of samples.
+			int cv$count = 0;
+			{
+				// Processing random variable 85.
+				{
+					{
+						{
+							// Processing sample task 101 of consumer random variable componentDistribution.
+							{
+								{
+									for(int var96 = 0; var96 < N; var96 += 1) {
+										// Flag recording if this sample task of the consuming random variable is constrained.
+										boolean cv$sampleConstrained = (fixedFlag$sample101 || constrainedFlag$sample101[((var96 - 0) / 1)]);
+										if(cv$sampleConstrained) {
+											// Mark that the sample has observed constrained data.
+											constrainedFlag$sample88 = true;
+											{
+												{
+													{
+														{
+															{
+																// Include the value sampled by task 101 from random variable componentDistribution.
+																// Increment the number of samples.
+																cv$count = (cv$count + 1);
+																
+																// If the sample value was positive increase the count
+																if(component[var96])
+																	cv$sum = (cv$sum + 1);
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			if(constrainedFlag$sample88)
+				// Write out the new value of the sample.
+				theta = Conjugates.sampleConjugateBetaBinomial(RNG$, 5.0, 5.0, cv$sum, cv$count);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample101 using sampled
+	// values.
+	private final void logProbabilityValue$sample101() {
+		// Determine if we need to calculate the values for sample task 101 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample101) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						boolean cv$sampleValue = component[var96];
+						{
+							{
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= theta) && (theta <= 1.0))?Math.log((cv$sampleValue?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			if(cv$sampleReached)
+				logProbability$componentDistribution = cv$sampleAccumulator;
+			
+			// Only update the sample if it was reached, otherwise the NaN will be
+			// erroneously over written.
+			if(cv$sampleReached)
+				// Store the random variable instance probability
+				logProbability$var97 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			logProbability$component = (logProbability$component + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedFlag$sample88);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1)
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var97;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			if(cv$sampleReached)
+				logProbability$componentDistribution = cv$rvAccumulator;
+			
+			// Update the variable probability
+			logProbability$component = (logProbability$component + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample138 using sampled
+	// values.
+	private final void logProbabilityValue$sample138() {
+		// Determine if we need to calculate the values for sample task 138 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample138) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						double cv$sampleValue = y[n];
+						{
+							{
+								double componentMu;
+								if(component[n])
+									componentMu = mu[0];
+								else
+									componentMu = mu[1];
+								double componentSigma;
+								if(component[n])
+									componentSigma = sigma[0];
+								else
+									componentSigma = sigma[1];
+								double var128 = (componentSigma * componentSigma);
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Only update the sample if it was reached, otherwise the NaN will be
+			// erroneously over written.
+			if(cv$sampleReached)
+				// Store the random variable instance probability
+				logProbability$var130 = cv$accumulator;
+			
+			// Update the variable probability
+			logProbability$y = (logProbability$y + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample138 = ((fixedFlag$sample20 && fixedFlag$sample83) && fixedFlag$sample101);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1)
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var130;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Update the variable probability
+			logProbability$y = (logProbability$y + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample20 using sampled
+	// values.
+	private final void logProbabilityValue$sample20() {
+		// Determine if we need to calculate the values for sample task 20 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample20) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						double cv$sampleValue = rawMu[var19];
+						{
+							{
+								double var3 = 0.0;
+								double var6 = (2.0 * 2.0);
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var3) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+								
+								// Looking for a path between Put 21 and consumer double 39.
+								{
+									// Guard to check that at most one copy of the code is executed for a given set of
+									// loop iterations.
+									boolean guard$put21if41 = false;
+									{
+										if((var19 == 0)) {
+											if(!guard$put21if41)
+												// The body will execute, so should not be executed again
+												guard$put21if41 = true;
+										}
+									}
+									{
+										if((var19 == 1)) {
+											if(!guard$put21if41)
+												// The body will execute, so should not be executed again
+												guard$put21if41 = true;
+										}
+									}
+								}
+								
+								// Looking for a path between Put 21 and consumer double 57.
+								{
+									// Guard to check that at most one copy of the code is executed for a given set of
+									// loop iterations.
+									boolean guard$put21if61 = false;
+									{
+										if((var19 == 0)) {
+											if(!guard$put21if61)
+												// The body will execute, so should not be executed again
+												guard$put21if61 = true;
+										}
+									}
+									{
+										if((var19 == 1)) {
+											if(!guard$put21if61)
+												// The body will execute, so should not be executed again
+												guard$put21if61 = true;
+										}
+									}
+								}
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				
+				// Only update the sample if it was reached, otherwise the NaN will be
+				// erroneously over written.
+				if(cv$sampleReached)
+					// Store the sample task probability
+					logProbability$sample20[((var19 - 0) / 1)] = cv$sampleProbability;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Update the variable probability
+			logProbability$rawMu = (logProbability$rawMu + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample20 = fixedFlag$sample20;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				double cv$sampleValue = logProbability$sample20[((var19 - 0) / 1)];
+				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Update the variable probability
+			logProbability$rawMu = (logProbability$rawMu + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample83 using sampled
+	// values.
+	private final void logProbabilityValue$sample83() {
+		// Determine if we need to calculate the values for sample task 83 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample83) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var78 = 0; var78 < 2; var78 += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						double cv$sampleValue = sigma[var78];
+						{
+							{
+								double var60 = 0.0;
+								double var63 = (2.0 * 2.0);
+								double var64 = 0.0;
+								double var65 = 1.0E100;
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + (((((var64 <= cv$sampleValue) && (cv$sampleValue <= var65)) && (var64 < var65)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var60) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((var65 - var60) / Math.sqrt(var63))) - Gaussian.cdf(((var64 - var60) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Only update the sample if it was reached, otherwise the NaN will be
+			// erroneously over written.
+			if(cv$sampleReached)
+				// Store the random variable instance probability
+				logProbability$var79 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			logProbability$sigma = (logProbability$sigma + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample83 = fixedFlag$sample83;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var78 = 0; var78 < 2; var78 += 1)
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var79;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Update the variable probability
+			logProbability$sigma = (logProbability$sigma + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample88 using sampled
+	// values.
+	private final void logProbabilityValue$sample88() {
+		// Determine if we need to calculate the values for sample task 88 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample88) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				{
+					// The sample value to calculate the probability of generating
+					double cv$sampleValue = theta;
+					{
+						{
+							double var81 = 5.0;
+							double var82 = 5.0;
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var81, var82));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						}
+					}
+				}
+			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Store the sample task probability
+			logProbability$theta = cv$sampleProbability;
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample88 = fixedFlag$sample88;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			double cv$sampleValue = logProbability$theta;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Method to allocate space temporary variables used by the inference methods. Allocating
+	// here prevents repeated allocation and deallocation, and makes the code more amenable
+	// to GPU execution.
+	@Override
+	public final void allocateScratch() {
+		// Allocate scratch space.
+		// Constructor for cv$var97$stateProbabilityGlobal
+		{
+			// Allocation of cv$var97$stateProbabilityGlobal for multithreaded execution
+			{
+				// Get the thread count.
+				int cv$threadCount = threadCount();
+				
+				// Allocate an array to hold a copy per thread
+				cv$var97$stateProbabilityGlobal = new double[cv$threadCount][];
+				
+				// Populate the array with a copy per thread
+				for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
+					cv$var97$stateProbabilityGlobal[cv$index] = new double[2];
+			}
+		}
+		
+		// Constructor for guard$sample20if124$global
+		{
+			// Calculate the largest index of var19 that is possible and allocate an array to
+			// hold the guard for each of these.
+			int cv$max_var19 = 0;
+			cv$max_var19 = Math.max(cv$max_var19, ((2 - 0) / 1));
+			
+			// Allocation of guard$sample20if124$global for multithreaded execution
+			{
+				// Get the thread count.
+				int cv$threadCount = threadCount();
+				
+				// Allocate an array to hold a copy per thread
+				guard$sample20if124$global = new boolean[cv$threadCount][];
+				
+				// Populate the array with a copy per thread
+				for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
+					guard$sample20if124$global[cv$index] = new boolean[cv$max_var19];
+			}
+		}
+	}
+
+	// Method to allocate space for model inputs and outputs.
+	@Override
+	public final void allocator() {
+		// If rawMu has not been set already allocate space.
+		if(!fixedFlag$sample20) {
+			// Constructor for rawMu
+			{
+				rawMu = new double[2];
+			}
+		}
+		
+		// Constructor for mu
+		{
+			mu = new double[2];
+		}
+		
+		// If sigma has not been set already allocate space.
+		if(!fixedFlag$sample83) {
+			// Constructor for sigma
+			{
+				sigma = new double[2];
+			}
+		}
+		
+		// If component has not been set already allocate space.
+		if(!fixedFlag$sample101) {
+			// Constructor for component
+			{
+				component = new boolean[length$yObserved];
+			}
+		}
+		
+		// Constructor for y
+		{
+			y = new double[length$yObserved];
+		}
+		
+		// Constructor for constrainedFlag$sample101
+		{
+			constrainedFlag$sample101 = new boolean[((((length$yObserved - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for constrainedFlag$sample20
+		{
+			constrainedFlag$sample20 = new boolean[((((2 - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for constrainedFlag$sample83
+		{
+			constrainedFlag$sample83 = new boolean[((((2 - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for logProbability$sample20
+		{
+			logProbability$sample20 = new double[((((2 - 1) - 0) / 1) + 1)];
+		}
+		
+		// Allocate scratch space
+		allocateScratch();
+	}
+
+	// Method to execute the model code conventionally.
+	@Override
+	public final void forwardGeneration() {
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[0];
+		} else {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[1];
+		}
+		if(!fixedFlag$sample20)
+			mu[0] = var39;
+		double var57 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[1];
+		} else {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[0];
+		}
+		if(!fixedFlag$sample20)
+			mu[1] = var57;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$n, int forEnd$n, int threadID$n, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int n = forStart$n; n < forEnd$n; n += 1) {
+						double componentMu;
+						if(component[n])
+							componentMu = mu[0];
+						else
+							componentMu = mu[1];
+						double componentSigma;
+						if(component[n])
+							componentSigma = sigma[0];
+						else
+							componentSigma = sigma[1];
+						y[n] = ((Math.sqrt((componentSigma * componentSigma)) * DistributionSampling.sampleGaussian(RNG$1)) + componentMu);
+					}
+			}
+		);
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are calculated
+	// and stored.
+	@Override
+	public final void forwardGenerationDistributionsNoOutputsPrime() {
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+	}
+
+	// Method to execute the model code conventionally with priming of fixed intermediate
+	// variables.
+	@Override
+	public final void forwardGenerationPrime() {
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$n, int forEnd$n, int threadID$n, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int n = forStart$n; n < forEnd$n; n += 1) {
+						double componentMu;
+						if(component[n])
+							componentMu = mu[0];
+						else
+							componentMu = mu[1];
+						double componentSigma;
+						if(component[n])
+							componentSigma = sigma[0];
+						else
+							componentSigma = sigma[1];
+						y[n] = ((Math.sqrt((componentSigma * componentSigma)) * DistributionSampling.sampleGaussian(RNG$1)) + componentMu);
+					}
+			}
+		);
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Distributions are collapsed to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputs() {
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[0];
+		} else {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[1];
+		}
+		if(!fixedFlag$sample20)
+			mu[0] = var39;
+		double var57 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[1];
+		} else {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[0];
+		}
+		if(!fixedFlag$sample20)
+			mu[1] = var57;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are collapsed
+	// to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputsPrime() {
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!fixedFlag$sample20)
+							rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$1)) + 0.0);
+					}
+			}
+		);
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1) {
+						if(!fixedFlag$sample83)
+							sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$1, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+					}
+			}
+		);
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!fixedFlag$sample101)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+					}
+			}
+		);
+	}
+
+	// Method to execute one round of Gibbs sampling.
+	@Override
+	public final void gibbsRound() {
+		// Infer the samples in chronological order.
+		if(system$gibbsForward) {
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+							if(!fixedFlag$sample20)
+								inferSample20(var19, threadID$var19, RNG$1);
+						}
+				}
+			);
+			for(int var78 = 0; var78 < 2; var78 += 1) {
+				if(!fixedFlag$sample83)
+					inferSample83(var78);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+							if(!fixedFlag$sample101)
+								inferSample101(var96, threadID$var96, RNG$1);
+						}
+				}
+			);
+		}
+		// Infer the samples in reverse chronological order.
+		else {
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+							if(!fixedFlag$sample101)
+								inferSample101(var96, threadID$var96, RNG$1);
+						}
+				}
+			);
+			if(!fixedFlag$sample88)
+				inferSample88();
+			for(int var78 = (2 - ((((2 - 1) - 0) % 1) + 1)); var78 >= ((0 - 1) + 1); var78 -= 1) {
+				if(!fixedFlag$sample83)
+					inferSample83(var78);
+			}
+			
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+							if(!fixedFlag$sample20)
+								inferSample20(var19, threadID$var19, RNG$1);
+						}
+				}
+			);
+		}
+		
+		// Reverse the direction of execution for the next iteration
+		system$gibbsForward = !system$gibbsForward;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!constrainedFlag$sample20[((var19 - 0) / 1)])
+							drawValueSample20(var19, threadID$var19, RNG$1);
+					}
+			}
+		);
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!constrainedFlag$sample83[((var78 - 0) / 1)])
+				drawValueSample83(var78);
+		}
+		if(!constrainedFlag$sample88)
+			drawValueSample88();
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!constrainedFlag$sample101[((var96 - 0) / 1)])
+							drawValueSample101(var96, threadID$var96, RNG$1);
+					}
+			}
+		);
+	}
+
+	// A method to initialize all the probabilities in the model to 0/Log(1) ready for
+	// the current probabilities to be calculated by calculating the probability of each
+	// sample task, and its effect on the rest of the model.
+	private final void initializeLogProbabilityFields() {
+		// Set the probabilities of the random variable, and the model as a whole to ready
+		// them to be reconstructed by the probability calls for each sample. Sample probabilities
+		// are only reset for samples that are not fixed at a value that has already been
+		// calculated.
+		logProbability$$model = 0.0;
+		logProbability$$evidence = 0.0;
+		logProbability$rawMu = 0.0;
+		logProbability$mu = 0.0;
+		if(!fixedProbFlag$sample20) {
+			for(int var19 = 0; var19 < 2; var19 += 1)
+				logProbability$sample20[((var19 - 0) / 1)] = Double.NaN;
+		}
+		logProbability$sigma = 0.0;
+		if(!fixedProbFlag$sample83)
+			logProbability$var79 = Double.NaN;
+		if(!fixedProbFlag$sample88)
+			logProbability$theta = Double.NaN;
+		logProbability$componentDistribution = Double.NaN;
+		logProbability$component = 0.0;
+		if(!fixedProbFlag$sample101)
+			logProbability$var97 = Double.NaN;
+		logProbability$y = 0.0;
+		if(!fixedProbFlag$sample138)
+			logProbability$var130 = Double.NaN;
+	}
+
+	// Method for initializing the model into a valid state before commencing inference
+	// etc.
+	@Override
+	public final void initializeModel() {
+		N = length$yObserved;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+			constrainedFlag$sample101[index$constrainedFlag$sample101$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+			constrainedFlag$sample20[index$constrainedFlag$sample20$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+			constrainedFlag$sample83[index$constrainedFlag$sample83$1] = true;
+	}
+
+	// Construct the evidence probabilities.
+	@Override
+	public final void logEvidenceProbabilities() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Call each method in turn to generate the new probability values.
+		if(fixedFlag$sample20)
+			logProbabilityValue$sample20();
+		if(fixedFlag$sample83)
+			logProbabilityValue$sample83();
+		if(fixedFlag$sample88)
+			logProbabilityValue$sample88();
+		if(fixedFlag$sample101)
+			logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model uses distributions
+	// when possible.
+	@Override
+	public final void logModelProbabilitiesDist() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model only uses values.
+	@Override
+	public final void logModelProbabilitiesVal() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to propagate observed values back into the model.
+	@Override
+	public final void propagateObservedValues() {
+		// Deep copy between arrays
+		double[] cv$source1 = yObserved;
+		double[] cv$target1 = y;
+		int cv$length1 = cv$target1.length;
+		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1)
+			cv$target1[cv$index1] = cv$source1[cv$index1];
+	}
+
+	// A method to set array values that depend on the output of a sample task, but are
+	// not directly set by the sample task. This method is called to propagate set values
+	// through the model. Any non-fixed sample values may be sampled to random variables
+	// as part of this process.
+	@Override
+	public final void setIntermediates() {
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+	}
+
+	@Override
+	public String modelCode() {
+		return "/*\n"
+		     + " * Sandwood\n"
+		     + " *\n"
+		     + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+		     + " * \n"
+		     + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+		     + " */\n"
+		     + "\n"
+		     + "package org.sandwood.compiler.tests.parser;\n"
+		     + "\n"
+		     + "public model LowDimMix(double[] yObserved) {\n"
+		     + "    int N = yObserved.length;\n"
+		     + "\n"
+		     + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+		     + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+		     + "    // the constant normalisation factor for the ordered constraint.\n"
+		     + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+		     + "    double[] mu = new double[2];\n"
+		     + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+		     + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+		     + "\n"
+		     + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+		     + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+		     + "\n"
+		     + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+		     + "    double theta = beta(5.0, 5.0).sample();\n"
+		     + "\n"
+		     + "    // Stan likelihood:\n"
+		     + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+		     + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+		     + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+		     + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+		     + "    boolean[] component = componentDistribution.sample(N);\n"
+		     + "    double[] y = new double[N];\n"
+		     + "\n"
+		     + "    for(int n = 0; n < N; n++) {\n"
+		     + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+		     + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+		     + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+		     + "    }\n"
+		     + "\n"
+		     + "    y.observe(yObserved);\n"
+		     + "}\n"
+		     + "";
+	}
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$MultiThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$MultiThreadCPU_optimisedModel.java
@@ -1,0 +1,4381 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.random.internal.Rng;
+import org.sandwood.runtime.internal.numericTools.Conjugates;
+import org.sandwood.runtime.internal.numericTools.DistributionSampling;
+import org.sandwood.runtime.model.ExecutionTarget;
+
+final class LowDimMix$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements LowDimMix$CoreInterface {
+	
+	// Declare the variables for the model.
+	private int N;
+	private boolean[] component;
+	private boolean[] constrainedFlag$sample101;
+	private boolean[] constrainedFlag$sample20;
+	private boolean[] constrainedFlag$sample83;
+	private boolean constrainedFlag$sample88 = true;
+	private double[][] cv$var97$stateProbabilityGlobal;
+	private boolean fixedFlag$sample101 = false;
+	private boolean fixedFlag$sample20 = false;
+	private boolean fixedFlag$sample83 = false;
+	private boolean fixedFlag$sample88 = false;
+	private boolean fixedProbFlag$sample101 = false;
+	private boolean fixedProbFlag$sample138 = false;
+	private boolean fixedProbFlag$sample20 = false;
+	private boolean fixedProbFlag$sample83 = false;
+	private boolean fixedProbFlag$sample88 = false;
+	private boolean[][] guard$sample20if124$global;
+	private int length$yObserved;
+	private double logProbability$$evidence;
+	private double logProbability$$model;
+	private double logProbability$component;
+	private double logProbability$componentDistribution;
+	private double logProbability$mu;
+	private double logProbability$rawMu;
+	private double[] logProbability$sample138;
+	private double[] logProbability$sample20;
+	private double logProbability$sigma;
+	private double logProbability$theta;
+	private double logProbability$var79;
+	private double logProbability$var97;
+	private double logProbability$y;
+	private double[] mu;
+	private double[] rawMu;
+	private double[] sigma;
+	private boolean system$gibbsForward = true;
+	private double theta;
+	private double[] y;
+	private double[] yObserved;
+
+	public LowDimMix$MultiThreadCPU(ExecutionTarget target) {
+		super(target);
+	}
+
+	// Getter for N.
+	@Override
+	public final int get$N() {
+		return N;
+	}
+
+	// Getter for component.
+	@Override
+	public final boolean[] get$component() {
+		return component;
+	}
+
+	// Setter for component.
+	@Override
+	public final void set$component(boolean[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of component including if probabilities need
+		// to be updated.
+		component = cv$value;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on component.
+		fixedProbFlag$sample101 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on component.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for fixedFlag$sample101.
+	@Override
+	public final boolean get$fixedFlag$sample101() {
+		return fixedFlag$sample101;
+	}
+
+	// Setter for fixedFlag$sample101.
+	@Override
+	public final void set$fixedFlag$sample101(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample101 including if probabilities
+		// need to be updated.
+		fixedFlag$sample101 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+				// Substituted "fixedFlag$sample101" with its value "cv$value".
+				constrainedFlag$sample101[index$constrainedFlag$sample101$1] = cv$value;
+		}
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample101" with its value "cv$value".
+		fixedProbFlag$sample101 = (cv$value && fixedProbFlag$sample101);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample101" with its value "cv$value".
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample20.
+	@Override
+	public final boolean get$fixedFlag$sample20() {
+		return fixedFlag$sample20;
+	}
+
+	// Setter for fixedFlag$sample20.
+	@Override
+	public final void set$fixedFlag$sample20(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample20 including if probabilities
+		// need to be updated.
+		fixedFlag$sample20 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+				// Substituted "fixedFlag$sample20" with its value "cv$value".
+				constrainedFlag$sample20[index$constrainedFlag$sample20$1] = cv$value;
+		}
+		
+		// Should the probability of sample 20 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample20" with its value "cv$value".
+		fixedProbFlag$sample20 = (cv$value && fixedProbFlag$sample20);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample20" with its value "cv$value".
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample83.
+	@Override
+	public final boolean get$fixedFlag$sample83() {
+		return fixedFlag$sample83;
+	}
+
+	// Setter for fixedFlag$sample83.
+	@Override
+	public final void set$fixedFlag$sample83(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample83 including if probabilities
+		// need to be updated.
+		fixedFlag$sample83 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+				// Substituted "fixedFlag$sample83" with its value "cv$value".
+				constrainedFlag$sample83[index$constrainedFlag$sample83$1] = cv$value;
+		}
+		
+		// Should the probability of sample 83 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample83" with its value "cv$value".
+		fixedProbFlag$sample83 = (cv$value && fixedProbFlag$sample83);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample83" with its value "cv$value".
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample88.
+	@Override
+	public final boolean get$fixedFlag$sample88() {
+		return fixedFlag$sample88;
+	}
+
+	// Setter for fixedFlag$sample88.
+	@Override
+	public final void set$fixedFlag$sample88(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample88 including if probabilities
+		// need to be updated.
+		fixedFlag$sample88 = cv$value;
+		
+		// Substituted "fixedFlag$sample88" with its value "cv$value".
+		constrainedFlag$sample88 = (cv$value || constrainedFlag$sample88);
+		
+		// Should the probability of sample 88 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample88" with its value "cv$value".
+		fixedProbFlag$sample88 = (cv$value && fixedProbFlag$sample88);
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample88" with its value "cv$value".
+		fixedProbFlag$sample101 = (cv$value && fixedProbFlag$sample101);
+	}
+
+	// Getter for length$yObserved.
+	@Override
+	public final int get$length$yObserved() {
+		return length$yObserved;
+	}
+
+	// Setter for length$yObserved.
+	@Override
+	public final void set$length$yObserved(int cv$value, boolean allocated$) {
+		length$yObserved = cv$value;
+	}
+
+	// Getter for logProbability$$evidence.
+	@Override
+	public final double get$logProbability$$evidence() {
+		return logProbability$$evidence;
+	}
+
+	// Getter for the probability of logProbability$$model.
+	@Override
+	public final double getCurrentLogProbability() {
+		return logProbability$$model;
+	}
+
+	// Getter for logProbability$component.
+	@Override
+	public final double get$logProbability$component() {
+		return logProbability$component;
+	}
+
+	// Getter for logProbability$componentDistribution.
+	@Override
+	public final double get$logProbability$componentDistribution() {
+		return logProbability$componentDistribution;
+	}
+
+	// Getter for logProbability$mu.
+	@Override
+	public final double get$logProbability$mu() {
+		return logProbability$mu;
+	}
+
+	// Getter for logProbability$rawMu.
+	@Override
+	public final double get$logProbability$rawMu() {
+		return logProbability$rawMu;
+	}
+
+	// Getter for logProbability$sigma.
+	@Override
+	public final double get$logProbability$sigma() {
+		return logProbability$sigma;
+	}
+
+	// Getter for logProbability$theta.
+	@Override
+	public final double get$logProbability$theta() {
+		return logProbability$theta;
+	}
+
+	// Getter for logProbability$y.
+	@Override
+	public final double get$logProbability$y() {
+		return logProbability$y;
+	}
+
+	// Getter for mu.
+	@Override
+	public final double[] get$mu() {
+		return mu;
+	}
+
+	// Getter for rawMu.
+	@Override
+	public final double[] get$rawMu() {
+		return rawMu;
+	}
+
+	// Setter for rawMu.
+	@Override
+	public final void set$rawMu(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of rawMu including if probabilities need to
+		// be updated.
+		rawMu = cv$value;
+		
+		// Unset the fixed probability flag for sample 20 as it depends on rawMu.
+		fixedProbFlag$sample20 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on rawMu.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for sigma.
+	@Override
+	public final double[] get$sigma() {
+		return sigma;
+	}
+
+	// Setter for sigma.
+	@Override
+	public final void set$sigma(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of sigma including if probabilities need to
+		// be updated.
+		sigma = cv$value;
+		
+		// Unset the fixed probability flag for sample 83 as it depends on sigma.
+		fixedProbFlag$sample83 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on sigma.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for theta.
+	@Override
+	public final double get$theta() {
+		return theta;
+	}
+
+	// Setter for theta.
+	@Override
+	public final void set$theta(double cv$value, boolean allocated$) {
+		// Set flags for all the side effects of theta including if probabilities need to
+		// be updated.
+		theta = cv$value;
+		
+		// Unset the fixed probability flag for sample 88 as it depends on theta.
+		fixedProbFlag$sample88 = false;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on theta.
+		fixedProbFlag$sample101 = false;
+	}
+
+	// Getter for y.
+	@Override
+	public final double[] get$y() {
+		return y;
+	}
+
+	// Getter for yObserved.
+	@Override
+	public final double[] get$yObserved() {
+		return yObserved;
+	}
+
+	// Setter for yObserved.
+	@Override
+	public final void set$yObserved(double[] cv$value, boolean allocated$) {
+		yObserved = cv$value;
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample101
+	private final void drawValueSample101(int var96, int threadID$cv$var96, Rng RNG$) {
+		component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample20
+	private final void drawValueSample20(int var19, int threadID$cv$var19, Rng RNG$) {
+		rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 41.
+		// 
+		// Guard to check that at most one copy of the code is executed for a given set of
+		// loop iterations.
+		boolean guard$sample20put43 = false;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((var19 == 0)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put43 = true;
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(((var19 == 1) && !guard$sample20put43)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put43 = true;
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put43 = true;
+			mu[0] = rawMu[0];
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+			mu[0] = rawMu[1];
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 59.
+		// 
+		// Guard to check that at most one copy of the code is executed for a given set of
+		// loop iterations.
+		boolean guard$sample20put63 = false;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((var19 == 0)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put63 = true;
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((var19 == 1)) {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20put63) {
+				// The body will execute, so should not be executed again
+				guard$sample20put63 = true;
+				double var57;
+				if((rawMu[0] < rawMu[1]))
+					var57 = rawMu[1];
+				else
+					var57 = rawMu[0];
+				mu[1] = var57;
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+				// The body will execute, so should not be executed again
+				guard$sample20put63 = true;
+				mu[1] = rawMu[1];
+			}
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+			mu[1] = rawMu[0];
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample83
+	private final void drawValueSample83(int var78) {
+		sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample88
+	private final void drawValueSample88() {
+		theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 101 drawn from componentDistribution. Inference was performed using
+	// variable marginalization.
+	private final void inferSample101(int var96, int threadID$cv$var96, Rng RNG$) {
+		// Get a local reference to the scratch space.
+		double[] cv$stateProbabilityLocal = cv$var97$stateProbabilityGlobal[threadID$cv$var96];
+		{
+			// Guards to ensure that component is only updated when there is a valid path.
+			// 
+			// Variable declaration of cv$currentValue moved.
+			// Declaration comment was:
+			// The value currently being tested
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			component[var96] = false;
+			
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Variable declaration of cv$currentValue moved.
+			// Declaration comment was:
+			// The value currently being tested
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			double cv$accumulatedProbabilities = (((0.0 <= theta) && (theta <= 1.0))?Math.log((1.0 - theta)):Double.NEGATIVE_INFINITY);
+			
+			// Processing conditional point124.
+			// 
+			// Looking for a path between Sample 101 and consumer double 118.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(component[var96]) {
+				{
+					// Variable declaration of componentSigma moved.
+					double componentSigma = sigma[0];
+					
+					// Constructing a random variable input for use later.
+					double var128 = (componentSigma * componentSigma);
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 138 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Substituted "n" with its value "var96".
+					cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				}
+				
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[0] = false;
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1]))
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					guard$sample20if124[0] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					guard$sample20if124[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124[0]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					guard$sample20if124[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124[1]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					guard$sample20if124[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((rawMu[0] < rawMu[1]) && !guard$sample20if124[0])) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					guard$sample20if124[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124[1])) {
+					// The body will execute, so should not be executed again
+					guard$sample20if124[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				double traceTempVariable$componentSigma$58_1 = sigma[0];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				// 
+				// Substituted "componentMu" with its value "mu[0]".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 83 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Looking for a path between Sample 83 and consumer double 127.
+				// 
+				// Unrolled loop
+				// 
+				// Processing sample task 83 of consumer random variable null.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((((0.0 <= sigma[0]) && (sigma[0] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[0] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			else {
+				{
+					// Variable declaration of componentSigma moved.
+					double componentSigma = sigma[1];
+					
+					// Constructing a random variable input for use later.
+					double var128 = (componentSigma * componentSigma);
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 138 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Substituted "n" with its value "var96".
+					cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				}
+				
+				// Looking for a path between Sample 20 and consumer double 118.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[0] = false;
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1]))
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					guard$sample20if124[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					guard$sample20if124[0] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124[0]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					guard$sample20if124[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124[1]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					guard$sample20if124[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((rawMu[0] < rawMu[1]) && !guard$sample20if124[1])) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					guard$sample20if124[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124[0])) {
+					// The body will execute, so should not be executed again
+					guard$sample20if124[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				double traceTempVariable$componentSigma$63_1 = sigma[1];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				// 
+				// Substituted "componentMu" with its value "mu[1]".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 83 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Processing sample task 83 of consumer random variable null.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((((0.0 <= sigma[1]) && (sigma[1] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[1] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Save the calculated index value into the array of index value probabilities
+			// 
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			cv$stateProbabilityLocal[0] = cv$accumulatedProbabilities;
+		}
+		
+		// Guards to ensure that component is only updated when there is a valid path.
+		// 
+		// Variable declaration of cv$currentValue moved.
+		// Declaration comment was:
+		// The value currently being tested
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		component[var96] = true;
+		
+		// An accumulator to allow the value for each distribution to be constructed before
+		// it is added to the index probabilities.
+		// 
+		// Variable declaration of cv$currentValue moved.
+		// Declaration comment was:
+		// The value currently being tested
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		double cv$accumulatedProbabilities = (((0.0 <= theta) && (theta <= 1.0))?Math.log(theta):Double.NEGATIVE_INFINITY);
+		
+		// Processing conditional point124.
+		// 
+		// Looking for a path between Sample 101 and consumer double 118.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(component[var96]) {
+			{
+				// Variable declaration of componentSigma moved.
+				double componentSigma = sigma[0];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (componentSigma * componentSigma);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Guard to check that at most one copy of the code is executed for a given random
+			// variable instance.
+			boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			guard$sample20if124[0] = false;
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			guard$sample20if124[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((rawMu[0] < rawMu[1]))
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[0] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			else
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124[0]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				guard$sample20if124[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124[1]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				guard$sample20if124[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20if124[0])) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				guard$sample20if124[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124[1])) {
+				// The body will execute, so should not be executed again
+				guard$sample20if124[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			double traceTempVariable$componentSigma$58_1 = sigma[0];
+			
+			// Mark that the sample has observed constrained data.
+			constrainedFlag$sample101[var96] = true;
+			
+			// Constructing a random variable input for use later.
+			double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 138 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Substituted "n" with its value "var96".
+			// 
+			// Substituted "componentMu" with its value "mu[0]".
+			cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 83 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Looking for a path between Sample 83 and consumer double 127.
+			// 
+			// Unrolled loop
+			// 
+			// Processing sample task 83 of consumer random variable null.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Constructing a random variable input for use later.
+			cv$accumulatedProbabilities = ((((0.0 <= sigma[0]) && (sigma[0] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[0] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		else {
+			{
+				// Variable declaration of componentSigma moved.
+				double componentSigma = sigma[1];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (componentSigma * componentSigma);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Looking for a path between Sample 20 and consumer double 118.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given random
+			// variable instance.
+			boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			guard$sample20if124[0] = false;
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			guard$sample20if124[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((rawMu[0] < rawMu[1]))
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			else
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[0] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124[0]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				guard$sample20if124[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124[1]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				guard$sample20if124[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20if124[1])) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				guard$sample20if124[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124[0])) {
+				// The body will execute, so should not be executed again
+				guard$sample20if124[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			double traceTempVariable$componentSigma$63_1 = sigma[1];
+			
+			// Mark that the sample has observed constrained data.
+			constrainedFlag$sample101[var96] = true;
+			
+			// Constructing a random variable input for use later.
+			double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 138 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Substituted "n" with its value "var96".
+			// 
+			// Substituted "componentMu" with its value "mu[1]".
+			cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 83 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Processing sample task 83 of consumer random variable null.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Constructing a random variable input for use later.
+			cv$accumulatedProbabilities = ((((0.0 <= sigma[1]) && (sigma[1] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[1] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+		}
+		
+		// Save the calculated index value into the array of index value probabilities
+		// 
+		// Initialize a log space accumulator to take the product of all the distribution
+		// probabilities.
+		// 
+		// Record the reached probability density.
+		// 
+		// Initialize a counter to track the reached distributions.
+		cv$stateProbabilityLocal[1] = cv$accumulatedProbabilities;
+		if(constrainedFlag$sample101[var96]) {
+			// This value is not used before it is set again, so removing the value declaration.
+			// 
+			// The sum of all the probabilities in log space
+			double cv$logSum;
+			
+			// Sum all the values
+			// 
+			// Initialize the max to the first element.
+			double cv$lseMax = cv$stateProbabilityLocal[0];
+			
+			// Unrolled loop
+			double cv$lseElementValue = cv$stateProbabilityLocal[1];
+			if((cv$lseMax < cv$lseElementValue))
+				cv$lseMax = cv$lseElementValue;
+			
+			// If the maximum value is -infinity return -infinity.
+			if((cv$lseMax == Double.NEGATIVE_INFINITY))
+				cv$logSum = Double.NEGATIVE_INFINITY;
+			
+			// Sum the values in the array.
+			else
+				// Increment the value of the target, moving the value back into log space.
+				// 
+				// The sum of all the probabilities in log space
+				// 
+				// Initialize the sum of the array elements
+				cv$logSum = (Math.log((Math.exp((cv$stateProbabilityLocal[0] - cv$lseMax)) + Math.exp((cv$stateProbabilityLocal[1] - cv$lseMax)))) + cv$lseMax);
+			
+			// If all the sum is zero, just share the probability evenly.
+			if((cv$logSum == Double.NEGATIVE_INFINITY)) {
+				// Unrolled loop
+				// cv$numStates's comment
+				// variable marginalization
+				cv$stateProbabilityLocal[0] = 0.5;
+				
+				// cv$numStates's comment
+				// variable marginalization
+				cv$stateProbabilityLocal[1] = 0.5;
+			} else {
+				// Unrolled loop
+				cv$stateProbabilityLocal[0] = Math.exp((cv$stateProbabilityLocal[0] - cv$logSum));
+				cv$stateProbabilityLocal[1] = Math.exp((cv$stateProbabilityLocal[1] - cv$logSum));
+			}
+			
+			// Set array values that are not computed for the input to negative infinity.
+			// 
+			// cv$numStates's comment
+			// variable marginalization
+			for(int cv$indexName = 2; cv$indexName < cv$stateProbabilityLocal.length; cv$indexName += 1)
+				cv$stateProbabilityLocal[cv$indexName] = Double.NEGATIVE_INFINITY;
+			
+			// Guards to ensure that component is only updated when there is a valid path.
+			// 
+			// Write out the value of the sample to a temporary variable prior to updating the
+			// intermediate variables.
+			// 
+			// cv$numStates's comment
+			// variable marginalization
+			component[var96] = (DistributionSampling.sampleCategorical(RNG$, cv$stateProbabilityLocal, 2) == 1);
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 20 drawn from Gaussian 7. Inference was performed using Metropolis-Hastings.
+	private final void inferSample20(int var19, int threadID$cv$var19, Rng RNG$) {
+		constrainedFlag$sample20[var19] = false;
+		
+		// The original value of the sample
+		double cv$originalValue = rawMu[var19];
+		
+		// This value is not used before it is set again, so removing the value declaration.
+		// 
+		// The probability of the random variable generating the originally sampled value
+		double cv$originalProbability;
+		
+		// Calculate a proposed variance.
+		double cv$var = ((cv$originalValue * cv$originalValue) * 0.010000000000000002);
+		
+		// Ensure the variance is at least 0.01
+		if((cv$var < 0.010000000000000002))
+			cv$var = 0.010000000000000002;
+		
+		// The proposed new value for the sample
+		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+		{
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			// 
+			// Set the current value to the current state of the tree.
+			double cv$accumulatedProbabilities = (DistributionSampling.logProbabilityGaussian((cv$originalValue / 2.0)) - 0.6931471805599453);
+			
+			// Looking for a path between Sample 20 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[0];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Set the current value to the current state of the tree.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 1)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							// 
+							// Set the current value to the current state of the tree.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							// 
+							// Set the current value to the current state of the tree.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[1];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Set the current value to the current state of the tree.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Processing conditional point41.
+			// 
+			// Looking for a path between Sample 20 and consumer double 39.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if41 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if41 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$36_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$36_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$52_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$52_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if41)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$37_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$37_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$53_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$53_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Processing conditional point61.
+			// 
+			// Looking for a path between Sample 20 and consumer double 57.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if61 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if61 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$72_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$72_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$88_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$88_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if61)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$73_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$73_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$89_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$89_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(constrainedFlag$sample20[var19]) {
+			{
+				// Guards to ensure that rawMu is only updated when there is a valid path.
+				rawMu[var19] = cv$proposedValue;
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put43 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((var19 == 1) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					mu[0] = rawMu[0];
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+					mu[0] = rawMu[1];
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put63 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put63 = true;
+					double var57;
+					if((rawMu[0] < rawMu[1]))
+						var57 = rawMu[1];
+					else
+						var57 = rawMu[0];
+					mu[1] = var57;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 1)) {
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						double var57;
+						if((rawMu[0] < rawMu[1]))
+							var57 = rawMu[1];
+						else
+							var57 = rawMu[0];
+						mu[1] = var57;
+					}
+					
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						mu[1] = rawMu[1];
+					}
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+					mu[1] = rawMu[0];
+			}
+			
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			double cv$accumulatedProbabilities = (DistributionSampling.logProbabilityGaussian((cv$proposedValue / 2.0)) - 0.6931471805599453);
+			
+			// Looking for a path between Sample 20 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[0];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 1)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[1];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Processing conditional point41.
+			// 
+			// Looking for a path between Sample 20 and consumer double 39.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if41 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if41 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$36_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$36_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$52_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$52_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if41)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$37_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$37_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$53_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$53_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Processing conditional point61.
+			// 
+			// Looking for a path between Sample 20 and consumer double 57.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if61 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if61 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$72_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$72_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$88_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$88_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if61)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$73_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$73_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$89_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$89_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// The probability ration for the proposed value and the current value.
+			// 
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			double cv$ratio = (cv$accumulatedProbabilities - cv$originalProbability);
+			
+			// Test if the probability of the sample is sufficient to keep the value. This needs
+			// to be less than or equal as otherwise if the proposed value is not possible and
+			// the random value is 0 an impossible value will be accepted.
+			if(((cv$ratio <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN(cv$ratio))) {
+				// If it is not revert the changes.
+				// 
+				// Set the sample value
+				// Guards to ensure that rawMu is only updated when there is a valid path.
+				// 
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				rawMu[var19] = cv$originalValue;
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put43 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((var19 == 1) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					mu[0] = rawMu[0];
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+					mu[0] = rawMu[1];
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put63 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put63 = true;
+					double var57;
+					if((rawMu[0] < rawMu[1]))
+						var57 = rawMu[1];
+					else
+						var57 = rawMu[0];
+					mu[1] = var57;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 1)) {
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						double var57;
+						if((rawMu[0] < rawMu[1]))
+							var57 = rawMu[1];
+						else
+							var57 = rawMu[0];
+						mu[1] = var57;
+					}
+					
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						mu[1] = rawMu[1];
+					}
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+					mu[1] = rawMu[0];
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 83 drawn from TruncatedGaussian 66. Inference was performed using
+	// Metropolis-Hastings.
+	private final void inferSample83(int var78) {
+		constrainedFlag$sample83[var78] = false;
+		
+		// The original value of the sample
+		double cv$originalValue = sigma[var78];
+		
+		// This value is not used before it is set again, so removing the value declaration.
+		// 
+		// The probability of the random variable generating the originally sampled value
+		double cv$originalProbability;
+		
+		// Calculate a proposed variance.
+		double cv$var = ((cv$originalValue * cv$originalValue) * 0.010000000000000002);
+		
+		// Ensure the variance is at least 0.01
+		if((cv$var < 0.010000000000000002))
+			cv$var = 0.010000000000000002;
+		
+		// The proposed new value for the sample
+		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+		{
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			// 
+			// Set the current value to the current state of the tree.
+			double cv$accumulatedProbabilities = (((0.0 <= cv$originalValue) && (cv$originalValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$originalValue / 2.0)):Double.NEGATIVE_INFINITY);
+			
+			// Looking for a path between Sample 83 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 0)) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[0] = true;
+						
+						// Constructing a random variable input for use later.
+						// 
+						// Set the current value to the current state of the tree.
+						double var128 = (cv$originalValue * cv$originalValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[0]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 1)) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[1] = true;
+						
+						// Constructing a random variable input for use later.
+						// 
+						// Set the current value to the current state of the tree.
+						double var128 = (cv$originalValue * cv$originalValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[1]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(constrainedFlag$sample83[var78]) {
+			// Guards to ensure that sigma is only updated when there is a valid path.
+			sigma[var78] = cv$proposedValue;
+			
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			double cv$accumulatedProbabilities = (((0.0 <= cv$proposedValue) && (cv$proposedValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$proposedValue / 2.0)):Double.NEGATIVE_INFINITY);
+			
+			// Looking for a path between Sample 83 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 0)) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[0] = true;
+						
+						// Constructing a random variable input for use later.
+						double var128 = (cv$proposedValue * cv$proposedValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[0]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 1)) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[1] = true;
+						
+						// Constructing a random variable input for use later.
+						double var128 = (cv$proposedValue * cv$proposedValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[1]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// The probability ration for the proposed value and the current value.
+			// 
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			double cv$ratio = (cv$accumulatedProbabilities - cv$originalProbability);
+			
+			// Test if the probability of the sample is sufficient to keep the value. This needs
+			// to be less than or equal as otherwise if the proposed value is not possible and
+			// the random value is 0 an impossible value will be accepted.
+			if(((cv$ratio <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN(cv$ratio)))
+				// If it is not revert the changes.
+				// 
+				// Set the sample value
+				// 
+				// Guards to ensure that sigma is only updated when there is a valid path.
+				// 
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				sigma[var78] = cv$originalValue;
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 88 drawn from Beta 83. Inference was performed using a Beta to Bernoulli/Binomial
+	// conjugate prior.
+	private final void inferSample88() {
+		constrainedFlag$sample88 = false;
+		
+		// Local variable to record the number of true samples.
+		int cv$sum = 0;
+		
+		// Local variable to record the number of samples.
+		int cv$count = 0;
+		
+		// Processing random variable 85.
+		// 
+		// Processing sample task 101 of consumer random variable componentDistribution.
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((fixedFlag$sample101 || constrainedFlag$sample101[var96])) {
+				// Mark that the sample has observed constrained data.
+				constrainedFlag$sample88 = true;
+				
+				// Include the value sampled by task 101 from random variable componentDistribution.
+				// 
+				// Increment the number of samples.
+				cv$count = (cv$count + 1);
+				
+				// If the sample value was positive increase the count
+				if(component[var96])
+					cv$sum = (cv$sum + 1);
+			}
+		}
+		if(constrainedFlag$sample88)
+			// Write out the new value of the sample.
+			theta = Conjugates.sampleConjugateBetaBinomial(RNG$, 5.0, 5.0, cv$sum, cv$count);
+	}
+
+	// Calculate the probability of the samples represented by sample101 using sampled
+	// values.
+	private final void logProbabilityValue$sample101() {
+		// Determine if we need to calculate the values for sample task 101 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample101) {
+			// Generating probabilities for sample task
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			for(int var96 = 0; var96 < N; var96 += 1)
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= theta) && (theta <= 1.0))?Math.log((component[var96]?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+			logProbability$componentDistribution = cv$sampleAccumulator;
+			
+			// Store the random variable instance probability
+			logProbability$var97 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$component = (logProbability$component + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedFlag$sample88);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			logProbability$componentDistribution = logProbability$var97;
+			
+			// Update the variable probability
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$component = (logProbability$component + logProbability$var97);
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$var97);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				// Variable declaration of cv$accumulator moved.
+				logProbability$$evidence = (logProbability$$evidence + logProbability$var97);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample138 using sampled
+	// values.
+	private final void logProbabilityValue$sample138() {
+		// Determine if we need to calculate the values for sample task 138 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample138) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			for(int n = 0; n < N; n += 1) {
+				double componentMu;
+				if(component[n])
+					componentMu = mu[0];
+				else
+					componentMu = mu[1];
+				double componentSigma;
+				if(component[n])
+					componentSigma = sigma[0];
+				else
+					componentSigma = sigma[1];
+				double var128 = (componentSigma * componentSigma);
+				
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				double cv$distributionAccumulator = ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY);
+				
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+				
+				// Store the sample task probability
+				logProbability$sample138[n] = cv$distributionAccumulator;
+			}
+			
+			// Update the variable probability
+			logProbability$y = (logProbability$y + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample138 = ((fixedFlag$sample20 && fixedFlag$sample83) && fixedFlag$sample101);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			for(int n = 0; n < N; n += 1)
+				cv$accumulator = (cv$accumulator + logProbability$sample138[n]);
+			
+			// Update the variable probability
+			logProbability$y = (logProbability$y + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample20 using sampled
+	// values.
+	private final void logProbabilityValue$sample20() {
+		// Determine if we need to calculate the values for sample task 20 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample20) {
+			// Generating probabilities for sample task
+			// This value is not used before it is set again, so removing the value declaration.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator;
+			{
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				double cv$weightedProbability = (DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) - 0.6931471805599453);
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				cv$sampleAccumulator = cv$weightedProbability;
+				
+				// Store the sample task probability
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				logProbability$sample20[0] = cv$weightedProbability;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					// Set the guard so the update is only applied once.
+					cv$guard$mu = true;
+					
+					// Update the variable probability
+					// 
+					// Scale the probability relative to the observed distribution space.
+					// 
+					// Add the probability of this distribution configuration to the accumulator.
+					// 
+					// An accumulator for the distributed probability space covered.
+					logProbability$mu = (logProbability$mu + cv$weightedProbability);
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !cv$guard$mu))
+					// Update the variable probability
+					// 
+					// Scale the probability relative to the observed distribution space.
+					// 
+					// Add the probability of this distribution configuration to the accumulator.
+					// 
+					// An accumulator for the distributed probability space covered.
+					logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			}
+			
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$weightedProbability = (DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) - 0.6931471805599453);
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$weightedProbability);
+			
+			// Store the sample task probability
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			logProbability$sample20[1] = cv$weightedProbability;
+			
+			// Guard to ensure that mu is only updated once for this probability.
+			boolean cv$guard$mu = false;
+			
+			// Add probability to constructed variables that have guards, so need per sample probabilities
+			// from the combined probability
+			// 
+			// Looking for a path between Sample 20 and consumer double[] 41.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Guard to ensure that mu is only updated once for this probability.
+			if(!(rawMu[0] < rawMu[1])) {
+				// Set the guard so the update is only applied once.
+				cv$guard$mu = true;
+				
+				// Update the variable probability
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			}
+			
+			// Looking for a path between Sample 20 and consumer double[] 59.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !cv$guard$mu))
+				// Update the variable probability
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$rawMu = (logProbability$rawMu + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample20 = fixedFlag$sample20;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// This value is not used before it is set again, so removing the value declaration.
+			double cv$rvAccumulator;
+			{
+				double cv$sampleValue = logProbability$sample20[0];
+				cv$rvAccumulator = cv$sampleValue;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					// Set the guard so the update is only applied once.
+					cv$guard$mu = true;
+					
+					// Update the variable probability
+					logProbability$mu = (logProbability$mu + cv$sampleValue);
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !cv$guard$mu))
+					// Update the variable probability
+					logProbability$mu = (logProbability$mu + cv$sampleValue);
+			}
+			double cv$sampleValue = logProbability$sample20[1];
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			
+			// Guard to ensure that mu is only updated once for this probability.
+			boolean cv$guard$mu = false;
+			
+			// Add probability to constructed variables that have guards, so need per sample probabilities
+			// from the combined probability
+			// 
+			// Looking for a path between Sample 20 and consumer double[] 41.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Guard to ensure that mu is only updated once for this probability.
+			if(!(rawMu[0] < rawMu[1])) {
+				// Set the guard so the update is only applied once.
+				cv$guard$mu = true;
+				
+				// Update the variable probability
+				logProbability$mu = (logProbability$mu + cv$sampleValue);
+			}
+			
+			// Looking for a path between Sample 20 and consumer double[] 59.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !cv$guard$mu))
+				// Update the variable probability
+				logProbability$mu = (logProbability$mu + cv$sampleValue);
+			
+			// Update the variable probability
+			logProbability$rawMu = (logProbability$rawMu + cv$rvAccumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$rvAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$rvAccumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample83 using sampled
+	// values.
+	private final void logProbabilityValue$sample83() {
+		// Determine if we need to calculate the values for sample task 83 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample83) {
+			// Generating probabilities for sample task
+			// This value is not used before it is set again, so removing the value declaration.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = sigma[0];
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				cv$sampleAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$sampleValue / 2.0)):Double.NEGATIVE_INFINITY);
+			}
+			
+			// The sample value to calculate the probability of generating
+			double cv$sampleValue = sigma[1];
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$sampleValue / 2.0)):Double.NEGATIVE_INFINITY));
+			
+			// Store the random variable instance probability
+			logProbability$var79 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$sigma = (logProbability$sigma + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample83 = fixedFlag$sample83;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// Update the variable probability
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$sigma = (logProbability$sigma + logProbability$var79);
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$var79);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				// Variable declaration of cv$accumulator moved.
+				logProbability$$evidence = (logProbability$$evidence + logProbability$var79);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample88 using sampled
+	// values.
+	private final void logProbabilityValue$sample88() {
+		// Determine if we need to calculate the values for sample task 88 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample88) {
+			// Generating probabilities for sample task
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(theta, 5.0, 5.0);
+			
+			// Store the sample task probability
+			logProbability$theta = cv$distributionAccumulator;
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			// Declaration comment was:
+			// Accumulator for probabilities of instances of the random variable
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				// Variable declaration of cv$accumulator moved.
+				// Declaration comment was:
+				// Accumulator for probabilities of instances of the random variable
+				// 
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				// 
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				logProbability$$evidence = (logProbability$$evidence + cv$distributionAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample88 = fixedFlag$sample88;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$theta);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				// Variable declaration of cv$accumulator moved.
+				logProbability$$evidence = (logProbability$$evidence + logProbability$theta);
+		}
+	}
+
+	// Method to allocate space temporary variables used by the inference methods. Allocating
+	// here prevents repeated allocation and deallocation, and makes the code more amenable
+	// to GPU execution.
+	@Override
+	public final void allocateScratch() {
+		// Allocate scratch space.
+		// Constructor for cv$var97$stateProbabilityGlobal
+		{
+			// Allocation of cv$var97$stateProbabilityGlobal for multithreaded execution
+			// Get the thread count.
+			int cv$threadCount = threadCount();
+			
+			// Allocate an array to hold a copy per thread
+			cv$var97$stateProbabilityGlobal = new double[cv$threadCount][];
+			
+			// Populate the array with a copy per thread
+			for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
+				cv$var97$stateProbabilityGlobal[cv$index] = new double[2];
+		}
+		
+		// Allocation of guard$sample20if124$global for multithreaded execution
+		// 
+		// Get the thread count.
+		int cv$threadCount = threadCount();
+		
+		// Allocate an array to hold a copy per thread
+		guard$sample20if124$global = new boolean[cv$threadCount][];
+		
+		// Populate the array with a copy per thread
+		for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
+			guard$sample20if124$global[cv$index] = new boolean[2];
+	}
+
+	// Method to allocate space for model inputs and outputs.
+	@Override
+	public final void allocator() {
+		// If rawMu has not been set already allocate space.
+		if(!fixedFlag$sample20)
+			// Constructor for rawMu
+			rawMu = new double[2];
+		
+		// Constructor for mu
+		mu = new double[2];
+		
+		// If sigma has not been set already allocate space.
+		if(!fixedFlag$sample83)
+			// Constructor for sigma
+			sigma = new double[2];
+		
+		// If component has not been set already allocate space.
+		if(!fixedFlag$sample101)
+			// Constructor for component
+			component = new boolean[length$yObserved];
+		
+		// Constructor for y
+		y = new double[length$yObserved];
+		
+		// Constructor for constrainedFlag$sample101
+		constrainedFlag$sample101 = new boolean[length$yObserved];
+		
+		// Constructor for constrainedFlag$sample20
+		constrainedFlag$sample20 = new boolean[2];
+		
+		// Constructor for constrainedFlag$sample83
+		constrainedFlag$sample83 = new boolean[2];
+		
+		// Constructor for logProbability$sample20
+		logProbability$sample20 = new double[2];
+		
+		// Constructor for logProbability$sample138
+		logProbability$sample138 = new double[length$yObserved];
+		
+		// Allocate scratch space
+		allocateScratch();
+	}
+
+	// Method to execute the model code conventionally.
+	@Override
+	public final void forwardGeneration() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$n, int forEnd$n, int threadID$n, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int n = forStart$n; n < forEnd$n; n += 1) {
+						double componentMu;
+						if(component[n])
+							componentMu = mu[0];
+						else
+							componentMu = mu[1];
+						double componentSigma;
+						if(component[n])
+							componentSigma = sigma[0];
+						else
+							componentSigma = sigma[1];
+						y[n] = ((componentSigma * DistributionSampling.sampleGaussian(RNG$1)) + componentMu);
+					}
+			}
+		);
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are calculated
+	// and stored.
+	@Override
+	public final void forwardGenerationDistributionsNoOutputsPrime() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+	}
+
+	// Method to execute the model code conventionally with priming of fixed intermediate
+	// variables.
+	@Override
+	public final void forwardGenerationPrime() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$n, int forEnd$n, int threadID$n, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int n = forStart$n; n < forEnd$n; n += 1) {
+						double componentMu;
+						if(component[n])
+							componentMu = mu[0];
+						else
+							componentMu = mu[1];
+						double componentSigma;
+						if(component[n])
+							componentSigma = sigma[0];
+						else
+							componentSigma = sigma[1];
+						y[n] = ((componentSigma * DistributionSampling.sampleGaussian(RNG$1)) + componentMu);
+					}
+			}
+		);
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Distributions are collapsed to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputs() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are collapsed
+	// to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputsPrime() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+	}
+
+	// Method to execute one round of Gibbs sampling.
+	@Override
+	public final void gibbsRound() {
+		// Infer the samples in chronological order.
+		if(system$gibbsForward) {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample20)
+				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+				parallelFor(RNG$, 0, 2, 1,
+					(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+						
+							// Inner loop for running batches of iterations, each batch has its own random number
+							// generator.
+							for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+								inferSample20(var19, threadID$var19, RNG$1);
+					}
+				);
+
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample83) {
+				inferSample83(0);
+				inferSample83(1);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample101)
+				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+				parallelFor(RNG$, 0, N, 1,
+					(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+						
+							// Inner loop for running batches of iterations, each batch has its own random number
+							// generator.
+							for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+								inferSample101(var96, threadID$var96, RNG$1);
+					}
+				);
+
+		}
+		// Infer the samples in reverse chronological order.
+		else {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample101)
+				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+				parallelFor(RNG$, 0, N, 1,
+					(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+						
+							// Inner loop for running batches of iterations, each batch has its own random number
+							// generator.
+							for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+								inferSample101(var96, threadID$var96, RNG$1);
+					}
+				);
+
+			if(!fixedFlag$sample88)
+				inferSample88();
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample83) {
+				inferSample83(1);
+				inferSample83(0);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample20)
+				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+				parallelFor(RNG$, 0, 2, 1,
+					(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+						
+							// Inner loop for running batches of iterations, each batch has its own random number
+							// generator.
+							for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+								inferSample20(var19, threadID$var19, RNG$1);
+					}
+				);
+
+		}
+		
+		// Reverse the direction of execution for the next iteration
+		system$gibbsForward = !system$gibbsForward;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!constrainedFlag$sample20[var19])
+							drawValueSample20(var19, threadID$var19, RNG$1);
+					}
+			}
+		);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!constrainedFlag$sample83[0])
+			drawValueSample83(0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!constrainedFlag$sample83[1])
+			drawValueSample83(1);
+		if(!constrainedFlag$sample88)
+			drawValueSample88();
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!constrainedFlag$sample101[var96])
+							drawValueSample101(var96, threadID$var96, RNG$1);
+					}
+			}
+		);
+	}
+
+	// A method to initialize all the probabilities in the model to 0/Log(1) ready for
+	// the current probabilities to be calculated by calculating the probability of each
+	// sample task, and its effect on the rest of the model.
+	private final void initializeLogProbabilityFields() {
+		// Set the probabilities of the random variable, and the model as a whole to ready
+		// them to be reconstructed by the probability calls for each sample. Sample probabilities
+		// are only reset for samples that are not fixed at a value that has already been
+		// calculated.
+		logProbability$$model = 0.0;
+		logProbability$$evidence = 0.0;
+		logProbability$rawMu = 0.0;
+		logProbability$mu = 0.0;
+		if(!fixedProbFlag$sample20) {
+			// Unrolled loop
+			logProbability$sample20[0] = Double.NaN;
+			logProbability$sample20[1] = Double.NaN;
+		}
+		logProbability$sigma = 0.0;
+		if(!fixedProbFlag$sample83)
+			logProbability$var79 = Double.NaN;
+		if(!fixedProbFlag$sample88)
+			logProbability$theta = Double.NaN;
+		logProbability$componentDistribution = Double.NaN;
+		logProbability$component = 0.0;
+		if(!fixedProbFlag$sample101)
+			logProbability$var97 = Double.NaN;
+		logProbability$y = 0.0;
+		if(!fixedProbFlag$sample138) {
+			for(int n = 0; n < N; n += 1)
+				logProbability$sample138[n] = Double.NaN;
+		}
+	}
+
+	// Method for initializing the model into a valid state before commencing inference
+	// etc.
+	@Override
+	public final void initializeModel() {
+		N = length$yObserved;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+			constrainedFlag$sample101[index$constrainedFlag$sample101$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+			constrainedFlag$sample20[index$constrainedFlag$sample20$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+			constrainedFlag$sample83[index$constrainedFlag$sample83$1] = true;
+	}
+
+	// Construct the evidence probabilities.
+	@Override
+	public final void logEvidenceProbabilities() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Call each method in turn to generate the new probability values.
+		if(fixedFlag$sample20)
+			logProbabilityValue$sample20();
+		if(fixedFlag$sample83)
+			logProbabilityValue$sample83();
+		if(fixedFlag$sample88)
+			logProbabilityValue$sample88();
+		if(fixedFlag$sample101)
+			logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model uses distributions
+	// when possible.
+	@Override
+	public final void logModelProbabilitiesDist() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model only uses values.
+	@Override
+	public final void logModelProbabilitiesVal() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to propagate observed values back into the model.
+	@Override
+	public final void propagateObservedValues() {
+		// Propagating values back from observations into the models intermediate variables.
+		// 
+		// Deep copy between arrays
+		int cv$length1 = y.length;
+		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1)
+			y[cv$index1] = yObserved[cv$index1];
+	}
+
+	// A method to set array values that depend on the output of a sample task, but are
+	// not directly set by the sample task. This method is called to propagate set values
+	// through the model. Any non-fixed sample values may be sampled to random variables
+	// as part of this process.
+	@Override
+	public final void setIntermediates() {
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+	}
+
+	@Override
+	public String modelCode() {
+		return "/*\n"
+		     + " * Sandwood\n"
+		     + " *\n"
+		     + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+		     + " * \n"
+		     + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+		     + " */\n"
+		     + "\n"
+		     + "package org.sandwood.compiler.tests.parser;\n"
+		     + "\n"
+		     + "public model LowDimMix(double[] yObserved) {\n"
+		     + "    int N = yObserved.length;\n"
+		     + "\n"
+		     + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+		     + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+		     + "    // the constant normalisation factor for the ordered constraint.\n"
+		     + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+		     + "    double[] mu = new double[2];\n"
+		     + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+		     + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+		     + "\n"
+		     + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+		     + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+		     + "\n"
+		     + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+		     + "    double theta = beta(5.0, 5.0).sample();\n"
+		     + "\n"
+		     + "    // Stan likelihood:\n"
+		     + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+		     + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+		     + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+		     + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+		     + "    boolean[] component = componentDistribution.sample(N);\n"
+		     + "    double[] y = new double[N];\n"
+		     + "\n"
+		     + "    for(int n = 0; n < N; n++) {\n"
+		     + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+		     + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+		     + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+		     + "    }\n"
+		     + "\n"
+		     + "    y.observe(yObserved);\n"
+		     + "}\n"
+		     + "";
+	}
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$MultiThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$MultiThreadCPU_optimisedModelNoComments.java
@@ -1,0 +1,1610 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.random.internal.Rng;
+import org.sandwood.runtime.internal.numericTools.Conjugates;
+import org.sandwood.runtime.internal.numericTools.DistributionSampling;
+import org.sandwood.runtime.model.ExecutionTarget;
+
+final class LowDimMix$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements LowDimMix$CoreInterface {
+	private int N;
+	private boolean[] component;
+	private boolean[] constrainedFlag$sample101;
+	private boolean[] constrainedFlag$sample20;
+	private boolean[] constrainedFlag$sample83;
+	private boolean constrainedFlag$sample88 = true;
+	private double[][] cv$var97$stateProbabilityGlobal;
+	private boolean fixedFlag$sample101 = false;
+	private boolean fixedFlag$sample20 = false;
+	private boolean fixedFlag$sample83 = false;
+	private boolean fixedFlag$sample88 = false;
+	private boolean fixedProbFlag$sample101 = false;
+	private boolean fixedProbFlag$sample138 = false;
+	private boolean fixedProbFlag$sample20 = false;
+	private boolean fixedProbFlag$sample83 = false;
+	private boolean fixedProbFlag$sample88 = false;
+	private boolean[][] guard$sample20if124$global;
+	private int length$yObserved;
+	private double logProbability$$evidence;
+	private double logProbability$$model;
+	private double logProbability$component;
+	private double logProbability$componentDistribution;
+	private double logProbability$mu;
+	private double logProbability$rawMu;
+	private double[] logProbability$sample138;
+	private double[] logProbability$sample20;
+	private double logProbability$sigma;
+	private double logProbability$theta;
+	private double logProbability$var79;
+	private double logProbability$var97;
+	private double logProbability$y;
+	private double[] mu;
+	private double[] rawMu;
+	private double[] sigma;
+	private boolean system$gibbsForward = true;
+	private double theta;
+	private double[] y;
+	private double[] yObserved;
+
+	public LowDimMix$MultiThreadCPU(ExecutionTarget target) {
+		super(target);
+	}
+
+	@Override
+	public final int get$N() {
+		return N;
+	}
+
+	@Override
+	public final boolean[] get$component() {
+		return component;
+	}
+
+	@Override
+	public final void set$component(boolean[] cv$value, boolean allocated$) {
+		component = cv$value;
+		fixedProbFlag$sample101 = false;
+		fixedProbFlag$sample138 = false;
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample101() {
+		return fixedFlag$sample101;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample101(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample101 = cv$value;
+		if(allocated$) {
+			for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+				constrainedFlag$sample101[index$constrainedFlag$sample101$1] = cv$value;
+		}
+		fixedProbFlag$sample101 = (cv$value && fixedProbFlag$sample101);
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample20() {
+		return fixedFlag$sample20;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample20(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample20 = cv$value;
+		if(allocated$) {
+			for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+				constrainedFlag$sample20[index$constrainedFlag$sample20$1] = cv$value;
+		}
+		fixedProbFlag$sample20 = (cv$value && fixedProbFlag$sample20);
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample83() {
+		return fixedFlag$sample83;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample83(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample83 = cv$value;
+		if(allocated$) {
+			for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+				constrainedFlag$sample83[index$constrainedFlag$sample83$1] = cv$value;
+		}
+		fixedProbFlag$sample83 = (cv$value && fixedProbFlag$sample83);
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample88() {
+		return fixedFlag$sample88;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample88(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample88 = cv$value;
+		constrainedFlag$sample88 = (cv$value || constrainedFlag$sample88);
+		fixedProbFlag$sample88 = (cv$value && fixedProbFlag$sample88);
+		fixedProbFlag$sample101 = (cv$value && fixedProbFlag$sample101);
+	}
+
+	@Override
+	public final int get$length$yObserved() {
+		return length$yObserved;
+	}
+
+	@Override
+	public final void set$length$yObserved(int cv$value, boolean allocated$) {
+		length$yObserved = cv$value;
+	}
+
+	@Override
+	public final double get$logProbability$$evidence() {
+		return logProbability$$evidence;
+	}
+
+	@Override
+	public final double getCurrentLogProbability() {
+		return logProbability$$model;
+	}
+
+	@Override
+	public final double get$logProbability$component() {
+		return logProbability$component;
+	}
+
+	@Override
+	public final double get$logProbability$componentDistribution() {
+		return logProbability$componentDistribution;
+	}
+
+	@Override
+	public final double get$logProbability$mu() {
+		return logProbability$mu;
+	}
+
+	@Override
+	public final double get$logProbability$rawMu() {
+		return logProbability$rawMu;
+	}
+
+	@Override
+	public final double get$logProbability$sigma() {
+		return logProbability$sigma;
+	}
+
+	@Override
+	public final double get$logProbability$theta() {
+		return logProbability$theta;
+	}
+
+	@Override
+	public final double get$logProbability$y() {
+		return logProbability$y;
+	}
+
+	@Override
+	public final double[] get$mu() {
+		return mu;
+	}
+
+	@Override
+	public final double[] get$rawMu() {
+		return rawMu;
+	}
+
+	@Override
+	public final void set$rawMu(double[] cv$value, boolean allocated$) {
+		rawMu = cv$value;
+		fixedProbFlag$sample20 = false;
+		fixedProbFlag$sample138 = false;
+	}
+
+	@Override
+	public final double[] get$sigma() {
+		return sigma;
+	}
+
+	@Override
+	public final void set$sigma(double[] cv$value, boolean allocated$) {
+		sigma = cv$value;
+		fixedProbFlag$sample83 = false;
+		fixedProbFlag$sample138 = false;
+	}
+
+	@Override
+	public final double get$theta() {
+		return theta;
+	}
+
+	@Override
+	public final void set$theta(double cv$value, boolean allocated$) {
+		theta = cv$value;
+		fixedProbFlag$sample88 = false;
+		fixedProbFlag$sample101 = false;
+	}
+
+	@Override
+	public final double[] get$y() {
+		return y;
+	}
+
+	@Override
+	public final double[] get$yObserved() {
+		return yObserved;
+	}
+
+	@Override
+	public final void set$yObserved(double[] cv$value, boolean allocated$) {
+		yObserved = cv$value;
+	}
+
+	private final void drawValueSample101(int var96, int threadID$cv$var96, Rng RNG$) {
+		component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+	}
+
+	private final void drawValueSample20(int var19, int threadID$cv$var19, Rng RNG$) {
+		rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		boolean guard$sample20put43 = false;
+		if((var19 == 0)) {
+			guard$sample20put43 = true;
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+		}
+		if(((var19 == 1) && !guard$sample20put43)) {
+			guard$sample20put43 = true;
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+		}
+		if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+			guard$sample20put43 = true;
+			mu[0] = rawMu[0];
+		}
+		if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+			mu[0] = rawMu[1];
+		boolean guard$sample20put63 = false;
+		if((var19 == 0)) {
+			guard$sample20put63 = true;
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		if((var19 == 1)) {
+			if(!guard$sample20put63) {
+				guard$sample20put63 = true;
+				double var57;
+				if((rawMu[0] < rawMu[1]))
+					var57 = rawMu[1];
+				else
+					var57 = rawMu[0];
+				mu[1] = var57;
+			}
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+				guard$sample20put63 = true;
+				mu[1] = rawMu[1];
+			}
+		}
+		if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+			mu[1] = rawMu[0];
+	}
+
+	private final void drawValueSample83(int var78) {
+		sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+	}
+
+	private final void drawValueSample88() {
+		theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+	}
+
+	private final void inferSample101(int var96, int threadID$cv$var96, Rng RNG$) {
+		double[] cv$stateProbabilityLocal = cv$var97$stateProbabilityGlobal[threadID$cv$var96];
+		{
+			component[var96] = false;
+			double cv$accumulatedProbabilities = (((0.0 <= theta) && (theta <= 1.0))?Math.log((1.0 - theta)):Double.NEGATIVE_INFINITY);
+			if(component[var96]) {
+				{
+					double componentSigma = sigma[0];
+					double var128 = (componentSigma * componentSigma);
+					cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				}
+				boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+				guard$sample20if124[0] = false;
+				guard$sample20if124[1] = false;
+				if((rawMu[0] < rawMu[1]))
+					guard$sample20if124[0] = false;
+				else
+					guard$sample20if124[1] = false;
+				if(!guard$sample20if124[0]) {
+					guard$sample20if124[0] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				if(!guard$sample20if124[1]) {
+					guard$sample20if124[1] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				if(((rawMu[0] < rawMu[1]) && !guard$sample20if124[0])) {
+					guard$sample20if124[0] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124[1])) {
+					guard$sample20if124[1] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				double traceTempVariable$componentSigma$58_1 = sigma[0];
+				double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				cv$accumulatedProbabilities = ((((0.0 <= sigma[0]) && (sigma[0] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[0] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			} else {
+				{
+					double componentSigma = sigma[1];
+					double var128 = (componentSigma * componentSigma);
+					cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				}
+				boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+				guard$sample20if124[0] = false;
+				guard$sample20if124[1] = false;
+				if((rawMu[0] < rawMu[1]))
+					guard$sample20if124[1] = false;
+				else
+					guard$sample20if124[0] = false;
+				if(!guard$sample20if124[0]) {
+					guard$sample20if124[0] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				if(!guard$sample20if124[1]) {
+					guard$sample20if124[1] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				if(((rawMu[0] < rawMu[1]) && !guard$sample20if124[1])) {
+					guard$sample20if124[1] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124[0])) {
+					guard$sample20if124[0] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				double traceTempVariable$componentSigma$63_1 = sigma[1];
+				double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				cv$accumulatedProbabilities = ((((0.0 <= sigma[1]) && (sigma[1] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[1] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			cv$stateProbabilityLocal[0] = cv$accumulatedProbabilities;
+		}
+		component[var96] = true;
+		double cv$accumulatedProbabilities = (((0.0 <= theta) && (theta <= 1.0))?Math.log(theta):Double.NEGATIVE_INFINITY);
+		if(component[var96]) {
+			{
+				double componentSigma = sigma[0];
+				double var128 = (componentSigma * componentSigma);
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+			guard$sample20if124[0] = false;
+			guard$sample20if124[1] = false;
+			if((rawMu[0] < rawMu[1]))
+				guard$sample20if124[0] = false;
+			else
+				guard$sample20if124[1] = false;
+			if(!guard$sample20if124[0]) {
+				guard$sample20if124[0] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			if(!guard$sample20if124[1]) {
+				guard$sample20if124[1] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20if124[0])) {
+				guard$sample20if124[0] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124[1])) {
+				guard$sample20if124[1] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			double traceTempVariable$componentSigma$58_1 = sigma[0];
+			constrainedFlag$sample101[var96] = true;
+			double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+			cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			cv$accumulatedProbabilities = ((((0.0 <= sigma[0]) && (sigma[0] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[0] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+		} else {
+			{
+				double componentSigma = sigma[1];
+				double var128 = (componentSigma * componentSigma);
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+			guard$sample20if124[0] = false;
+			guard$sample20if124[1] = false;
+			if((rawMu[0] < rawMu[1]))
+				guard$sample20if124[1] = false;
+			else
+				guard$sample20if124[0] = false;
+			if(!guard$sample20if124[0]) {
+				guard$sample20if124[0] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			if(!guard$sample20if124[1]) {
+				guard$sample20if124[1] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20if124[1])) {
+				guard$sample20if124[1] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124[0])) {
+				guard$sample20if124[0] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			double traceTempVariable$componentSigma$63_1 = sigma[1];
+			constrainedFlag$sample101[var96] = true;
+			double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+			cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			cv$accumulatedProbabilities = ((((0.0 <= sigma[1]) && (sigma[1] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[1] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+		}
+		cv$stateProbabilityLocal[1] = cv$accumulatedProbabilities;
+		if(constrainedFlag$sample101[var96]) {
+			double cv$logSum;
+			double cv$lseMax = cv$stateProbabilityLocal[0];
+			double cv$lseElementValue = cv$stateProbabilityLocal[1];
+			if((cv$lseMax < cv$lseElementValue))
+				cv$lseMax = cv$lseElementValue;
+			if((cv$lseMax == Double.NEGATIVE_INFINITY))
+				cv$logSum = Double.NEGATIVE_INFINITY;
+			else
+				cv$logSum = (Math.log((Math.exp((cv$stateProbabilityLocal[0] - cv$lseMax)) + Math.exp((cv$stateProbabilityLocal[1] - cv$lseMax)))) + cv$lseMax);
+			if((cv$logSum == Double.NEGATIVE_INFINITY)) {
+				cv$stateProbabilityLocal[0] = 0.5;
+				cv$stateProbabilityLocal[1] = 0.5;
+			} else {
+				cv$stateProbabilityLocal[0] = Math.exp((cv$stateProbabilityLocal[0] - cv$logSum));
+				cv$stateProbabilityLocal[1] = Math.exp((cv$stateProbabilityLocal[1] - cv$logSum));
+			}
+			for(int cv$indexName = 2; cv$indexName < cv$stateProbabilityLocal.length; cv$indexName += 1)
+				cv$stateProbabilityLocal[cv$indexName] = Double.NEGATIVE_INFINITY;
+			component[var96] = (DistributionSampling.sampleCategorical(RNG$, cv$stateProbabilityLocal, 2) == 1);
+		}
+	}
+
+	private final void inferSample20(int var19, int threadID$cv$var19, Rng RNG$) {
+		constrainedFlag$sample20[var19] = false;
+		double cv$originalValue = rawMu[var19];
+		double cv$originalProbability;
+		double cv$var = ((cv$originalValue * cv$originalValue) * 0.010000000000000002);
+		if((cv$var < 0.010000000000000002))
+			cv$var = 0.010000000000000002;
+		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+		{
+			double cv$accumulatedProbabilities = (DistributionSampling.logProbabilityGaussian((cv$originalValue / 2.0)) - 0.6931471805599453);
+			if(((rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						constrainedFlag$sample20[0] = true;
+						double componentSigma = sigma[0];
+						double var128 = (componentSigma * componentSigma);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			if((var19 == 1)) {
+				if((rawMu[0] < rawMu[1])) {
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				} else {
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+			}
+			if((!(rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						constrainedFlag$sample20[0] = true;
+						double componentSigma = sigma[1];
+						double var128 = (componentSigma * componentSigma);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			boolean guard$sample20if41 = false;
+			if((var19 == 0)) {
+				guard$sample20if41 = true;
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$36_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$36_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var115$52_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$52_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			if(((var19 == 1) && !guard$sample20if41)) {
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$37_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$37_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var115$53_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$53_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			boolean guard$sample20if61 = false;
+			if((var19 == 0)) {
+				guard$sample20if61 = true;
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$72_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$72_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var117$88_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$88_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			if(((var19 == 1) && !guard$sample20if61)) {
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$73_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$73_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var117$89_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$89_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		if(constrainedFlag$sample20[var19]) {
+			{
+				rawMu[var19] = cv$proposedValue;
+				boolean guard$sample20put43 = false;
+				if((var19 == 0)) {
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				if(((var19 == 1) && !guard$sample20put43)) {
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+					guard$sample20put43 = true;
+					mu[0] = rawMu[0];
+				}
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+					mu[0] = rawMu[1];
+				boolean guard$sample20put63 = false;
+				if((var19 == 0)) {
+					guard$sample20put63 = true;
+					double var57;
+					if((rawMu[0] < rawMu[1]))
+						var57 = rawMu[1];
+					else
+						var57 = rawMu[0];
+					mu[1] = var57;
+				}
+				if((var19 == 1)) {
+					if(!guard$sample20put63) {
+						guard$sample20put63 = true;
+						double var57;
+						if((rawMu[0] < rawMu[1]))
+							var57 = rawMu[1];
+						else
+							var57 = rawMu[0];
+						mu[1] = var57;
+					}
+					if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+						guard$sample20put63 = true;
+						mu[1] = rawMu[1];
+					}
+				}
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+					mu[1] = rawMu[0];
+			}
+			double cv$accumulatedProbabilities = (DistributionSampling.logProbabilityGaussian((cv$proposedValue / 2.0)) - 0.6931471805599453);
+			if(((rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						constrainedFlag$sample20[0] = true;
+						double componentSigma = sigma[0];
+						double var128 = (componentSigma * componentSigma);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			if((var19 == 1)) {
+				if((rawMu[0] < rawMu[1])) {
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				} else {
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+			}
+			if((!(rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						constrainedFlag$sample20[0] = true;
+						double componentSigma = sigma[1];
+						double var128 = (componentSigma * componentSigma);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			boolean guard$sample20if41 = false;
+			if((var19 == 0)) {
+				guard$sample20if41 = true;
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$36_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$36_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var115$52_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$52_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			if(((var19 == 1) && !guard$sample20if41)) {
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$37_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$37_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var115$53_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$53_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			boolean guard$sample20if61 = false;
+			if((var19 == 0)) {
+				guard$sample20if61 = true;
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$72_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$72_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var117$88_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$88_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			if(((var19 == 1) && !guard$sample20if61)) {
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$73_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$73_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var117$89_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$89_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			double cv$ratio = (cv$accumulatedProbabilities - cv$originalProbability);
+			if(((cv$ratio <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN(cv$ratio))) {
+				rawMu[var19] = cv$originalValue;
+				boolean guard$sample20put43 = false;
+				if((var19 == 0)) {
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				if(((var19 == 1) && !guard$sample20put43)) {
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+					guard$sample20put43 = true;
+					mu[0] = rawMu[0];
+				}
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+					mu[0] = rawMu[1];
+				boolean guard$sample20put63 = false;
+				if((var19 == 0)) {
+					guard$sample20put63 = true;
+					double var57;
+					if((rawMu[0] < rawMu[1]))
+						var57 = rawMu[1];
+					else
+						var57 = rawMu[0];
+					mu[1] = var57;
+				}
+				if((var19 == 1)) {
+					if(!guard$sample20put63) {
+						guard$sample20put63 = true;
+						double var57;
+						if((rawMu[0] < rawMu[1]))
+							var57 = rawMu[1];
+						else
+							var57 = rawMu[0];
+						mu[1] = var57;
+					}
+					if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+						guard$sample20put63 = true;
+						mu[1] = rawMu[1];
+					}
+				}
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+					mu[1] = rawMu[0];
+			}
+		}
+	}
+
+	private final void inferSample83(int var78) {
+		constrainedFlag$sample83[var78] = false;
+		double cv$originalValue = sigma[var78];
+		double cv$originalProbability;
+		double cv$var = ((cv$originalValue * cv$originalValue) * 0.010000000000000002);
+		if((cv$var < 0.010000000000000002))
+			cv$var = 0.010000000000000002;
+		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+		{
+			double cv$accumulatedProbabilities = (((0.0 <= cv$originalValue) && (cv$originalValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$originalValue / 2.0)):Double.NEGATIVE_INFINITY);
+			if((var78 == 0)) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						constrainedFlag$sample83[0] = true;
+						double var128 = (cv$originalValue * cv$originalValue);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			if((var78 == 1)) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						constrainedFlag$sample83[1] = true;
+						double var128 = (cv$originalValue * cv$originalValue);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		if(constrainedFlag$sample83[var78]) {
+			sigma[var78] = cv$proposedValue;
+			double cv$accumulatedProbabilities = (((0.0 <= cv$proposedValue) && (cv$proposedValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$proposedValue / 2.0)):Double.NEGATIVE_INFINITY);
+			if((var78 == 0)) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						constrainedFlag$sample83[0] = true;
+						double var128 = (cv$proposedValue * cv$proposedValue);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			if((var78 == 1)) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						constrainedFlag$sample83[1] = true;
+						double var128 = (cv$proposedValue * cv$proposedValue);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			double cv$ratio = (cv$accumulatedProbabilities - cv$originalProbability);
+			if(((cv$ratio <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN(cv$ratio)))
+				sigma[var78] = cv$originalValue;
+		}
+	}
+
+	private final void inferSample88() {
+		constrainedFlag$sample88 = false;
+		int cv$sum = 0;
+		int cv$count = 0;
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if((fixedFlag$sample101 || constrainedFlag$sample101[var96])) {
+				constrainedFlag$sample88 = true;
+				cv$count = (cv$count + 1);
+				if(component[var96])
+					cv$sum = (cv$sum + 1);
+			}
+		}
+		if(constrainedFlag$sample88)
+			theta = Conjugates.sampleConjugateBetaBinomial(RNG$, 5.0, 5.0, cv$sum, cv$count);
+	}
+
+	private final void logProbabilityValue$sample101() {
+		if(!fixedProbFlag$sample101) {
+			double cv$sampleAccumulator = 0.0;
+			for(int var96 = 0; var96 < N; var96 += 1)
+				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= theta) && (theta <= 1.0))?Math.log((component[var96]?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+			logProbability$componentDistribution = cv$sampleAccumulator;
+			logProbability$var97 = cv$sampleAccumulator;
+			logProbability$component = (logProbability$component + cv$sampleAccumulator);
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedFlag$sample88);
+		} else {
+			logProbability$componentDistribution = logProbability$var97;
+			logProbability$component = (logProbability$component + logProbability$var97);
+			logProbability$$model = (logProbability$$model + logProbability$var97);
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + logProbability$var97);
+		}
+	}
+
+	private final void logProbabilityValue$sample138() {
+		if(!fixedProbFlag$sample138) {
+			double cv$accumulator = 0.0;
+			for(int n = 0; n < N; n += 1) {
+				double componentMu;
+				if(component[n])
+					componentMu = mu[0];
+				else
+					componentMu = mu[1];
+				double componentSigma;
+				if(component[n])
+					componentSigma = sigma[0];
+				else
+					componentSigma = sigma[1];
+				double var128 = (componentSigma * componentSigma);
+				double cv$distributionAccumulator = ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY);
+				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+				logProbability$sample138[n] = cv$distributionAccumulator;
+			}
+			logProbability$y = (logProbability$y + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			fixedProbFlag$sample138 = ((fixedFlag$sample20 && fixedFlag$sample83) && fixedFlag$sample101);
+		} else {
+			double cv$accumulator = 0.0;
+			for(int n = 0; n < N; n += 1)
+				cv$accumulator = (cv$accumulator + logProbability$sample138[n]);
+			logProbability$y = (logProbability$y + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	private final void logProbabilityValue$sample20() {
+		if(!fixedProbFlag$sample20) {
+			double cv$sampleAccumulator;
+			{
+				double cv$weightedProbability = (DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) - 0.6931471805599453);
+				cv$sampleAccumulator = cv$weightedProbability;
+				logProbability$sample20[0] = cv$weightedProbability;
+				boolean cv$guard$mu = false;
+				if((rawMu[0] < rawMu[1])) {
+					cv$guard$mu = true;
+					logProbability$mu = (logProbability$mu + cv$weightedProbability);
+				}
+				if((!(rawMu[0] < rawMu[1]) && !cv$guard$mu))
+					logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			}
+			double cv$weightedProbability = (DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) - 0.6931471805599453);
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$weightedProbability);
+			logProbability$sample20[1] = cv$weightedProbability;
+			boolean cv$guard$mu = false;
+			if(!(rawMu[0] < rawMu[1])) {
+				cv$guard$mu = true;
+				logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			}
+			if(((rawMu[0] < rawMu[1]) && !cv$guard$mu))
+				logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			logProbability$rawMu = (logProbability$rawMu + cv$sampleAccumulator);
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			fixedProbFlag$sample20 = fixedFlag$sample20;
+		} else {
+			double cv$rvAccumulator;
+			{
+				double cv$sampleValue = logProbability$sample20[0];
+				cv$rvAccumulator = cv$sampleValue;
+				boolean cv$guard$mu = false;
+				if((rawMu[0] < rawMu[1])) {
+					cv$guard$mu = true;
+					logProbability$mu = (logProbability$mu + cv$sampleValue);
+				}
+				if((!(rawMu[0] < rawMu[1]) && !cv$guard$mu))
+					logProbability$mu = (logProbability$mu + cv$sampleValue);
+			}
+			double cv$sampleValue = logProbability$sample20[1];
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			boolean cv$guard$mu = false;
+			if(!(rawMu[0] < rawMu[1])) {
+				cv$guard$mu = true;
+				logProbability$mu = (logProbability$mu + cv$sampleValue);
+			}
+			if(((rawMu[0] < rawMu[1]) && !cv$guard$mu))
+				logProbability$mu = (logProbability$mu + cv$sampleValue);
+			logProbability$rawMu = (logProbability$rawMu + cv$rvAccumulator);
+			logProbability$$model = (logProbability$$model + cv$rvAccumulator);
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$rvAccumulator);
+		}
+	}
+
+	private final void logProbabilityValue$sample83() {
+		if(!fixedProbFlag$sample83) {
+			double cv$sampleAccumulator;
+			{
+				double cv$sampleValue = sigma[0];
+				cv$sampleAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$sampleValue / 2.0)):Double.NEGATIVE_INFINITY);
+			}
+			double cv$sampleValue = sigma[1];
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$sampleValue / 2.0)):Double.NEGATIVE_INFINITY));
+			logProbability$var79 = cv$sampleAccumulator;
+			logProbability$sigma = (logProbability$sigma + cv$sampleAccumulator);
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			fixedProbFlag$sample83 = fixedFlag$sample83;
+		} else {
+			logProbability$sigma = (logProbability$sigma + logProbability$var79);
+			logProbability$$model = (logProbability$$model + logProbability$var79);
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + logProbability$var79);
+		}
+	}
+
+	private final void logProbabilityValue$sample88() {
+		if(!fixedProbFlag$sample88) {
+			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(theta, 5.0, 5.0);
+			logProbability$theta = cv$distributionAccumulator;
+			logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$distributionAccumulator);
+			fixedProbFlag$sample88 = fixedFlag$sample88;
+		} else {
+			logProbability$$model = (logProbability$$model + logProbability$theta);
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + logProbability$theta);
+		}
+	}
+
+	@Override
+	public final void allocateScratch() {
+		{
+			int cv$threadCount = threadCount();
+			cv$var97$stateProbabilityGlobal = new double[cv$threadCount][];
+			for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
+				cv$var97$stateProbabilityGlobal[cv$index] = new double[2];
+		}
+		int cv$threadCount = threadCount();
+		guard$sample20if124$global = new boolean[cv$threadCount][];
+		for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
+			guard$sample20if124$global[cv$index] = new boolean[2];
+	}
+
+	@Override
+	public final void allocator() {
+		if(!fixedFlag$sample20)
+			rawMu = new double[2];
+		mu = new double[2];
+		if(!fixedFlag$sample83)
+			sigma = new double[2];
+		if(!fixedFlag$sample101)
+			component = new boolean[length$yObserved];
+		y = new double[length$yObserved];
+		constrainedFlag$sample101 = new boolean[length$yObserved];
+		constrainedFlag$sample20 = new boolean[2];
+		constrainedFlag$sample83 = new boolean[2];
+		logProbability$sample20 = new double[2];
+		logProbability$sample138 = new double[length$yObserved];
+		allocateScratch();
+	}
+
+	@Override
+	public final void forwardGeneration() {
+		if(!fixedFlag$sample20) {
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		if(!fixedFlag$sample83)
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		if(!fixedFlag$sample101)
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$n, int forEnd$n, int threadID$n, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int n = forStart$n; n < forEnd$n; n += 1) {
+						double componentMu;
+						if(component[n])
+							componentMu = mu[0];
+						else
+							componentMu = mu[1];
+						double componentSigma;
+						if(component[n])
+							componentSigma = sigma[0];
+						else
+							componentSigma = sigma[1];
+						y[n] = ((componentSigma * DistributionSampling.sampleGaussian(RNG$1)) + componentMu);
+					}
+			}
+		);
+	}
+
+	@Override
+	public final void forwardGenerationDistributionsNoOutputsPrime() {
+		if(!fixedFlag$sample20)
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		if(!fixedFlag$sample83)
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		if(!fixedFlag$sample101)
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+	}
+
+	@Override
+	public final void forwardGenerationPrime() {
+		if(!fixedFlag$sample20)
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		if(!fixedFlag$sample83)
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		if(!fixedFlag$sample101)
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$n, int forEnd$n, int threadID$n, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int n = forStart$n; n < forEnd$n; n += 1) {
+						double componentMu;
+						if(component[n])
+							componentMu = mu[0];
+						else
+							componentMu = mu[1];
+						double componentSigma;
+						if(component[n])
+							componentSigma = sigma[0];
+						else
+							componentSigma = sigma[1];
+						y[n] = ((componentSigma * DistributionSampling.sampleGaussian(RNG$1)) + componentMu);
+					}
+			}
+		);
+	}
+
+	@Override
+	public final void forwardGenerationValuesNoOutputs() {
+		if(!fixedFlag$sample20) {
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		if(!fixedFlag$sample83)
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		if(!fixedFlag$sample101)
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+	}
+
+	@Override
+	public final void forwardGenerationValuesNoOutputsPrime() {
+		if(!fixedFlag$sample20)
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		if(!fixedFlag$sample83)
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		if(!fixedFlag$sample101)
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+	}
+
+	@Override
+	public final void gibbsRound() {
+		if(system$gibbsForward) {
+			if(!fixedFlag$sample20)
+				parallelFor(RNG$, 0, 2, 1,
+					(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+								inferSample20(var19, threadID$var19, RNG$1);
+					}
+				);
+
+			if(!fixedFlag$sample83) {
+				inferSample83(0);
+				inferSample83(1);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			if(!fixedFlag$sample101)
+				parallelFor(RNG$, 0, N, 1,
+					(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+								inferSample101(var96, threadID$var96, RNG$1);
+					}
+				);
+
+		} else {
+			if(!fixedFlag$sample101)
+				parallelFor(RNG$, 0, N, 1,
+					(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+								inferSample101(var96, threadID$var96, RNG$1);
+					}
+				);
+
+			if(!fixedFlag$sample88)
+				inferSample88();
+			if(!fixedFlag$sample83) {
+				inferSample83(1);
+				inferSample83(0);
+			}
+			if(!fixedFlag$sample20)
+				parallelFor(RNG$, 0, 2, 1,
+					(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+								inferSample20(var19, threadID$var19, RNG$1);
+					}
+				);
+
+		}
+		system$gibbsForward = !system$gibbsForward;
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!constrainedFlag$sample20[var19])
+							drawValueSample20(var19, threadID$var19, RNG$1);
+					}
+			}
+		);
+		if(!constrainedFlag$sample83[0])
+			drawValueSample83(0);
+		if(!constrainedFlag$sample83[1])
+			drawValueSample83(1);
+		if(!constrainedFlag$sample88)
+			drawValueSample88();
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!constrainedFlag$sample101[var96])
+							drawValueSample101(var96, threadID$var96, RNG$1);
+					}
+			}
+		);
+	}
+
+	private final void initializeLogProbabilityFields() {
+		logProbability$$model = 0.0;
+		logProbability$$evidence = 0.0;
+		logProbability$rawMu = 0.0;
+		logProbability$mu = 0.0;
+		if(!fixedProbFlag$sample20) {
+			logProbability$sample20[0] = Double.NaN;
+			logProbability$sample20[1] = Double.NaN;
+		}
+		logProbability$sigma = 0.0;
+		if(!fixedProbFlag$sample83)
+			logProbability$var79 = Double.NaN;
+		if(!fixedProbFlag$sample88)
+			logProbability$theta = Double.NaN;
+		logProbability$componentDistribution = Double.NaN;
+		logProbability$component = 0.0;
+		if(!fixedProbFlag$sample101)
+			logProbability$var97 = Double.NaN;
+		logProbability$y = 0.0;
+		if(!fixedProbFlag$sample138) {
+			for(int n = 0; n < N; n += 1)
+				logProbability$sample138[n] = Double.NaN;
+		}
+	}
+
+	@Override
+	public final void initializeModel() {
+		N = length$yObserved;
+		for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+			constrainedFlag$sample101[index$constrainedFlag$sample101$1] = true;
+		for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+			constrainedFlag$sample20[index$constrainedFlag$sample20$1] = true;
+		for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+			constrainedFlag$sample83[index$constrainedFlag$sample83$1] = true;
+	}
+
+	@Override
+	public final void logEvidenceProbabilities() {
+		initializeLogProbabilityFields();
+		if(fixedFlag$sample20)
+			logProbabilityValue$sample20();
+		if(fixedFlag$sample83)
+			logProbabilityValue$sample83();
+		if(fixedFlag$sample88)
+			logProbabilityValue$sample88();
+		if(fixedFlag$sample101)
+			logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	@Override
+	public final void logModelProbabilitiesDist() {
+		initializeLogProbabilityFields();
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	@Override
+	public final void logModelProbabilitiesVal() {
+		initializeLogProbabilityFields();
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	@Override
+	public final void propagateObservedValues() {
+		int cv$length1 = y.length;
+		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1)
+			y[cv$index1] = yObserved[cv$index1];
+	}
+
+	@Override
+	public final void setIntermediates() {
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+	}
+
+	@Override
+	public String modelCode() {
+		return "/*\n"
+		     + " * Sandwood\n"
+		     + " *\n"
+		     + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+		     + " * \n"
+		     + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+		     + " */\n"
+		     + "\n"
+		     + "package org.sandwood.compiler.tests.parser;\n"
+		     + "\n"
+		     + "public model LowDimMix(double[] yObserved) {\n"
+		     + "    int N = yObserved.length;\n"
+		     + "\n"
+		     + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+		     + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+		     + "    // the constant normalisation factor for the ordered constraint.\n"
+		     + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+		     + "    double[] mu = new double[2];\n"
+		     + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+		     + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+		     + "\n"
+		     + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+		     + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+		     + "\n"
+		     + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+		     + "    double theta = beta(5.0, 5.0).sample();\n"
+		     + "\n"
+		     + "    // Stan likelihood:\n"
+		     + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+		     + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+		     + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+		     + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+		     + "    boolean[] component = componentDistribution.sample(N);\n"
+		     + "    double[] y = new double[N];\n"
+		     + "\n"
+		     + "    for(int n = 0; n < N; n++) {\n"
+		     + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+		     + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+		     + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+		     + "    }\n"
+		     + "\n"
+		     + "    y.observe(yObserved);\n"
+		     + "}\n"
+		     + "";
+	}
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$MultiThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$MultiThreadCPU_optimisedModelSingle.java
@@ -1,0 +1,4408 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.random.internal.Rng;
+import org.sandwood.runtime.internal.numericTools.Conjugates;
+import org.sandwood.runtime.internal.numericTools.DistributionSampling;
+import org.sandwood.runtime.model.ExecutionTarget;
+
+final class LowDimMix$MultiThreadCPU extends org.sandwood.runtime.internal.model.CoreModelMultiThreadCPU implements LowDimMix$CoreInterface {
+	
+	// Declare the variables for the model.
+	private int N;
+	private boolean[] component;
+	private boolean[] constrainedFlag$sample101;
+	private boolean[] constrainedFlag$sample20;
+	private boolean[] constrainedFlag$sample83;
+	private boolean constrainedFlag$sample88 = true;
+	private double[][] cv$var97$stateProbabilityGlobal;
+	private boolean fixedFlag$sample101 = false;
+	private boolean fixedFlag$sample20 = false;
+	private boolean fixedFlag$sample83 = false;
+	private boolean fixedFlag$sample88 = false;
+	private boolean fixedProbFlag$sample101 = false;
+	private boolean fixedProbFlag$sample138 = false;
+	private boolean fixedProbFlag$sample20 = false;
+	private boolean fixedProbFlag$sample83 = false;
+	private boolean fixedProbFlag$sample88 = false;
+	private boolean[][] guard$sample20if124$global;
+	private int length$yObserved;
+	private double logProbability$$evidence;
+	private double logProbability$$model;
+	private double logProbability$component;
+	private double logProbability$componentDistribution;
+	private double logProbability$mu;
+	private double logProbability$rawMu;
+	private double[] logProbability$sample20;
+	private double logProbability$sigma;
+	private double logProbability$theta;
+	private double logProbability$var130;
+	private double logProbability$var79;
+	private double logProbability$var97;
+	private double logProbability$y;
+	private double[] mu;
+	private double[] rawMu;
+	private double[] sigma;
+	private boolean system$gibbsForward = true;
+	private double theta;
+	private double[] y;
+	private double[] yObserved;
+
+	public LowDimMix$MultiThreadCPU(ExecutionTarget target) {
+		super(target);
+	}
+
+	// Getter for N.
+	@Override
+	public final int get$N() {
+		return N;
+	}
+
+	// Getter for component.
+	@Override
+	public final boolean[] get$component() {
+		return component;
+	}
+
+	// Setter for component.
+	@Override
+	public final void set$component(boolean[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of component including if probabilities need
+		// to be updated.
+		component = cv$value;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on component.
+		fixedProbFlag$sample101 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on component.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for fixedFlag$sample101.
+	@Override
+	public final boolean get$fixedFlag$sample101() {
+		return fixedFlag$sample101;
+	}
+
+	// Setter for fixedFlag$sample101.
+	@Override
+	public final void set$fixedFlag$sample101(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample101 including if probabilities
+		// need to be updated.
+		fixedFlag$sample101 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+				// Substituted "fixedFlag$sample101" with its value "cv$value".
+				constrainedFlag$sample101[index$constrainedFlag$sample101$1] = cv$value;
+		}
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample101" with its value "cv$value".
+		fixedProbFlag$sample101 = (cv$value && fixedProbFlag$sample101);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample101" with its value "cv$value".
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample20.
+	@Override
+	public final boolean get$fixedFlag$sample20() {
+		return fixedFlag$sample20;
+	}
+
+	// Setter for fixedFlag$sample20.
+	@Override
+	public final void set$fixedFlag$sample20(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample20 including if probabilities
+		// need to be updated.
+		fixedFlag$sample20 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+				// Substituted "fixedFlag$sample20" with its value "cv$value".
+				constrainedFlag$sample20[index$constrainedFlag$sample20$1] = cv$value;
+		}
+		
+		// Should the probability of sample 20 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample20" with its value "cv$value".
+		fixedProbFlag$sample20 = (cv$value && fixedProbFlag$sample20);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample20" with its value "cv$value".
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample83.
+	@Override
+	public final boolean get$fixedFlag$sample83() {
+		return fixedFlag$sample83;
+	}
+
+	// Setter for fixedFlag$sample83.
+	@Override
+	public final void set$fixedFlag$sample83(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample83 including if probabilities
+		// need to be updated.
+		fixedFlag$sample83 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+				// Substituted "fixedFlag$sample83" with its value "cv$value".
+				constrainedFlag$sample83[index$constrainedFlag$sample83$1] = cv$value;
+		}
+		
+		// Should the probability of sample 83 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample83" with its value "cv$value".
+		fixedProbFlag$sample83 = (cv$value && fixedProbFlag$sample83);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample83" with its value "cv$value".
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample88.
+	@Override
+	public final boolean get$fixedFlag$sample88() {
+		return fixedFlag$sample88;
+	}
+
+	// Setter for fixedFlag$sample88.
+	@Override
+	public final void set$fixedFlag$sample88(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample88 including if probabilities
+		// need to be updated.
+		fixedFlag$sample88 = cv$value;
+		
+		// Substituted "fixedFlag$sample88" with its value "cv$value".
+		constrainedFlag$sample88 = (cv$value || constrainedFlag$sample88);
+		
+		// Should the probability of sample 88 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample88" with its value "cv$value".
+		fixedProbFlag$sample88 = (cv$value && fixedProbFlag$sample88);
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample88" with its value "cv$value".
+		fixedProbFlag$sample101 = (cv$value && fixedProbFlag$sample101);
+	}
+
+	// Getter for length$yObserved.
+	@Override
+	public final int get$length$yObserved() {
+		return length$yObserved;
+	}
+
+	// Setter for length$yObserved.
+	@Override
+	public final void set$length$yObserved(int cv$value, boolean allocated$) {
+		length$yObserved = cv$value;
+	}
+
+	// Getter for logProbability$$evidence.
+	@Override
+	public final double get$logProbability$$evidence() {
+		return logProbability$$evidence;
+	}
+
+	// Getter for the probability of logProbability$$model.
+	@Override
+	public final double getCurrentLogProbability() {
+		return logProbability$$model;
+	}
+
+	// Getter for logProbability$component.
+	@Override
+	public final double get$logProbability$component() {
+		return logProbability$component;
+	}
+
+	// Getter for logProbability$componentDistribution.
+	@Override
+	public final double get$logProbability$componentDistribution() {
+		return logProbability$componentDistribution;
+	}
+
+	// Getter for logProbability$mu.
+	@Override
+	public final double get$logProbability$mu() {
+		return logProbability$mu;
+	}
+
+	// Getter for logProbability$rawMu.
+	@Override
+	public final double get$logProbability$rawMu() {
+		return logProbability$rawMu;
+	}
+
+	// Getter for logProbability$sigma.
+	@Override
+	public final double get$logProbability$sigma() {
+		return logProbability$sigma;
+	}
+
+	// Getter for logProbability$theta.
+	@Override
+	public final double get$logProbability$theta() {
+		return logProbability$theta;
+	}
+
+	// Getter for logProbability$y.
+	@Override
+	public final double get$logProbability$y() {
+		return logProbability$y;
+	}
+
+	// Getter for mu.
+	@Override
+	public final double[] get$mu() {
+		return mu;
+	}
+
+	// Getter for rawMu.
+	@Override
+	public final double[] get$rawMu() {
+		return rawMu;
+	}
+
+	// Setter for rawMu.
+	@Override
+	public final void set$rawMu(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of rawMu including if probabilities need to
+		// be updated.
+		rawMu = cv$value;
+		
+		// Unset the fixed probability flag for sample 20 as it depends on rawMu.
+		fixedProbFlag$sample20 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on rawMu.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for sigma.
+	@Override
+	public final double[] get$sigma() {
+		return sigma;
+	}
+
+	// Setter for sigma.
+	@Override
+	public final void set$sigma(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of sigma including if probabilities need to
+		// be updated.
+		sigma = cv$value;
+		
+		// Unset the fixed probability flag for sample 83 as it depends on sigma.
+		fixedProbFlag$sample83 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on sigma.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for theta.
+	@Override
+	public final double get$theta() {
+		return theta;
+	}
+
+	// Setter for theta.
+	@Override
+	public final void set$theta(double cv$value, boolean allocated$) {
+		// Set flags for all the side effects of theta including if probabilities need to
+		// be updated.
+		theta = cv$value;
+		
+		// Unset the fixed probability flag for sample 88 as it depends on theta.
+		fixedProbFlag$sample88 = false;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on theta.
+		fixedProbFlag$sample101 = false;
+	}
+
+	// Getter for y.
+	@Override
+	public final double[] get$y() {
+		return y;
+	}
+
+	// Getter for yObserved.
+	@Override
+	public final double[] get$yObserved() {
+		return yObserved;
+	}
+
+	// Setter for yObserved.
+	@Override
+	public final void set$yObserved(double[] cv$value, boolean allocated$) {
+		yObserved = cv$value;
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample101
+	private final void drawValueSample101(int var96, int threadID$cv$var96, Rng RNG$) {
+		component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample20
+	private final void drawValueSample20(int var19, int threadID$cv$var19, Rng RNG$) {
+		rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 41.
+		// 
+		// Guard to check that at most one copy of the code is executed for a given set of
+		// loop iterations.
+		boolean guard$sample20put43 = false;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((var19 == 0)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put43 = true;
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(((var19 == 1) && !guard$sample20put43)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put43 = true;
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put43 = true;
+			mu[0] = rawMu[0];
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+			mu[0] = rawMu[1];
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 59.
+		// 
+		// Guard to check that at most one copy of the code is executed for a given set of
+		// loop iterations.
+		boolean guard$sample20put63 = false;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((var19 == 0)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put63 = true;
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((var19 == 1)) {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20put63) {
+				// The body will execute, so should not be executed again
+				guard$sample20put63 = true;
+				double var57;
+				if((rawMu[0] < rawMu[1]))
+					var57 = rawMu[1];
+				else
+					var57 = rawMu[0];
+				mu[1] = var57;
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+				// The body will execute, so should not be executed again
+				guard$sample20put63 = true;
+				mu[1] = rawMu[1];
+			}
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+			mu[1] = rawMu[0];
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample83
+	private final void drawValueSample83(int var78) {
+		sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample88
+	private final void drawValueSample88() {
+		theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 101 drawn from componentDistribution. Inference was performed using
+	// variable marginalization.
+	private final void inferSample101(int var96, int threadID$cv$var96, Rng RNG$) {
+		// Get a local reference to the scratch space.
+		double[] cv$stateProbabilityLocal = cv$var97$stateProbabilityGlobal[threadID$cv$var96];
+		{
+			// Guards to ensure that component is only updated when there is a valid path.
+			// 
+			// Variable declaration of cv$currentValue moved.
+			// Declaration comment was:
+			// The value currently being tested
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			component[var96] = false;
+			
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Variable declaration of cv$currentValue moved.
+			// Declaration comment was:
+			// The value currently being tested
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			double cv$accumulatedProbabilities = (((0.0 <= theta) && (theta <= 1.0))?Math.log((1.0 - theta)):Double.NEGATIVE_INFINITY);
+			
+			// Processing conditional point124.
+			// 
+			// Looking for a path between Sample 101 and consumer double 118.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(component[var96]) {
+				{
+					// Variable declaration of componentSigma moved.
+					double componentSigma = sigma[0];
+					
+					// Constructing a random variable input for use later.
+					double var128 = (componentSigma * componentSigma);
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 138 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Substituted "n" with its value "var96".
+					cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				}
+				
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[0] = false;
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1]))
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					guard$sample20if124[0] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					guard$sample20if124[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124[0]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					guard$sample20if124[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124[1]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					guard$sample20if124[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((rawMu[0] < rawMu[1]) && !guard$sample20if124[0])) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					guard$sample20if124[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124[1])) {
+					// The body will execute, so should not be executed again
+					guard$sample20if124[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				double traceTempVariable$componentSigma$58_1 = sigma[0];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				// 
+				// Substituted "componentMu" with its value "mu[0]".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 83 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Looking for a path between Sample 83 and consumer double 127.
+				// 
+				// Unrolled loop
+				// 
+				// Processing sample task 83 of consumer random variable null.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((((0.0 <= sigma[0]) && (sigma[0] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[0] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			else {
+				{
+					// Variable declaration of componentSigma moved.
+					double componentSigma = sigma[1];
+					
+					// Constructing a random variable input for use later.
+					double var128 = (componentSigma * componentSigma);
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 138 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Substituted "n" with its value "var96".
+					cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				}
+				
+				// Looking for a path between Sample 20 and consumer double 118.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[0] = false;
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1]))
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					guard$sample20if124[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					guard$sample20if124[0] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124[0]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					guard$sample20if124[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124[1]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					guard$sample20if124[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((rawMu[0] < rawMu[1]) && !guard$sample20if124[1])) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					guard$sample20if124[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124[0])) {
+					// The body will execute, so should not be executed again
+					guard$sample20if124[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				double traceTempVariable$componentSigma$63_1 = sigma[1];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				// 
+				// Substituted "componentMu" with its value "mu[1]".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 83 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Processing sample task 83 of consumer random variable null.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((((0.0 <= sigma[1]) && (sigma[1] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[1] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Save the calculated index value into the array of index value probabilities
+			// 
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			cv$stateProbabilityLocal[0] = cv$accumulatedProbabilities;
+		}
+		
+		// Guards to ensure that component is only updated when there is a valid path.
+		// 
+		// Variable declaration of cv$currentValue moved.
+		// Declaration comment was:
+		// The value currently being tested
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		component[var96] = true;
+		
+		// An accumulator to allow the value for each distribution to be constructed before
+		// it is added to the index probabilities.
+		// 
+		// Variable declaration of cv$currentValue moved.
+		// Declaration comment was:
+		// The value currently being tested
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		double cv$accumulatedProbabilities = (((0.0 <= theta) && (theta <= 1.0))?Math.log(theta):Double.NEGATIVE_INFINITY);
+		
+		// Processing conditional point124.
+		// 
+		// Looking for a path between Sample 101 and consumer double 118.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(component[var96]) {
+			{
+				// Variable declaration of componentSigma moved.
+				double componentSigma = sigma[0];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (componentSigma * componentSigma);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Guard to check that at most one copy of the code is executed for a given random
+			// variable instance.
+			boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			guard$sample20if124[0] = false;
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			guard$sample20if124[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((rawMu[0] < rawMu[1]))
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[0] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			else
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124[0]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				guard$sample20if124[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124[1]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				guard$sample20if124[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20if124[0])) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				guard$sample20if124[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124[1])) {
+				// The body will execute, so should not be executed again
+				guard$sample20if124[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			double traceTempVariable$componentSigma$58_1 = sigma[0];
+			
+			// Mark that the sample has observed constrained data.
+			constrainedFlag$sample101[var96] = true;
+			
+			// Constructing a random variable input for use later.
+			double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 138 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Substituted "n" with its value "var96".
+			// 
+			// Substituted "componentMu" with its value "mu[0]".
+			cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 83 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Looking for a path between Sample 83 and consumer double 127.
+			// 
+			// Unrolled loop
+			// 
+			// Processing sample task 83 of consumer random variable null.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Constructing a random variable input for use later.
+			cv$accumulatedProbabilities = ((((0.0 <= sigma[0]) && (sigma[0] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[0] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		else {
+			{
+				// Variable declaration of componentSigma moved.
+				double componentSigma = sigma[1];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (componentSigma * componentSigma);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Looking for a path between Sample 20 and consumer double 118.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given random
+			// variable instance.
+			boolean[] guard$sample20if124 = guard$sample20if124$global[threadID$cv$var96];
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			guard$sample20if124[0] = false;
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			guard$sample20if124[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((rawMu[0] < rawMu[1]))
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			else
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				guard$sample20if124[0] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124[0]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				guard$sample20if124[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124[1]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				guard$sample20if124[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20if124[1])) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				guard$sample20if124[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124[0])) {
+				// The body will execute, so should not be executed again
+				guard$sample20if124[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			double traceTempVariable$componentSigma$63_1 = sigma[1];
+			
+			// Mark that the sample has observed constrained data.
+			constrainedFlag$sample101[var96] = true;
+			
+			// Constructing a random variable input for use later.
+			double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 138 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Substituted "n" with its value "var96".
+			// 
+			// Substituted "componentMu" with its value "mu[1]".
+			cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 83 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Processing sample task 83 of consumer random variable null.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Constructing a random variable input for use later.
+			cv$accumulatedProbabilities = ((((0.0 <= sigma[1]) && (sigma[1] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[1] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+		}
+		
+		// Save the calculated index value into the array of index value probabilities
+		// 
+		// Initialize a log space accumulator to take the product of all the distribution
+		// probabilities.
+		// 
+		// Record the reached probability density.
+		// 
+		// Initialize a counter to track the reached distributions.
+		cv$stateProbabilityLocal[1] = cv$accumulatedProbabilities;
+		if(constrainedFlag$sample101[var96]) {
+			// This value is not used before it is set again, so removing the value declaration.
+			// 
+			// The sum of all the probabilities in log space
+			double cv$logSum;
+			
+			// Sum all the values
+			// 
+			// Initialize the max to the first element.
+			double cv$lseMax = cv$stateProbabilityLocal[0];
+			
+			// Unrolled loop
+			double cv$lseElementValue = cv$stateProbabilityLocal[1];
+			if((cv$lseMax < cv$lseElementValue))
+				cv$lseMax = cv$lseElementValue;
+			
+			// If the maximum value is -infinity return -infinity.
+			if((cv$lseMax == Double.NEGATIVE_INFINITY))
+				cv$logSum = Double.NEGATIVE_INFINITY;
+			
+			// Sum the values in the array.
+			else
+				// Increment the value of the target, moving the value back into log space.
+				// 
+				// The sum of all the probabilities in log space
+				// 
+				// Initialize the sum of the array elements
+				cv$logSum = (Math.log((Math.exp((cv$stateProbabilityLocal[0] - cv$lseMax)) + Math.exp((cv$stateProbabilityLocal[1] - cv$lseMax)))) + cv$lseMax);
+			
+			// If all the sum is zero, just share the probability evenly.
+			if((cv$logSum == Double.NEGATIVE_INFINITY)) {
+				// Unrolled loop
+				// cv$numStates's comment
+				// variable marginalization
+				cv$stateProbabilityLocal[0] = 0.5;
+				
+				// cv$numStates's comment
+				// variable marginalization
+				cv$stateProbabilityLocal[1] = 0.5;
+			} else {
+				// Unrolled loop
+				cv$stateProbabilityLocal[0] = Math.exp((cv$stateProbabilityLocal[0] - cv$logSum));
+				cv$stateProbabilityLocal[1] = Math.exp((cv$stateProbabilityLocal[1] - cv$logSum));
+			}
+			
+			// Set array values that are not computed for the input to negative infinity.
+			// 
+			// cv$numStates's comment
+			// variable marginalization
+			for(int cv$indexName = 2; cv$indexName < cv$stateProbabilityLocal.length; cv$indexName += 1)
+				cv$stateProbabilityLocal[cv$indexName] = Double.NEGATIVE_INFINITY;
+			
+			// Guards to ensure that component is only updated when there is a valid path.
+			// 
+			// Write out the value of the sample to a temporary variable prior to updating the
+			// intermediate variables.
+			// 
+			// cv$numStates's comment
+			// variable marginalization
+			component[var96] = (DistributionSampling.sampleCategorical(RNG$, cv$stateProbabilityLocal, 2) == 1);
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 20 drawn from Gaussian 7. Inference was performed using Metropolis-Hastings.
+	private final void inferSample20(int var19, int threadID$cv$var19, Rng RNG$) {
+		constrainedFlag$sample20[var19] = false;
+		
+		// The original value of the sample
+		double cv$originalValue = rawMu[var19];
+		
+		// This value is not used before it is set again, so removing the value declaration.
+		// 
+		// The probability of the random variable generating the originally sampled value
+		double cv$originalProbability;
+		
+		// Calculate a proposed variance.
+		double cv$var = ((cv$originalValue * cv$originalValue) * 0.010000000000000002);
+		
+		// Ensure the variance is at least 0.01
+		if((cv$var < 0.010000000000000002))
+			cv$var = 0.010000000000000002;
+		
+		// The proposed new value for the sample
+		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+		{
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			// 
+			// Set the current value to the current state of the tree.
+			double cv$accumulatedProbabilities = (DistributionSampling.logProbabilityGaussian((cv$originalValue / 2.0)) - 0.6931471805599453);
+			
+			// Looking for a path between Sample 20 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[0];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Set the current value to the current state of the tree.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 1)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							// 
+							// Set the current value to the current state of the tree.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							// 
+							// Set the current value to the current state of the tree.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[1];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Set the current value to the current state of the tree.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Processing conditional point41.
+			// 
+			// Looking for a path between Sample 20 and consumer double 39.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if41 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if41 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$36_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$36_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$52_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$52_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if41)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$37_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$37_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$53_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$53_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Processing conditional point61.
+			// 
+			// Looking for a path between Sample 20 and consumer double 57.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if61 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if61 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$72_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$72_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$88_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$88_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if61)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$73_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$73_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$89_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$89_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(constrainedFlag$sample20[var19]) {
+			{
+				// Guards to ensure that rawMu is only updated when there is a valid path.
+				rawMu[var19] = cv$proposedValue;
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put43 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((var19 == 1) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					mu[0] = rawMu[0];
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+					mu[0] = rawMu[1];
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put63 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put63 = true;
+					double var57;
+					if((rawMu[0] < rawMu[1]))
+						var57 = rawMu[1];
+					else
+						var57 = rawMu[0];
+					mu[1] = var57;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 1)) {
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						double var57;
+						if((rawMu[0] < rawMu[1]))
+							var57 = rawMu[1];
+						else
+							var57 = rawMu[0];
+						mu[1] = var57;
+					}
+					
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						mu[1] = rawMu[1];
+					}
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+					mu[1] = rawMu[0];
+			}
+			
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			double cv$accumulatedProbabilities = (DistributionSampling.logProbabilityGaussian((cv$proposedValue / 2.0)) - 0.6931471805599453);
+			
+			// Looking for a path between Sample 20 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[0];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 1)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[1];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Processing conditional point41.
+			// 
+			// Looking for a path between Sample 20 and consumer double 39.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if41 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if41 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$36_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$36_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$52_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$52_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if41)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$37_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$37_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$53_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$53_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Processing conditional point61.
+			// 
+			// Looking for a path between Sample 20 and consumer double 57.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if61 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if61 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$72_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$72_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$88_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$88_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if61)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$73_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$73_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$89_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$89_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// The probability ration for the proposed value and the current value.
+			// 
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			double cv$ratio = (cv$accumulatedProbabilities - cv$originalProbability);
+			
+			// Test if the probability of the sample is sufficient to keep the value. This needs
+			// to be less than or equal as otherwise if the proposed value is not possible and
+			// the random value is 0 an impossible value will be accepted.
+			if(((cv$ratio <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN(cv$ratio))) {
+				// If it is not revert the changes.
+				// 
+				// Set the sample value
+				// Guards to ensure that rawMu is only updated when there is a valid path.
+				// 
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				rawMu[var19] = cv$originalValue;
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put43 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((var19 == 1) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					mu[0] = rawMu[0];
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+					mu[0] = rawMu[1];
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put63 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put63 = true;
+					double var57;
+					if((rawMu[0] < rawMu[1]))
+						var57 = rawMu[1];
+					else
+						var57 = rawMu[0];
+					mu[1] = var57;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 1)) {
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						double var57;
+						if((rawMu[0] < rawMu[1]))
+							var57 = rawMu[1];
+						else
+							var57 = rawMu[0];
+						mu[1] = var57;
+					}
+					
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						mu[1] = rawMu[1];
+					}
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+					mu[1] = rawMu[0];
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 83 drawn from TruncatedGaussian 66. Inference was performed using
+	// Metropolis-Hastings.
+	private final void inferSample83(int var78) {
+		constrainedFlag$sample83[var78] = false;
+		
+		// The original value of the sample
+		double cv$originalValue = sigma[var78];
+		
+		// This value is not used before it is set again, so removing the value declaration.
+		// 
+		// The probability of the random variable generating the originally sampled value
+		double cv$originalProbability;
+		
+		// Calculate a proposed variance.
+		double cv$var = ((cv$originalValue * cv$originalValue) * 0.010000000000000002);
+		
+		// Ensure the variance is at least 0.01
+		if((cv$var < 0.010000000000000002))
+			cv$var = 0.010000000000000002;
+		
+		// The proposed new value for the sample
+		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+		{
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			// 
+			// Set the current value to the current state of the tree.
+			double cv$accumulatedProbabilities = (((0.0 <= cv$originalValue) && (cv$originalValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$originalValue / 2.0)):Double.NEGATIVE_INFINITY);
+			
+			// Looking for a path between Sample 83 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 0)) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[0] = true;
+						
+						// Constructing a random variable input for use later.
+						// 
+						// Set the current value to the current state of the tree.
+						double var128 = (cv$originalValue * cv$originalValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[0]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 1)) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[1] = true;
+						
+						// Constructing a random variable input for use later.
+						// 
+						// Set the current value to the current state of the tree.
+						double var128 = (cv$originalValue * cv$originalValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[1]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(constrainedFlag$sample83[var78]) {
+			// Guards to ensure that sigma is only updated when there is a valid path.
+			sigma[var78] = cv$proposedValue;
+			
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			double cv$accumulatedProbabilities = (((0.0 <= cv$proposedValue) && (cv$proposedValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$proposedValue / 2.0)):Double.NEGATIVE_INFINITY);
+			
+			// Looking for a path between Sample 83 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 0)) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[0] = true;
+						
+						// Constructing a random variable input for use later.
+						double var128 = (cv$proposedValue * cv$proposedValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[0]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 1)) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[1] = true;
+						
+						// Constructing a random variable input for use later.
+						double var128 = (cv$proposedValue * cv$proposedValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[1]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// The probability ration for the proposed value and the current value.
+			// 
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			double cv$ratio = (cv$accumulatedProbabilities - cv$originalProbability);
+			
+			// Test if the probability of the sample is sufficient to keep the value. This needs
+			// to be less than or equal as otherwise if the proposed value is not possible and
+			// the random value is 0 an impossible value will be accepted.
+			if(((cv$ratio <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN(cv$ratio)))
+				// If it is not revert the changes.
+				// 
+				// Set the sample value
+				// 
+				// Guards to ensure that sigma is only updated when there is a valid path.
+				// 
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				sigma[var78] = cv$originalValue;
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 88 drawn from Beta 83. Inference was performed using a Beta to Bernoulli/Binomial
+	// conjugate prior.
+	private final void inferSample88() {
+		constrainedFlag$sample88 = false;
+		
+		// Local variable to record the number of true samples.
+		int cv$sum = 0;
+		
+		// Local variable to record the number of samples.
+		int cv$count = 0;
+		
+		// Processing random variable 85.
+		// 
+		// Processing sample task 101 of consumer random variable componentDistribution.
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((fixedFlag$sample101 || constrainedFlag$sample101[var96])) {
+				// Mark that the sample has observed constrained data.
+				constrainedFlag$sample88 = true;
+				
+				// Include the value sampled by task 101 from random variable componentDistribution.
+				// 
+				// Increment the number of samples.
+				cv$count = (cv$count + 1);
+				
+				// If the sample value was positive increase the count
+				if(component[var96])
+					cv$sum = (cv$sum + 1);
+			}
+		}
+		if(constrainedFlag$sample88)
+			// Write out the new value of the sample.
+			theta = Conjugates.sampleConjugateBetaBinomial(RNG$, 5.0, 5.0, cv$sum, cv$count);
+	}
+
+	// Calculate the probability of the samples represented by sample101 using sampled
+	// values.
+	private final void logProbabilityValue$sample101() {
+		// Determine if we need to calculate the values for sample task 101 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample101) {
+			// Generating probabilities for sample task
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1) {
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= theta) && (theta <= 1.0))?Math.log((component[var96]?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(cv$sampleReached) {
+				logProbability$componentDistribution = cv$sampleAccumulator;
+				
+				// Store the random variable instance probability
+				logProbability$var97 = cv$sampleAccumulator;
+			}
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$component = (logProbability$component + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedFlag$sample88);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			if((0 < N))
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+			if(cv$sampleReached)
+				logProbability$componentDistribution = logProbability$var97;
+			
+			// Update the variable probability
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$component = (logProbability$component + logProbability$var97);
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$var97);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				// Variable declaration of cv$accumulator moved.
+				logProbability$$evidence = (logProbability$$evidence + logProbability$var97);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample138 using sampled
+	// values.
+	private final void logProbabilityValue$sample138() {
+		// Determine if we need to calculate the values for sample task 138 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample138) {
+			// Generating probabilities for sample task
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1) {
+				double componentMu;
+				if(component[n])
+					componentMu = mu[0];
+				else
+					componentMu = mu[1];
+				double componentSigma;
+				if(component[n])
+					componentSigma = sigma[0];
+				else
+					componentSigma = sigma[1];
+				double var128 = (componentSigma * componentSigma);
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				cv$sampleAccumulator = (cv$sampleAccumulator + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY));
+			}
+			
+			// Only update the sample if it was reached, otherwise the NaN will be
+			// erroneously over written.
+			if(cv$sampleReached)
+				// Store the random variable instance probability
+				// 
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$var130 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$y = (logProbability$y + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample138 = ((fixedFlag$sample20 && fixedFlag$sample83) && fixedFlag$sample101);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// Update the variable probability
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$y = (logProbability$y + logProbability$var130);
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$var130);
+			
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$evidence = (logProbability$$evidence + logProbability$var130);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample20 using sampled
+	// values.
+	private final void logProbabilityValue$sample20() {
+		// Determine if we need to calculate the values for sample task 20 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample20) {
+			// Generating probabilities for sample task
+			// This value is not used before it is set again, so removing the value declaration.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator;
+			{
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				double cv$weightedProbability = (DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) - 0.6931471805599453);
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				cv$sampleAccumulator = cv$weightedProbability;
+				
+				// Store the sample task probability
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				logProbability$sample20[0] = cv$weightedProbability;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					// Set the guard so the update is only applied once.
+					cv$guard$mu = true;
+					
+					// Update the variable probability
+					// 
+					// Scale the probability relative to the observed distribution space.
+					// 
+					// Add the probability of this distribution configuration to the accumulator.
+					// 
+					// An accumulator for the distributed probability space covered.
+					logProbability$mu = (logProbability$mu + cv$weightedProbability);
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !cv$guard$mu))
+					// Update the variable probability
+					// 
+					// Scale the probability relative to the observed distribution space.
+					// 
+					// Add the probability of this distribution configuration to the accumulator.
+					// 
+					// An accumulator for the distributed probability space covered.
+					logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			}
+			
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$weightedProbability = (DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) - 0.6931471805599453);
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$weightedProbability);
+			
+			// Store the sample task probability
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			logProbability$sample20[1] = cv$weightedProbability;
+			
+			// Guard to ensure that mu is only updated once for this probability.
+			boolean cv$guard$mu = false;
+			
+			// Add probability to constructed variables that have guards, so need per sample probabilities
+			// from the combined probability
+			// 
+			// Looking for a path between Sample 20 and consumer double[] 41.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Guard to ensure that mu is only updated once for this probability.
+			if(!(rawMu[0] < rawMu[1])) {
+				// Set the guard so the update is only applied once.
+				cv$guard$mu = true;
+				
+				// Update the variable probability
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			}
+			
+			// Looking for a path between Sample 20 and consumer double[] 59.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !cv$guard$mu))
+				// Update the variable probability
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$rawMu = (logProbability$rawMu + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample20 = fixedFlag$sample20;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// This value is not used before it is set again, so removing the value declaration.
+			double cv$rvAccumulator;
+			{
+				double cv$sampleValue = logProbability$sample20[0];
+				cv$rvAccumulator = cv$sampleValue;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					// Set the guard so the update is only applied once.
+					cv$guard$mu = true;
+					
+					// Update the variable probability
+					logProbability$mu = (logProbability$mu + cv$sampleValue);
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !cv$guard$mu))
+					// Update the variable probability
+					logProbability$mu = (logProbability$mu + cv$sampleValue);
+			}
+			double cv$sampleValue = logProbability$sample20[1];
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			
+			// Guard to ensure that mu is only updated once for this probability.
+			boolean cv$guard$mu = false;
+			
+			// Add probability to constructed variables that have guards, so need per sample probabilities
+			// from the combined probability
+			// 
+			// Looking for a path between Sample 20 and consumer double[] 41.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Guard to ensure that mu is only updated once for this probability.
+			if(!(rawMu[0] < rawMu[1])) {
+				// Set the guard so the update is only applied once.
+				cv$guard$mu = true;
+				
+				// Update the variable probability
+				logProbability$mu = (logProbability$mu + cv$sampleValue);
+			}
+			
+			// Looking for a path between Sample 20 and consumer double[] 59.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !cv$guard$mu))
+				// Update the variable probability
+				logProbability$mu = (logProbability$mu + cv$sampleValue);
+			
+			// Update the variable probability
+			logProbability$rawMu = (logProbability$rawMu + cv$rvAccumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$rvAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$rvAccumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample83 using sampled
+	// values.
+	private final void logProbabilityValue$sample83() {
+		// Determine if we need to calculate the values for sample task 83 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample83) {
+			// Generating probabilities for sample task
+			// This value is not used before it is set again, so removing the value declaration.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = sigma[0];
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				cv$sampleAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$sampleValue / 2.0)):Double.NEGATIVE_INFINITY);
+			}
+			
+			// The sample value to calculate the probability of generating
+			double cv$sampleValue = sigma[1];
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$sampleValue / 2.0)):Double.NEGATIVE_INFINITY));
+			
+			// Store the random variable instance probability
+			logProbability$var79 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$sigma = (logProbability$sigma + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample83 = fixedFlag$sample83;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// Update the variable probability
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$sigma = (logProbability$sigma + logProbability$var79);
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$var79);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				// Variable declaration of cv$accumulator moved.
+				logProbability$$evidence = (logProbability$$evidence + logProbability$var79);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample88 using sampled
+	// values.
+	private final void logProbabilityValue$sample88() {
+		// Determine if we need to calculate the values for sample task 88 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample88) {
+			// Generating probabilities for sample task
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(theta, 5.0, 5.0);
+			
+			// Store the sample task probability
+			logProbability$theta = cv$distributionAccumulator;
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			// Declaration comment was:
+			// Accumulator for probabilities of instances of the random variable
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				// Variable declaration of cv$accumulator moved.
+				// Declaration comment was:
+				// Accumulator for probabilities of instances of the random variable
+				// 
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				// 
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				logProbability$$evidence = (logProbability$$evidence + cv$distributionAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample88 = fixedFlag$sample88;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$theta);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				// Variable declaration of cv$accumulator moved.
+				logProbability$$evidence = (logProbability$$evidence + logProbability$theta);
+		}
+	}
+
+	// Method to allocate space temporary variables used by the inference methods. Allocating
+	// here prevents repeated allocation and deallocation, and makes the code more amenable
+	// to GPU execution.
+	@Override
+	public final void allocateScratch() {
+		// Allocate scratch space.
+		// Constructor for cv$var97$stateProbabilityGlobal
+		{
+			// Allocation of cv$var97$stateProbabilityGlobal for multithreaded execution
+			// Get the thread count.
+			int cv$threadCount = threadCount();
+			
+			// Allocate an array to hold a copy per thread
+			cv$var97$stateProbabilityGlobal = new double[cv$threadCount][];
+			
+			// Populate the array with a copy per thread
+			for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
+				cv$var97$stateProbabilityGlobal[cv$index] = new double[2];
+		}
+		
+		// Allocation of guard$sample20if124$global for multithreaded execution
+		// 
+		// Get the thread count.
+		int cv$threadCount = threadCount();
+		
+		// Allocate an array to hold a copy per thread
+		guard$sample20if124$global = new boolean[cv$threadCount][];
+		
+		// Populate the array with a copy per thread
+		for(int cv$index = 0; cv$index < cv$threadCount; cv$index += 1)
+			guard$sample20if124$global[cv$index] = new boolean[2];
+	}
+
+	// Method to allocate space for model inputs and outputs.
+	@Override
+	public final void allocator() {
+		// If rawMu has not been set already allocate space.
+		if(!fixedFlag$sample20)
+			// Constructor for rawMu
+			rawMu = new double[2];
+		
+		// Constructor for mu
+		mu = new double[2];
+		
+		// If sigma has not been set already allocate space.
+		if(!fixedFlag$sample83)
+			// Constructor for sigma
+			sigma = new double[2];
+		
+		// If component has not been set already allocate space.
+		if(!fixedFlag$sample101)
+			// Constructor for component
+			component = new boolean[length$yObserved];
+		
+		// Constructor for y
+		y = new double[length$yObserved];
+		
+		// Constructor for constrainedFlag$sample101
+		constrainedFlag$sample101 = new boolean[length$yObserved];
+		
+		// Constructor for constrainedFlag$sample20
+		constrainedFlag$sample20 = new boolean[2];
+		
+		// Constructor for constrainedFlag$sample83
+		constrainedFlag$sample83 = new boolean[2];
+		
+		// Constructor for logProbability$sample20
+		logProbability$sample20 = new double[2];
+		
+		// Allocate scratch space
+		allocateScratch();
+	}
+
+	// Method to execute the model code conventionally.
+	@Override
+	public final void forwardGeneration() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$n, int forEnd$n, int threadID$n, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int n = forStart$n; n < forEnd$n; n += 1) {
+						double componentMu;
+						if(component[n])
+							componentMu = mu[0];
+						else
+							componentMu = mu[1];
+						double componentSigma;
+						if(component[n])
+							componentSigma = sigma[0];
+						else
+							componentSigma = sigma[1];
+						y[n] = ((componentSigma * DistributionSampling.sampleGaussian(RNG$1)) + componentMu);
+					}
+			}
+		);
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are calculated
+	// and stored.
+	@Override
+	public final void forwardGenerationDistributionsNoOutputsPrime() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+	}
+
+	// Method to execute the model code conventionally with priming of fixed intermediate
+	// variables.
+	@Override
+	public final void forwardGenerationPrime() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$n, int forEnd$n, int threadID$n, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int n = forStart$n; n < forEnd$n; n += 1) {
+						double componentMu;
+						if(component[n])
+							componentMu = mu[0];
+						else
+							componentMu = mu[1];
+						double componentSigma;
+						if(component[n])
+							componentSigma = sigma[0];
+						else
+							componentSigma = sigma[1];
+						y[n] = ((componentSigma * DistributionSampling.sampleGaussian(RNG$1)) + componentMu);
+					}
+			}
+		);
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Distributions are collapsed to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputs() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are collapsed
+	// to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputsPrime() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+							rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$1) * 2.0);
+				}
+			);
+
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, 2, 1,
+				(int forStart$var78, int forEnd$var78, int threadID$var78, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var78 = forStart$var78; var78 < forEnd$var78; var78 += 1)
+							sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$1, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+				}
+			);
+
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101)
+			//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+			parallelFor(RNG$, 0, N, 1,
+				(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+					
+						// Inner loop for running batches of iterations, each batch has its own random number
+						// generator.
+						for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+							component[var96] = DistributionSampling.sampleBernoulli(RNG$1, theta);
+				}
+			);
+
+	}
+
+	// Method to execute one round of Gibbs sampling.
+	@Override
+	public final void gibbsRound() {
+		// Infer the samples in chronological order.
+		if(system$gibbsForward) {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample20)
+				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+				parallelFor(RNG$, 0, 2, 1,
+					(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+						
+							// Inner loop for running batches of iterations, each batch has its own random number
+							// generator.
+							for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+								inferSample20(var19, threadID$var19, RNG$1);
+					}
+				);
+
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample83) {
+				inferSample83(0);
+				inferSample83(1);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample101)
+				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+				parallelFor(RNG$, 0, N, 1,
+					(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+						
+							// Inner loop for running batches of iterations, each batch has its own random number
+							// generator.
+							for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+								inferSample101(var96, threadID$var96, RNG$1);
+					}
+				);
+
+		}
+		// Infer the samples in reverse chronological order.
+		else {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample101)
+				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+				parallelFor(RNG$, 0, N, 1,
+					(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+						
+							// Inner loop for running batches of iterations, each batch has its own random number
+							// generator.
+							for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1)
+								inferSample101(var96, threadID$var96, RNG$1);
+					}
+				);
+
+			if(!fixedFlag$sample88)
+				inferSample88();
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample83) {
+				inferSample83(1);
+				inferSample83(0);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample20)
+				//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+				parallelFor(RNG$, 0, 2, 1,
+					(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+						
+							// Inner loop for running batches of iterations, each batch has its own random number
+							// generator.
+							for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1)
+								inferSample20(var19, threadID$var19, RNG$1);
+					}
+				);
+
+		}
+		
+		// Reverse the direction of execution for the next iteration
+		system$gibbsForward = !system$gibbsForward;
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, 2, 1,
+			(int forStart$var19, int forEnd$var19, int threadID$var19, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var19 = forStart$var19; var19 < forEnd$var19; var19 += 1) {
+						if(!constrainedFlag$sample20[var19])
+							drawValueSample20(var19, threadID$var19, RNG$1);
+					}
+			}
+		);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!constrainedFlag$sample83[0])
+			drawValueSample83(0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!constrainedFlag$sample83[1])
+			drawValueSample83(1);
+		if(!constrainedFlag$sample88)
+			drawValueSample88();
+		
+		//  Outer loop for dispatching multiple batches of iterations to execute in parallel
+		parallelFor(RNG$, 0, N, 1,
+			(int forStart$var96, int forEnd$var96, int threadID$var96, org.sandwood.random.internal.Rng RNG$1) -> { 
+				
+					// Inner loop for running batches of iterations, each batch has its own random number
+					// generator.
+					for(int var96 = forStart$var96; var96 < forEnd$var96; var96 += 1) {
+						if(!constrainedFlag$sample101[var96])
+							drawValueSample101(var96, threadID$var96, RNG$1);
+					}
+			}
+		);
+	}
+
+	// A method to initialize all the probabilities in the model to 0/Log(1) ready for
+	// the current probabilities to be calculated by calculating the probability of each
+	// sample task, and its effect on the rest of the model.
+	private final void initializeLogProbabilityFields() {
+		// Set the probabilities of the random variable, and the model as a whole to ready
+		// them to be reconstructed by the probability calls for each sample. Sample probabilities
+		// are only reset for samples that are not fixed at a value that has already been
+		// calculated.
+		logProbability$$model = 0.0;
+		logProbability$$evidence = 0.0;
+		logProbability$rawMu = 0.0;
+		logProbability$mu = 0.0;
+		if(!fixedProbFlag$sample20) {
+			// Unrolled loop
+			logProbability$sample20[0] = Double.NaN;
+			logProbability$sample20[1] = Double.NaN;
+		}
+		logProbability$sigma = 0.0;
+		if(!fixedProbFlag$sample83)
+			logProbability$var79 = Double.NaN;
+		if(!fixedProbFlag$sample88)
+			logProbability$theta = Double.NaN;
+		logProbability$componentDistribution = Double.NaN;
+		logProbability$component = 0.0;
+		if(!fixedProbFlag$sample101)
+			logProbability$var97 = Double.NaN;
+		logProbability$y = 0.0;
+		if(!fixedProbFlag$sample138)
+			logProbability$var130 = Double.NaN;
+	}
+
+	// Method for initializing the model into a valid state before commencing inference
+	// etc.
+	@Override
+	public final void initializeModel() {
+		N = length$yObserved;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+			constrainedFlag$sample101[index$constrainedFlag$sample101$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+			constrainedFlag$sample20[index$constrainedFlag$sample20$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+			constrainedFlag$sample83[index$constrainedFlag$sample83$1] = true;
+	}
+
+	// Construct the evidence probabilities.
+	@Override
+	public final void logEvidenceProbabilities() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Call each method in turn to generate the new probability values.
+		if(fixedFlag$sample20)
+			logProbabilityValue$sample20();
+		if(fixedFlag$sample83)
+			logProbabilityValue$sample83();
+		if(fixedFlag$sample88)
+			logProbabilityValue$sample88();
+		if(fixedFlag$sample101)
+			logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model uses distributions
+	// when possible.
+	@Override
+	public final void logModelProbabilitiesDist() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model only uses values.
+	@Override
+	public final void logModelProbabilitiesVal() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to propagate observed values back into the model.
+	@Override
+	public final void propagateObservedValues() {
+		// Propagating values back from observations into the models intermediate variables.
+		// 
+		// Deep copy between arrays
+		int cv$length1 = y.length;
+		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1)
+			y[cv$index1] = yObserved[cv$index1];
+	}
+
+	// A method to set array values that depend on the output of a sample task, but are
+	// not directly set by the sample task. This method is called to propagate set values
+	// through the model. Any non-fixed sample values may be sampled to random variables
+	// as part of this process.
+	@Override
+	public final void setIntermediates() {
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+	}
+
+	@Override
+	public String modelCode() {
+		return "/*\n"
+		     + " * Sandwood\n"
+		     + " *\n"
+		     + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+		     + " * \n"
+		     + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+		     + " */\n"
+		     + "\n"
+		     + "package org.sandwood.compiler.tests.parser;\n"
+		     + "\n"
+		     + "public model LowDimMix(double[] yObserved) {\n"
+		     + "    int N = yObserved.length;\n"
+		     + "\n"
+		     + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+		     + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+		     + "    // the constant normalisation factor for the ordered constraint.\n"
+		     + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+		     + "    double[] mu = new double[2];\n"
+		     + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+		     + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+		     + "\n"
+		     + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+		     + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+		     + "\n"
+		     + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+		     + "    double theta = beta(5.0, 5.0).sample();\n"
+		     + "\n"
+		     + "    // Stan likelihood:\n"
+		     + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+		     + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+		     + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+		     + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+		     + "    boolean[] component = componentDistribution.sample(N);\n"
+		     + "    double[] y = new double[N];\n"
+		     + "\n"
+		     + "    for(int n = 0; n < N; n++) {\n"
+		     + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+		     + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+		     + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+		     + "    }\n"
+		     + "\n"
+		     + "    y.observe(yObserved);\n"
+		     + "}\n"
+		     + "";
+	}
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$SingleThreadCPU_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$SingleThreadCPU_model.java
@@ -1,0 +1,7288 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.runtime.internal.numericTools.Conjugates;
+import org.sandwood.runtime.internal.numericTools.DistributionSampling;
+import org.sandwood.runtime.internal.numericTools.Gaussian;
+import org.sandwood.runtime.model.ExecutionTarget;
+
+final class LowDimMix$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements LowDimMix$CoreInterface {
+	
+	// Declare the variables for the model.
+	private int N;
+	private boolean[] component;
+	private boolean[] constrainedFlag$sample101;
+	private boolean[] constrainedFlag$sample20;
+	private boolean[] constrainedFlag$sample83;
+	private boolean constrainedFlag$sample88 = true;
+	private double[] cv$var97$stateProbabilityGlobal;
+	private boolean fixedFlag$sample101 = false;
+	private boolean fixedFlag$sample20 = false;
+	private boolean fixedFlag$sample83 = false;
+	private boolean fixedFlag$sample88 = false;
+	private boolean fixedProbFlag$sample101 = false;
+	private boolean fixedProbFlag$sample138 = false;
+	private boolean fixedProbFlag$sample20 = false;
+	private boolean fixedProbFlag$sample83 = false;
+	private boolean fixedProbFlag$sample88 = false;
+	private boolean[] guard$sample20if124$global;
+	private int length$yObserved;
+	private double logProbability$$evidence;
+	private double logProbability$$model;
+	private double logProbability$component;
+	private double logProbability$componentDistribution;
+	private double logProbability$mu;
+	private double logProbability$rawMu;
+	private double[] logProbability$sample138;
+	private double[] logProbability$sample20;
+	private double logProbability$sigma;
+	private double logProbability$theta;
+	private double logProbability$var79;
+	private double logProbability$var97;
+	private double logProbability$y;
+	private double[] mu;
+	private double[] rawMu;
+	private double[] sigma;
+	private boolean system$gibbsForward = true;
+	private double theta;
+	private double[] y;
+	private double[] yObserved;
+
+	public LowDimMix$SingleThreadCPU(ExecutionTarget target) {
+		super(target);
+	}
+
+	// Getter for N.
+	@Override
+	public final int get$N() {
+		return N;
+	}
+
+	// Getter for component.
+	@Override
+	public final boolean[] get$component() {
+		return component;
+	}
+
+	// Setter for component.
+	@Override
+	public final void set$component(boolean[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of component including if probabilities need
+		// to be updated.
+		component = cv$value;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on component.
+		fixedProbFlag$sample101 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on component.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for fixedFlag$sample101.
+	@Override
+	public final boolean get$fixedFlag$sample101() {
+		return fixedFlag$sample101;
+	}
+
+	// Setter for fixedFlag$sample101.
+	@Override
+	public final void set$fixedFlag$sample101(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample101 including if probabilities
+		// need to be updated.
+		fixedFlag$sample101 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+				constrainedFlag$sample101[index$constrainedFlag$sample101$1] = fixedFlag$sample101;
+		}
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedProbFlag$sample101);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample138 = (fixedFlag$sample101 && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample20.
+	@Override
+	public final boolean get$fixedFlag$sample20() {
+		return fixedFlag$sample20;
+	}
+
+	// Setter for fixedFlag$sample20.
+	@Override
+	public final void set$fixedFlag$sample20(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample20 including if probabilities
+		// need to be updated.
+		fixedFlag$sample20 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+				constrainedFlag$sample20[index$constrainedFlag$sample20$1] = fixedFlag$sample20;
+		}
+		
+		// Should the probability of sample 20 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample20 = (fixedFlag$sample20 && fixedProbFlag$sample20);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample138 = (fixedFlag$sample20 && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample83.
+	@Override
+	public final boolean get$fixedFlag$sample83() {
+		return fixedFlag$sample83;
+	}
+
+	// Setter for fixedFlag$sample83.
+	@Override
+	public final void set$fixedFlag$sample83(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample83 including if probabilities
+		// need to be updated.
+		fixedFlag$sample83 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+				constrainedFlag$sample83[index$constrainedFlag$sample83$1] = fixedFlag$sample83;
+		}
+		
+		// Should the probability of sample 83 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample83 = (fixedFlag$sample83 && fixedProbFlag$sample83);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample138 = (fixedFlag$sample83 && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample88.
+	@Override
+	public final boolean get$fixedFlag$sample88() {
+		return fixedFlag$sample88;
+	}
+
+	// Setter for fixedFlag$sample88.
+	@Override
+	public final void set$fixedFlag$sample88(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample88 including if probabilities
+		// need to be updated.
+		fixedFlag$sample88 = cv$value;
+		constrainedFlag$sample88 = (fixedFlag$sample88 || constrainedFlag$sample88);
+		
+		// Should the probability of sample 88 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample88 = (fixedFlag$sample88 && fixedProbFlag$sample88);
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample101 = (fixedFlag$sample88 && fixedProbFlag$sample101);
+	}
+
+	// Getter for length$yObserved.
+	@Override
+	public final int get$length$yObserved() {
+		return length$yObserved;
+	}
+
+	// Setter for length$yObserved.
+	@Override
+	public final void set$length$yObserved(int cv$value, boolean allocated$) {
+		length$yObserved = cv$value;
+	}
+
+	// Getter for logProbability$$evidence.
+	@Override
+	public final double get$logProbability$$evidence() {
+		return logProbability$$evidence;
+	}
+
+	// Getter for the probability of logProbability$$model.
+	@Override
+	public final double getCurrentLogProbability() {
+		return logProbability$$model;
+	}
+
+	// Getter for logProbability$component.
+	@Override
+	public final double get$logProbability$component() {
+		return logProbability$component;
+	}
+
+	// Getter for logProbability$componentDistribution.
+	@Override
+	public final double get$logProbability$componentDistribution() {
+		return logProbability$componentDistribution;
+	}
+
+	// Getter for logProbability$mu.
+	@Override
+	public final double get$logProbability$mu() {
+		return logProbability$mu;
+	}
+
+	// Getter for logProbability$rawMu.
+	@Override
+	public final double get$logProbability$rawMu() {
+		return logProbability$rawMu;
+	}
+
+	// Getter for logProbability$sigma.
+	@Override
+	public final double get$logProbability$sigma() {
+		return logProbability$sigma;
+	}
+
+	// Getter for logProbability$theta.
+	@Override
+	public final double get$logProbability$theta() {
+		return logProbability$theta;
+	}
+
+	// Getter for logProbability$y.
+	@Override
+	public final double get$logProbability$y() {
+		return logProbability$y;
+	}
+
+	// Getter for mu.
+	@Override
+	public final double[] get$mu() {
+		return mu;
+	}
+
+	// Getter for rawMu.
+	@Override
+	public final double[] get$rawMu() {
+		return rawMu;
+	}
+
+	// Setter for rawMu.
+	@Override
+	public final void set$rawMu(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of rawMu including if probabilities need to
+		// be updated.
+		rawMu = cv$value;
+		
+		// Unset the fixed probability flag for sample 20 as it depends on rawMu.
+		fixedProbFlag$sample20 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on rawMu.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for sigma.
+	@Override
+	public final double[] get$sigma() {
+		return sigma;
+	}
+
+	// Setter for sigma.
+	@Override
+	public final void set$sigma(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of sigma including if probabilities need to
+		// be updated.
+		sigma = cv$value;
+		
+		// Unset the fixed probability flag for sample 83 as it depends on sigma.
+		fixedProbFlag$sample83 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on sigma.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for theta.
+	@Override
+	public final double get$theta() {
+		return theta;
+	}
+
+	// Setter for theta.
+	@Override
+	public final void set$theta(double cv$value, boolean allocated$) {
+		// Set flags for all the side effects of theta including if probabilities need to
+		// be updated.
+		theta = cv$value;
+		
+		// Unset the fixed probability flag for sample 88 as it depends on theta.
+		fixedProbFlag$sample88 = false;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on theta.
+		fixedProbFlag$sample101 = false;
+	}
+
+	// Getter for y.
+	@Override
+	public final double[] get$y() {
+		return y;
+	}
+
+	// Getter for yObserved.
+	@Override
+	public final double[] get$yObserved() {
+		return yObserved;
+	}
+
+	// Setter for yObserved.
+	@Override
+	public final void set$yObserved(double[] cv$value, boolean allocated$) {
+		yObserved = cv$value;
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample101
+	private final void drawValueSample101(int var96) {
+		component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample20
+	private final void drawValueSample20(int var19) {
+		rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 41.
+		{
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20put43 = false;
+			{
+				if((var19 == 0)) {
+					if(!guard$sample20put43) {
+						// The body will execute, so should not be executed again
+						guard$sample20put43 = true;
+						{
+							double var39;
+							if((rawMu[0] < rawMu[1]))
+								var39 = rawMu[0];
+							else
+								var39 = rawMu[1];
+							mu[0] = var39;
+						}
+					}
+				}
+			}
+			{
+				if((var19 == 1)) {
+					if(!guard$sample20put43) {
+						// The body will execute, so should not be executed again
+						guard$sample20put43 = true;
+						{
+							double var39;
+							if((rawMu[0] < rawMu[1]))
+								var39 = rawMu[0];
+							else
+								var39 = rawMu[1];
+							mu[0] = var39;
+						}
+					}
+				}
+			}
+			{
+				if((rawMu[0] < rawMu[1])) {
+					if((var19 == 0)) {
+						if((rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put43) {
+								// The body will execute, so should not be executed again
+								guard$sample20put43 = true;
+								{
+									double var39;
+									if((rawMu[0] < rawMu[1]))
+										var39 = rawMu[0];
+									else
+										var39 = rawMu[1];
+									mu[0] = var39;
+								}
+							}
+						}
+					}
+				}
+			}
+			{
+				if(!(rawMu[0] < rawMu[1])) {
+					if((var19 == 1)) {
+						if(!(rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put43) {
+								// The body will execute, so should not be executed again
+								guard$sample20put43 = true;
+								{
+									double var39;
+									if((rawMu[0] < rawMu[1]))
+										var39 = rawMu[0];
+									else
+										var39 = rawMu[1];
+									mu[0] = var39;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 59.
+		{
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20put63 = false;
+			{
+				if((var19 == 0)) {
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						{
+							double var57;
+							if((rawMu[0] < rawMu[1]))
+								var57 = rawMu[1];
+							else
+								var57 = rawMu[0];
+							mu[1] = var57;
+						}
+					}
+				}
+			}
+			{
+				if((var19 == 1)) {
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						{
+							double var57;
+							if((rawMu[0] < rawMu[1]))
+								var57 = rawMu[1];
+							else
+								var57 = rawMu[0];
+							mu[1] = var57;
+						}
+					}
+				}
+			}
+			{
+				if((rawMu[0] < rawMu[1])) {
+					if((var19 == 1)) {
+						if((rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put63) {
+								// The body will execute, so should not be executed again
+								guard$sample20put63 = true;
+								{
+									double var57;
+									if((rawMu[0] < rawMu[1]))
+										var57 = rawMu[1];
+									else
+										var57 = rawMu[0];
+									mu[1] = var57;
+								}
+							}
+						}
+					}
+				}
+			}
+			{
+				if(!(rawMu[0] < rawMu[1])) {
+					if((var19 == 0)) {
+						if(!(rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put63) {
+								// The body will execute, so should not be executed again
+								guard$sample20put63 = true;
+								{
+									double var57;
+									if((rawMu[0] < rawMu[1]))
+										var57 = rawMu[1];
+									else
+										var57 = rawMu[0];
+									mu[1] = var57;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample83
+	private final void drawValueSample83(int var78) {
+		sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample88
+	private final void drawValueSample88() {
+		theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 101 drawn from componentDistribution. Inference was performed using
+	// variable marginalization.
+	private final void inferSample101(int var96) {
+		if(true) {
+			constrainedFlag$sample101[((var96 - 0) / 1)] = false;
+			
+			// Calculate the number of states to evaluate.
+			int cv$numStates = 0;
+			{
+				// variable marginalization
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			
+			// Get a local reference to the scratch space.
+			double[] cv$stateProbabilityLocal = cv$var97$stateProbabilityGlobal;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				// Initialize the summed probabilities to 0.
+				double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+				
+				// Initialize a counter to track the reached distributions.
+				double cv$reachedDistributionSourceRV = 0.0;
+				
+				// Initialize a log space accumulator to take the product of all the distribution
+				// probabilities.
+				double cv$accumulatedDistributionProbabilities = 0.0;
+				
+				// The value currently being tested
+				boolean cv$currentValue;
+				
+				// Value of the variable at this index
+				cv$currentValue = (cv$valuePos == 1);
+				
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				boolean var97 = cv$currentValue;
+				
+				// Guards to ensure that component is only updated when there is a valid path.
+				{
+					{
+						{
+							component[var96] = cv$currentValue;
+						}
+					}
+				}
+				{
+					// Record the reached probability density.
+					cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+					
+					// An accumulator to allow the value for each distribution to be constructed before
+					// it is added to the index probabilities.
+					double cv$accumulatedProbabilities = (Math.log(1.0) + (((0.0 <= theta) && (theta <= 1.0))?Math.log((cv$currentValue?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+					
+					// Processing conditional point124.
+					{
+						// Looking for a path between Sample 101 and consumer double 118.
+						{
+							{
+								for(int n = 0; n < N; n += 1) {
+									if((var96 == n)) {
+										{
+											{
+												{
+													if(component[n]) {
+														double traceTempVariable$componentMu$3_1 = mu[0];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentSigma;
+																							if(component[n])
+																								componentSigma = sigma[0];
+																							else
+																								componentSigma = sigma[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (componentSigma * componentSigma);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 20 and consumer double 118.
+											{
+												// Guard to check that at most one copy of the code is executed for a given random
+												// variable instance.
+												boolean[] guard$sample20if124 = guard$sample20if124$global;
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													if(!component[n]) {
+														double traceTempVariable$componentMu$30_1 = mu[1];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentSigma;
+																							if(component[n])
+																								componentSigma = sigma[0];
+																							else
+																								componentSigma = sigma[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (componentSigma * componentSigma);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 20 and consumer double 118.
+											{
+												// Guard to check that at most one copy of the code is executed for a given random
+												// variable instance.
+												boolean[] guard$sample20if124 = guard$sample20if124$global;
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					
+					// Processing conditional point135.
+					{
+						// Looking for a path between Sample 101 and consumer double 127.
+						{
+							{
+								for(int n = 0; n < N; n += 1) {
+									if((var96 == n)) {
+										{
+											{
+												{
+													if(component[n]) {
+														double traceTempVariable$componentSigma$58_1 = sigma[0];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentMu;
+																							if(component[n])
+																								componentMu = mu[0];
+																							else
+																								componentMu = mu[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 83 and consumer double 127.
+											{
+												{
+													for(int var78 = 0; var78 < 2; var78 += 1) {
+														if(component[n]) {
+															if((var78 == 0)) {
+																if(component[n]) {
+																	// Processing sample task 83 of consumer random variable null.
+																	{
+																		{
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							// Constructing a random variable input for use later.
+																							double var63 = (2.0 * 2.0);
+																							
+																							// Record the probability of sample task 83 generating output with current configuration.
+																							if(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 83 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													if(!component[n]) {
+														double traceTempVariable$componentSigma$63_1 = sigma[1];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentMu;
+																							if(component[n])
+																								componentMu = mu[0];
+																							else
+																								componentMu = mu[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 83 and consumer double 127.
+											{
+												{
+													for(int var78 = 0; var78 < 2; var78 += 1) {
+														if(!component[n]) {
+															if((var78 == 1)) {
+																if(!component[n]) {
+																	// Processing sample task 83 of consumer random variable null.
+																	{
+																		{
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							// Constructing a random variable input for use later.
+																							double var63 = (2.0 * 2.0);
+																							
+																							// Record the probability of sample task 83 generating output with current configuration.
+																							if(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 83 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					
+					// Add the values for the source and any standard consumers for this configuration
+					// of arguments to the source.
+					if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+						cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+					else {
+						// If the second value is -infinity.
+						if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+							cv$stateProbabilityValue = cv$accumulatedProbabilities;
+						else
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+					}
+				}
+				
+				// Save the calculated index value into the array of index value probabilities
+				cv$stateProbabilityLocal[cv$valuePos] = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+			}
+			if(constrainedFlag$sample101[((var96 - 0) / 1)]) {
+				// The sum of all the probabilities in log space
+				double cv$logSum = 0.0;
+				
+				// Sum all the values
+				{
+					// Initialize the max to the first element.
+					double cv$lseMax = cv$stateProbabilityLocal[0];
+					
+					// Find max value.
+					for(int cv$lseIndex = 1; cv$lseIndex < cv$numStates; cv$lseIndex += 1) {
+						double cv$lseElementValue = cv$stateProbabilityLocal[cv$lseIndex];
+						if((cv$lseMax < cv$lseElementValue))
+							cv$lseMax = cv$lseElementValue;
+					}
+					
+					// If the maximum value is -infinity return -infinity.
+					if((cv$lseMax == Double.NEGATIVE_INFINITY))
+						cv$logSum = Double.NEGATIVE_INFINITY;
+					
+					// Sum the values in the array.
+					else {
+						// Initialize the sum of the array elements
+						double cv$lseSum = 0.0;
+						
+						// Offset values, move to normal space, and sum.
+						for(int cv$lseIndex = 0; cv$lseIndex < cv$numStates; cv$lseIndex += 1)
+							cv$lseSum = (cv$lseSum + Math.exp((cv$stateProbabilityLocal[cv$lseIndex] - cv$lseMax)));
+						
+						// Increment the value of the target, moving the value back into log space.
+						cv$logSum = (cv$logSum + (Math.log(cv$lseSum) + cv$lseMax));
+					}
+				}
+				
+				// If all the sum is zero, just share the probability evenly.
+				if((cv$logSum == Double.NEGATIVE_INFINITY)) {
+					// Normalize log space values and move to normal space
+					for(int cv$indexName = 0; cv$indexName < cv$numStates; cv$indexName += 1)
+						cv$stateProbabilityLocal[cv$indexName] = (1.0 / cv$numStates);
+				} else {
+					// Normalize log space values and move to normal space
+					for(int cv$indexName = 0; cv$indexName < cv$numStates; cv$indexName += 1)
+						cv$stateProbabilityLocal[cv$indexName] = Math.exp((cv$stateProbabilityLocal[cv$indexName] - cv$logSum));
+				}
+				
+				// Set array values that are not computed for the input to negative infinity.
+				for(int cv$indexName = cv$numStates; cv$indexName < cv$stateProbabilityLocal.length; cv$indexName += 1)
+					cv$stateProbabilityLocal[cv$indexName] = Double.NEGATIVE_INFINITY;
+				
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				boolean var97 = (DistributionSampling.sampleCategorical(RNG$, cv$stateProbabilityLocal, cv$numStates) == 1);
+				
+				// Guards to ensure that component is only updated when there is a valid path.
+				{
+					{
+						{
+							component[var96] = var97;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 20 drawn from Gaussian 7. Inference was performed using Metropolis-Hastings.
+	private final void inferSample20(int var19) {
+		if(true) {
+			constrainedFlag$sample20[((var19 - 0) / 1)] = false;
+			
+			// Calculate the number of states to evaluate.
+			int cv$numStates = 0;
+			{
+				// Metropolis-Hastings
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			
+			// The original value of the sample
+			double cv$originalValue = rawMu[var19];
+			
+			// The probability of the random variable generating the originally sampled value
+			double cv$originalProbability = 0.0;
+			
+			// Calculate a proposed variance.
+			double cv$var = ((cv$originalValue * cv$originalValue) * (0.1 * 0.1));
+			
+			// Ensure the variance is at least 0.01
+			if((cv$var < (0.1 * 0.1)))
+				cv$var = (0.1 * 0.1);
+			
+			// The proposed new value for the sample
+			double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+			
+			// The probability of the random variable generating the new sample value.
+			double cv$proposedProbability = 0.0;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				if((constrainedFlag$sample20[((var19 - 0) / 1)] || (cv$valuePos == 0))) {
+					// Initialize the summed probabilities to 0.
+					double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+					
+					// Initialize a counter to track the reached distributions.
+					double cv$reachedDistributionSourceRV = 0.0;
+					
+					// Initialize a log space accumulator to take the product of all the distribution
+					// probabilities.
+					double cv$accumulatedDistributionProbabilities = 0.0;
+					
+					// The value currently being tested
+					double cv$currentValue;
+					if((cv$valuePos == 0))
+						// Set the current value to the current state of the tree.
+						cv$currentValue = cv$originalValue;
+					else {
+						cv$currentValue = cv$proposedValue;
+						
+						// Update Sample and intermediate values
+						// 
+						// Write out the value of the sample to a temporary variable prior to updating the
+						// intermediate variables.
+						double var20 = cv$proposedValue;
+						
+						// Guards to ensure that rawMu is only updated when there is a valid path.
+						{
+							{
+								{
+									rawMu[var19] = cv$currentValue;
+								}
+							}
+						}
+						
+						// Guards to ensure that mu is only updated when there is a valid path.
+						// 
+						// Looking for a path between Sample 20 and consumer double[] 41.
+						{
+							// Guard to check that at most one copy of the code is executed for a given set of
+							// loop iterations.
+							boolean guard$sample20put43 = false;
+							{
+								if((var19 == 0)) {
+									if(!guard$sample20put43) {
+										// The body will execute, so should not be executed again
+										guard$sample20put43 = true;
+										{
+											double var39;
+											if((rawMu[0] < rawMu[1]))
+												var39 = rawMu[0];
+											else
+												var39 = rawMu[1];
+											mu[0] = var39;
+										}
+									}
+								}
+							}
+							{
+								if((var19 == 1)) {
+									if(!guard$sample20put43) {
+										// The body will execute, so should not be executed again
+										guard$sample20put43 = true;
+										{
+											double var39;
+											if((rawMu[0] < rawMu[1]))
+												var39 = rawMu[0];
+											else
+												var39 = rawMu[1];
+											mu[0] = var39;
+										}
+									}
+								}
+							}
+							{
+								if((rawMu[0] < rawMu[1])) {
+									if((var19 == 0)) {
+										if((rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put43) {
+												// The body will execute, so should not be executed again
+												guard$sample20put43 = true;
+												{
+													double var39;
+													if((rawMu[0] < rawMu[1]))
+														var39 = rawMu[0];
+													else
+														var39 = rawMu[1];
+													mu[0] = var39;
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								if(!(rawMu[0] < rawMu[1])) {
+									if((var19 == 1)) {
+										if(!(rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put43) {
+												// The body will execute, so should not be executed again
+												guard$sample20put43 = true;
+												{
+													double var39;
+													if((rawMu[0] < rawMu[1]))
+														var39 = rawMu[0];
+													else
+														var39 = rawMu[1];
+													mu[0] = var39;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Guards to ensure that mu is only updated when there is a valid path.
+						// 
+						// Looking for a path between Sample 20 and consumer double[] 59.
+						{
+							// Guard to check that at most one copy of the code is executed for a given set of
+							// loop iterations.
+							boolean guard$sample20put63 = false;
+							{
+								if((var19 == 0)) {
+									if(!guard$sample20put63) {
+										// The body will execute, so should not be executed again
+										guard$sample20put63 = true;
+										{
+											double var57;
+											if((rawMu[0] < rawMu[1]))
+												var57 = rawMu[1];
+											else
+												var57 = rawMu[0];
+											mu[1] = var57;
+										}
+									}
+								}
+							}
+							{
+								if((var19 == 1)) {
+									if(!guard$sample20put63) {
+										// The body will execute, so should not be executed again
+										guard$sample20put63 = true;
+										{
+											double var57;
+											if((rawMu[0] < rawMu[1]))
+												var57 = rawMu[1];
+											else
+												var57 = rawMu[0];
+											mu[1] = var57;
+										}
+									}
+								}
+							}
+							{
+								if((rawMu[0] < rawMu[1])) {
+									if((var19 == 1)) {
+										if((rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put63) {
+												// The body will execute, so should not be executed again
+												guard$sample20put63 = true;
+												{
+													double var57;
+													if((rawMu[0] < rawMu[1]))
+														var57 = rawMu[1];
+													else
+														var57 = rawMu[0];
+													mu[1] = var57;
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								if(!(rawMu[0] < rawMu[1])) {
+									if((var19 == 0)) {
+										if(!(rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put63) {
+												// The body will execute, so should not be executed again
+												guard$sample20put63 = true;
+												{
+													double var57;
+													if((rawMu[0] < rawMu[1]))
+														var57 = rawMu[1];
+													else
+														var57 = rawMu[0];
+													mu[1] = var57;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					{
+						// Record the reached probability density.
+						cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+						
+						// Constructing a random variable input for use later.
+						double var6 = (2.0 * 2.0);
+						
+						// An accumulator to allow the value for each distribution to be constructed before
+						// it is added to the index probabilities.
+						double cv$accumulatedProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((cv$currentValue - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+						
+						// Processing random variable 129.
+						{
+							// Looking for a path between Sample 20 and consumer Gaussian 129.
+							{
+								{
+									double traceTempVariable$var36$10_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$10_2 = traceTempVariable$var36$10_1;
+												double traceTempVariable$var115$10_3 = traceTempVariable$var39$10_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((0 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$10_5 = traceTempVariable$var115$10_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var36$11_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$11_2 = traceTempVariable$var36$11_1;
+												double traceTempVariable$var117$11_3 = traceTempVariable$var39$11_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((0 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$11_5 = traceTempVariable$var117$11_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var38$12_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$12_2 = traceTempVariable$var38$12_1;
+												double traceTempVariable$var115$12_3 = traceTempVariable$var39$12_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((0 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$12_5 = traceTempVariable$var115$12_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var38$13_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$13_2 = traceTempVariable$var38$13_1;
+												double traceTempVariable$var117$13_3 = traceTempVariable$var39$13_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((0 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$13_5 = traceTempVariable$var117$13_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var54$14_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$14_2 = traceTempVariable$var54$14_1;
+												double traceTempVariable$var115$14_3 = traceTempVariable$var57$14_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((1 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$14_5 = traceTempVariable$var115$14_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var54$15_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$15_2 = traceTempVariable$var54$15_1;
+												double traceTempVariable$var117$15_3 = traceTempVariable$var57$15_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((1 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$15_5 = traceTempVariable$var117$15_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var56$16_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$16_2 = traceTempVariable$var56$16_1;
+												double traceTempVariable$var115$16_3 = traceTempVariable$var57$16_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((1 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$16_5 = traceTempVariable$var115$16_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var56$17_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$17_2 = traceTempVariable$var56$17_1;
+												double traceTempVariable$var117$17_3 = traceTempVariable$var57$17_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((1 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$17_5 = traceTempVariable$var117$17_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Processing conditional point41.
+						{
+							// Looking for a path between Sample 20 and consumer double 39.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20if41 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20if41) {
+											// The body will execute, so should not be executed again
+											guard$sample20if41 = true;
+											{
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$36_1 = rawMu[0];
+															double traceTempVariable$var115$36_2 = traceTempVariable$var39$36_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$36_4 = traceTempVariable$var115$36_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$38_1 = rawMu[0];
+															double traceTempVariable$var117$38_2 = traceTempVariable$var39$38_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$38_4 = traceTempVariable$var117$38_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$48_1 = 0; index$var19$48_1 < 2; index$var19$48_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$48_1 == 0)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$52_1 = rawMu[1];
+															double traceTempVariable$var115$52_2 = traceTempVariable$var39$52_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$52_4 = traceTempVariable$var115$52_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$54_1 = rawMu[1];
+															double traceTempVariable$var117$54_2 = traceTempVariable$var39$54_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$54_4 = traceTempVariable$var117$54_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$64_1 = 0; index$var19$64_1 < 2; index$var19$64_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$64_1 == 1)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20if41) {
+											// The body will execute, so should not be executed again
+											guard$sample20if41 = true;
+											{
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$37_1 = rawMu[0];
+															double traceTempVariable$var115$37_2 = traceTempVariable$var39$37_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$37_4 = traceTempVariable$var115$37_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$39_1 = rawMu[0];
+															double traceTempVariable$var117$39_2 = traceTempVariable$var39$39_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$39_4 = traceTempVariable$var117$39_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$49_1 = 0; index$var19$49_1 < 2; index$var19$49_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$49_1 == 0)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$53_1 = rawMu[1];
+															double traceTempVariable$var115$53_2 = traceTempVariable$var39$53_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$53_4 = traceTempVariable$var115$53_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$55_1 = rawMu[1];
+															double traceTempVariable$var117$55_2 = traceTempVariable$var39$55_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$55_4 = traceTempVariable$var117$55_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$65_1 = 0; index$var19$65_1 < 2; index$var19$65_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$65_1 == 1)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Processing conditional point61.
+						{
+							// Looking for a path between Sample 20 and consumer double 57.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20if61 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20if61) {
+											// The body will execute, so should not be executed again
+											guard$sample20if61 = true;
+											{
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$70_1 = rawMu[1];
+															double traceTempVariable$var115$70_2 = traceTempVariable$var57$70_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$70_4 = traceTempVariable$var115$70_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$72_1 = rawMu[1];
+															double traceTempVariable$var117$72_2 = traceTempVariable$var57$72_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$72_4 = traceTempVariable$var117$72_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$82_1 = 0; index$var19$82_1 < 2; index$var19$82_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$82_1 == 1)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$86_1 = rawMu[0];
+															double traceTempVariable$var115$86_2 = traceTempVariable$var57$86_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$86_4 = traceTempVariable$var115$86_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$88_1 = rawMu[0];
+															double traceTempVariable$var117$88_2 = traceTempVariable$var57$88_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$88_4 = traceTempVariable$var117$88_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$98_1 = 0; index$var19$98_1 < 2; index$var19$98_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$98_1 == 0)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20if61) {
+											// The body will execute, so should not be executed again
+											guard$sample20if61 = true;
+											{
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$71_1 = rawMu[1];
+															double traceTempVariable$var115$71_2 = traceTempVariable$var57$71_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$71_4 = traceTempVariable$var115$71_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$73_1 = rawMu[1];
+															double traceTempVariable$var117$73_2 = traceTempVariable$var57$73_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$73_4 = traceTempVariable$var117$73_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$83_1 = 0; index$var19$83_1 < 2; index$var19$83_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$83_1 == 1)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$87_1 = rawMu[0];
+															double traceTempVariable$var115$87_2 = traceTempVariable$var57$87_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$87_4 = traceTempVariable$var115$87_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$89_1 = rawMu[0];
+															double traceTempVariable$var117$89_2 = traceTempVariable$var57$89_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$89_4 = traceTempVariable$var117$89_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$99_1 = 0; index$var19$99_1 < 2; index$var19$99_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$99_1 == 0)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Add the values for the source and any standard consumers for this configuration
+						// of arguments to the source.
+						if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+						else {
+							// If the second value is -infinity.
+							if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+								cv$stateProbabilityValue = cv$accumulatedProbabilities;
+							else
+								cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// Save the probability of the original value.
+					if((cv$valuePos == 0))
+						cv$originalProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// Save the probability of the proposed value.
+					else
+						cv$proposedProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// The probability ration for the proposed value and the current value.
+					double cv$ratio = (cv$proposedProbability - cv$originalProbability);
+					
+					// Test if the probability of the sample is sufficient to keep the value. This needs
+					// to be less than or equal as otherwise if the proposed value is not possible and
+					// the random value is 0 an impossible value will be accepted.
+					if((cv$valuePos == 1)) {
+						if(((cv$ratio <= Math.log((0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$))))) || Double.isNaN(cv$ratio))) {
+							// If it is not revert the changes.
+							// 
+							// Set the sample value
+							// Write out the value of the sample to a temporary variable prior to updating the
+							// intermediate variables.
+							double var20 = cv$originalValue;
+							
+							// Guards to ensure that rawMu is only updated when there is a valid path.
+							{
+								{
+									{
+										rawMu[var19] = var20;
+									}
+								}
+							}
+							
+							// Guards to ensure that mu is only updated when there is a valid path.
+							// 
+							// Looking for a path between Sample 20 and consumer double[] 41.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20put43 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20put43) {
+											// The body will execute, so should not be executed again
+											guard$sample20put43 = true;
+											{
+												double var39;
+												if((rawMu[0] < rawMu[1]))
+													var39 = rawMu[0];
+												else
+													var39 = rawMu[1];
+												mu[0] = var39;
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20put43) {
+											// The body will execute, so should not be executed again
+											guard$sample20put43 = true;
+											{
+												double var39;
+												if((rawMu[0] < rawMu[1]))
+													var39 = rawMu[0];
+												else
+													var39 = rawMu[1];
+												mu[0] = var39;
+											}
+										}
+									}
+								}
+								{
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put43) {
+													// The body will execute, so should not be executed again
+													guard$sample20put43 = true;
+													{
+														double var39;
+														if((rawMu[0] < rawMu[1]))
+															var39 = rawMu[0];
+														else
+															var39 = rawMu[1];
+														mu[0] = var39;
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put43) {
+													// The body will execute, so should not be executed again
+													guard$sample20put43 = true;
+													{
+														double var39;
+														if((rawMu[0] < rawMu[1]))
+															var39 = rawMu[0];
+														else
+															var39 = rawMu[1];
+														mu[0] = var39;
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+							
+							// Guards to ensure that mu is only updated when there is a valid path.
+							// 
+							// Looking for a path between Sample 20 and consumer double[] 59.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20put63 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20put63) {
+											// The body will execute, so should not be executed again
+											guard$sample20put63 = true;
+											{
+												double var57;
+												if((rawMu[0] < rawMu[1]))
+													var57 = rawMu[1];
+												else
+													var57 = rawMu[0];
+												mu[1] = var57;
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20put63) {
+											// The body will execute, so should not be executed again
+											guard$sample20put63 = true;
+											{
+												double var57;
+												if((rawMu[0] < rawMu[1]))
+													var57 = rawMu[1];
+												else
+													var57 = rawMu[0];
+												mu[1] = var57;
+											}
+										}
+									}
+								}
+								{
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put63) {
+													// The body will execute, so should not be executed again
+													guard$sample20put63 = true;
+													{
+														double var57;
+														if((rawMu[0] < rawMu[1]))
+															var57 = rawMu[1];
+														else
+															var57 = rawMu[0];
+														mu[1] = var57;
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put63) {
+													// The body will execute, so should not be executed again
+													guard$sample20put63 = true;
+													{
+														double var57;
+														if((rawMu[0] < rawMu[1]))
+															var57 = rawMu[1];
+														else
+															var57 = rawMu[0];
+														mu[1] = var57;
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 83 drawn from TruncatedGaussian 66. Inference was performed using
+	// Metropolis-Hastings.
+	private final void inferSample83(int var78) {
+		if(true) {
+			constrainedFlag$sample83[((var78 - 0) / 1)] = false;
+			
+			// Calculate the number of states to evaluate.
+			int cv$numStates = 0;
+			{
+				// Metropolis-Hastings
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			
+			// The original value of the sample
+			double cv$originalValue = sigma[var78];
+			
+			// The probability of the random variable generating the originally sampled value
+			double cv$originalProbability = 0.0;
+			
+			// Calculate a proposed variance.
+			double cv$var = ((cv$originalValue * cv$originalValue) * (0.1 * 0.1));
+			
+			// Ensure the variance is at least 0.01
+			if((cv$var < (0.1 * 0.1)))
+				cv$var = (0.1 * 0.1);
+			
+			// The proposed new value for the sample
+			double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+			
+			// The probability of the random variable generating the new sample value.
+			double cv$proposedProbability = 0.0;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				if((constrainedFlag$sample83[((var78 - 0) / 1)] || (cv$valuePos == 0))) {
+					// Initialize the summed probabilities to 0.
+					double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+					
+					// Initialize a counter to track the reached distributions.
+					double cv$reachedDistributionSourceRV = 0.0;
+					
+					// Initialize a log space accumulator to take the product of all the distribution
+					// probabilities.
+					double cv$accumulatedDistributionProbabilities = 0.0;
+					
+					// The value currently being tested
+					double cv$currentValue;
+					if((cv$valuePos == 0))
+						// Set the current value to the current state of the tree.
+						cv$currentValue = cv$originalValue;
+					else {
+						cv$currentValue = cv$proposedValue;
+						
+						// Update Sample and intermediate values
+						// 
+						// Write out the value of the sample to a temporary variable prior to updating the
+						// intermediate variables.
+						double var79 = cv$proposedValue;
+						
+						// Guards to ensure that sigma is only updated when there is a valid path.
+						{
+							{
+								{
+									sigma[var78] = cv$currentValue;
+								}
+							}
+						}
+					}
+					{
+						// Record the reached probability density.
+						cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+						
+						// Constructing a random variable input for use later.
+						double var63 = (2.0 * 2.0);
+						
+						// An accumulator to allow the value for each distribution to be constructed before
+						// it is added to the index probabilities.
+						double cv$accumulatedProbabilities = (Math.log(1.0) + (((((0.0 <= cv$currentValue) && (cv$currentValue <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((cv$currentValue - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+						
+						// Processing random variable 129.
+						{
+							// Looking for a path between Sample 83 and consumer Gaussian 129.
+							{
+								{
+									double traceTempVariable$var124$2_1 = cv$currentValue;
+									for(int n = 0; n < N; n += 1) {
+										if(component[n]) {
+											if((var78 == 0)) {
+												if(component[n]) {
+													double traceTempVariable$componentSigma$2_3 = traceTempVariable$var124$2_1;
+													
+													// Processing sample task 138 of consumer random variable null.
+													{
+														{
+															// Flag recording if this sample task of the consuming random variable is constrained.
+															boolean cv$sampleConstrained = true;
+															if(cv$sampleConstrained) {
+																// Mark that the sample has observed constrained data.
+																constrainedFlag$sample83[((var78 - 0) / 1)] = true;
+																
+																// Set an accumulator to sum the probabilities for each possible configuration of
+																// inputs.
+																double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																
+																// Set an accumulator to record the consumer distributions not seen. Initially set
+																// to 1 as seen values will be deducted from this value.
+																double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																{
+																	{
+																		{
+																			{
+																				{
+																					double componentMu;
+																					if(component[n])
+																						componentMu = mu[0];
+																					else
+																						componentMu = mu[1];
+																					
+																					// Constructing a random variable input for use later.
+																					double var128 = (traceTempVariable$componentSigma$2_3 * traceTempVariable$componentSigma$2_3);
+																					
+																					// Record the probability of sample task 138 generating output with current configuration.
+																					if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																						else
+																							cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																					}
+																					
+																					// Recorded the probability of reaching sample task 138 with the current configuration.
+																					cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																				}
+																			}
+																		}
+																	}
+																}
+																
+																// A check to ensure rounding of floating point values can never result in a negative
+																// value.
+																cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																
+																// Multiply (log space add) in the probability of the sample task to the overall probability
+																// for this configuration of the source random variable.
+																if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																	cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																else {
+																	// If the second value is -infinity.
+																	if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																		cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																	else
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var126$3_1 = cv$currentValue;
+									for(int n = 0; n < N; n += 1) {
+										if(!component[n]) {
+											if((var78 == 1)) {
+												if(!component[n]) {
+													double traceTempVariable$componentSigma$3_3 = traceTempVariable$var126$3_1;
+													
+													// Processing sample task 138 of consumer random variable null.
+													{
+														{
+															// Flag recording if this sample task of the consuming random variable is constrained.
+															boolean cv$sampleConstrained = true;
+															if(cv$sampleConstrained) {
+																// Mark that the sample has observed constrained data.
+																constrainedFlag$sample83[((var78 - 0) / 1)] = true;
+																
+																// Set an accumulator to sum the probabilities for each possible configuration of
+																// inputs.
+																double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																
+																// Set an accumulator to record the consumer distributions not seen. Initially set
+																// to 1 as seen values will be deducted from this value.
+																double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																{
+																	{
+																		{
+																			{
+																				{
+																					double componentMu;
+																					if(component[n])
+																						componentMu = mu[0];
+																					else
+																						componentMu = mu[1];
+																					
+																					// Constructing a random variable input for use later.
+																					double var128 = (traceTempVariable$componentSigma$3_3 * traceTempVariable$componentSigma$3_3);
+																					
+																					// Record the probability of sample task 138 generating output with current configuration.
+																					if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																						else
+																							cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																					}
+																					
+																					// Recorded the probability of reaching sample task 138 with the current configuration.
+																					cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																				}
+																			}
+																		}
+																	}
+																}
+																
+																// A check to ensure rounding of floating point values can never result in a negative
+																// value.
+																cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																
+																// Multiply (log space add) in the probability of the sample task to the overall probability
+																// for this configuration of the source random variable.
+																if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																	cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																else {
+																	// If the second value is -infinity.
+																	if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																		cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																	else
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Add the values for the source and any standard consumers for this configuration
+						// of arguments to the source.
+						if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+						else {
+							// If the second value is -infinity.
+							if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+								cv$stateProbabilityValue = cv$accumulatedProbabilities;
+							else
+								cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// Save the probability of the original value.
+					if((cv$valuePos == 0))
+						cv$originalProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// Save the probability of the proposed value.
+					else
+						cv$proposedProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// The probability ration for the proposed value and the current value.
+					double cv$ratio = (cv$proposedProbability - cv$originalProbability);
+					
+					// Test if the probability of the sample is sufficient to keep the value. This needs
+					// to be less than or equal as otherwise if the proposed value is not possible and
+					// the random value is 0 an impossible value will be accepted.
+					if((cv$valuePos == 1)) {
+						if(((cv$ratio <= Math.log((0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$))))) || Double.isNaN(cv$ratio))) {
+							// If it is not revert the changes.
+							// 
+							// Set the sample value
+							// Write out the value of the sample to a temporary variable prior to updating the
+							// intermediate variables.
+							double var79 = cv$originalValue;
+							
+							// Guards to ensure that sigma is only updated when there is a valid path.
+							{
+								{
+									{
+										sigma[var78] = var79;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 88 drawn from Beta 83. Inference was performed using a Beta to Bernoulli/Binomial
+	// conjugate prior.
+	private final void inferSample88() {
+		if(true) {
+			constrainedFlag$sample88 = false;
+			
+			// Local variable to record the number of true samples.
+			int cv$sum = 0;
+			
+			// Local variable to record the number of samples.
+			int cv$count = 0;
+			{
+				// Processing random variable 85.
+				{
+					{
+						{
+							// Processing sample task 101 of consumer random variable componentDistribution.
+							{
+								{
+									for(int var96 = 0; var96 < N; var96 += 1) {
+										// Flag recording if this sample task of the consuming random variable is constrained.
+										boolean cv$sampleConstrained = (fixedFlag$sample101 || constrainedFlag$sample101[((var96 - 0) / 1)]);
+										if(cv$sampleConstrained) {
+											// Mark that the sample has observed constrained data.
+											constrainedFlag$sample88 = true;
+											{
+												{
+													{
+														{
+															{
+																// Include the value sampled by task 101 from random variable componentDistribution.
+																// Increment the number of samples.
+																cv$count = (cv$count + 1);
+																
+																// If the sample value was positive increase the count
+																if(component[var96])
+																	cv$sum = (cv$sum + 1);
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			if(constrainedFlag$sample88)
+				// Write out the new value of the sample.
+				theta = Conjugates.sampleConjugateBetaBinomial(RNG$, 5.0, 5.0, cv$sum, cv$count);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample101 using sampled
+	// values.
+	private final void logProbabilityValue$sample101() {
+		// Determine if we need to calculate the values for sample task 101 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample101) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						boolean cv$sampleValue = component[var96];
+						{
+							{
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= theta) && (theta <= 1.0))?Math.log((cv$sampleValue?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$componentDistribution = cv$sampleAccumulator;
+			
+			// Store the random variable instance probability
+			logProbability$var97 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			logProbability$component = (logProbability$component + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedFlag$sample88);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1)
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var97;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			logProbability$componentDistribution = cv$rvAccumulator;
+			
+			// Update the variable probability
+			logProbability$component = (logProbability$component + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample138 using sampled
+	// values.
+	private final void logProbabilityValue$sample138() {
+		// Determine if we need to calculate the values for sample task 138 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample138) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1) {
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				double cv$sampleAccumulator = 0.0;
+				
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						double cv$sampleValue = y[n];
+						{
+							{
+								double componentMu;
+								if(component[n])
+									componentMu = mu[0];
+								else
+									componentMu = mu[1];
+								double componentSigma;
+								if(component[n])
+									componentSigma = sigma[0];
+								else
+									componentSigma = sigma[1];
+								double var128 = (componentSigma * componentSigma);
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+				
+				// Store the sample task probability
+				logProbability$sample138[((n - 0) / 1)] = cv$sampleProbability;
+			}
+			
+			// Update the variable probability
+			logProbability$y = (logProbability$y + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample138 = ((fixedFlag$sample20 && fixedFlag$sample83) && fixedFlag$sample101);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1) {
+				double cv$rvAccumulator = 0.0;
+				double cv$sampleValue = logProbability$sample138[((n - 0) / 1)];
+				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			}
+			
+			// Update the variable probability
+			logProbability$y = (logProbability$y + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample20 using sampled
+	// values.
+	private final void logProbabilityValue$sample20() {
+		// Determine if we need to calculate the values for sample task 20 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample20) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						double cv$sampleValue = rawMu[var19];
+						{
+							{
+								double var3 = 0.0;
+								double var6 = (2.0 * 2.0);
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var3) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+								
+								// Looking for a path between Put 21 and consumer double 39.
+								{
+									// Guard to check that at most one copy of the code is executed for a given set of
+									// loop iterations.
+									boolean guard$put21if41 = false;
+									{
+										if((var19 == 0)) {
+											if(!guard$put21if41)
+												// The body will execute, so should not be executed again
+												guard$put21if41 = true;
+										}
+									}
+									{
+										if((var19 == 1)) {
+											if(!guard$put21if41)
+												// The body will execute, so should not be executed again
+												guard$put21if41 = true;
+										}
+									}
+								}
+								
+								// Looking for a path between Put 21 and consumer double 57.
+								{
+									// Guard to check that at most one copy of the code is executed for a given set of
+									// loop iterations.
+									boolean guard$put21if61 = false;
+									{
+										if((var19 == 0)) {
+											if(!guard$put21if61)
+												// The body will execute, so should not be executed again
+												guard$put21if61 = true;
+										}
+									}
+									{
+										if((var19 == 1)) {
+											if(!guard$put21if61)
+												// The body will execute, so should not be executed again
+												guard$put21if61 = true;
+										}
+									}
+								}
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				
+				// Store the sample task probability
+				logProbability$sample20[((var19 - 0) / 1)] = cv$sampleProbability;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Update the variable probability
+			logProbability$rawMu = (logProbability$rawMu + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample20 = fixedFlag$sample20;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				double cv$sampleValue = logProbability$sample20[((var19 - 0) / 1)];
+				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Update the variable probability
+			logProbability$rawMu = (logProbability$rawMu + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample83 using sampled
+	// values.
+	private final void logProbabilityValue$sample83() {
+		// Determine if we need to calculate the values for sample task 83 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample83) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var78 = 0; var78 < 2; var78 += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						double cv$sampleValue = sigma[var78];
+						{
+							{
+								double var60 = 0.0;
+								double var63 = (2.0 * 2.0);
+								double var64 = 0.0;
+								double var65 = 1.0E100;
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + (((((var64 <= cv$sampleValue) && (cv$sampleValue <= var65)) && (var64 < var65)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var60) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((var65 - var60) / Math.sqrt(var63))) - Gaussian.cdf(((var64 - var60) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Store the random variable instance probability
+			logProbability$var79 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			logProbability$sigma = (logProbability$sigma + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample83 = fixedFlag$sample83;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var78 = 0; var78 < 2; var78 += 1)
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var79;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Update the variable probability
+			logProbability$sigma = (logProbability$sigma + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample88 using sampled
+	// values.
+	private final void logProbabilityValue$sample88() {
+		// Determine if we need to calculate the values for sample task 88 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample88) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				{
+					// The sample value to calculate the probability of generating
+					double cv$sampleValue = theta;
+					{
+						{
+							double var81 = 5.0;
+							double var82 = 5.0;
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var81, var82));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						}
+					}
+				}
+			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Store the sample task probability
+			logProbability$theta = cv$sampleProbability;
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample88 = fixedFlag$sample88;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			double cv$sampleValue = logProbability$theta;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Method to allocate space temporary variables used by the inference methods. Allocating
+	// here prevents repeated allocation and deallocation, and makes the code more amenable
+	// to GPU execution.
+	@Override
+	public final void allocateScratch() {
+		// Allocate scratch space.
+		// Constructor for cv$var97$stateProbabilityGlobal
+		{
+			// Allocation of cv$var97$stateProbabilityGlobal for single threaded execution
+			cv$var97$stateProbabilityGlobal = new double[2];
+		}
+		
+		// Constructor for guard$sample20if124$global
+		{
+			// Calculate the largest index of var19 that is possible and allocate an array to
+			// hold the guard for each of these.
+			int cv$max_var19 = 0;
+			cv$max_var19 = Math.max(cv$max_var19, ((2 - 0) / 1));
+			
+			// Allocation of guard$sample20if124$global for single threaded execution
+			guard$sample20if124$global = new boolean[cv$max_var19];
+		}
+	}
+
+	// Method to allocate space for model inputs and outputs.
+	@Override
+	public final void allocator() {
+		// If rawMu has not been set already allocate space.
+		if(!fixedFlag$sample20) {
+			// Constructor for rawMu
+			{
+				rawMu = new double[2];
+			}
+		}
+		
+		// Constructor for mu
+		{
+			mu = new double[2];
+		}
+		
+		// If sigma has not been set already allocate space.
+		if(!fixedFlag$sample83) {
+			// Constructor for sigma
+			{
+				sigma = new double[2];
+			}
+		}
+		
+		// If component has not been set already allocate space.
+		if(!fixedFlag$sample101) {
+			// Constructor for component
+			{
+				component = new boolean[length$yObserved];
+			}
+		}
+		
+		// Constructor for y
+		{
+			y = new double[length$yObserved];
+		}
+		
+		// Constructor for constrainedFlag$sample101
+		{
+			constrainedFlag$sample101 = new boolean[((((length$yObserved - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for constrainedFlag$sample20
+		{
+			constrainedFlag$sample20 = new boolean[((((2 - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for constrainedFlag$sample83
+		{
+			constrainedFlag$sample83 = new boolean[((((2 - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for logProbability$sample20
+		{
+			logProbability$sample20 = new double[((((2 - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for logProbability$sample138
+		{
+			logProbability$sample138 = new double[((((length$yObserved - 1) - 0) / 1) + 1)];
+		}
+		
+		// Allocate scratch space
+		allocateScratch();
+	}
+
+	// Method to execute the model code conventionally.
+	@Override
+	public final void forwardGeneration() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[0];
+		} else {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[1];
+		}
+		if(!fixedFlag$sample20)
+			mu[0] = var39;
+		double var57 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[1];
+		} else {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[0];
+		}
+		if(!fixedFlag$sample20)
+			mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+		for(int n = 0; n < N; n += 1) {
+			double componentMu;
+			if(component[n])
+				componentMu = mu[0];
+			else
+				componentMu = mu[1];
+			double componentSigma;
+			if(component[n])
+				componentSigma = sigma[0];
+			else
+				componentSigma = sigma[1];
+			y[n] = ((Math.sqrt((componentSigma * componentSigma)) * DistributionSampling.sampleGaussian(RNG$)) + componentMu);
+		}
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are calculated
+	// and stored.
+	@Override
+	public final void forwardGenerationDistributionsNoOutputsPrime() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	// Method to execute the model code conventionally with priming of fixed intermediate
+	// variables.
+	@Override
+	public final void forwardGenerationPrime() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+		for(int n = 0; n < N; n += 1) {
+			double componentMu;
+			if(component[n])
+				componentMu = mu[0];
+			else
+				componentMu = mu[1];
+			double componentSigma;
+			if(component[n])
+				componentSigma = sigma[0];
+			else
+				componentSigma = sigma[1];
+			y[n] = ((Math.sqrt((componentSigma * componentSigma)) * DistributionSampling.sampleGaussian(RNG$)) + componentMu);
+		}
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Distributions are collapsed to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputs() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[0];
+		} else {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[1];
+		}
+		if(!fixedFlag$sample20)
+			mu[0] = var39;
+		double var57 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[1];
+		} else {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[0];
+		}
+		if(!fixedFlag$sample20)
+			mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are collapsed
+	// to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputsPrime() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	// Method to execute one round of Gibbs sampling.
+	@Override
+	public final void gibbsRound() {
+		// Infer the samples in chronological order.
+		if(system$gibbsForward) {
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				if(!fixedFlag$sample20)
+					inferSample20(var19);
+			}
+			for(int var78 = 0; var78 < 2; var78 += 1) {
+				if(!fixedFlag$sample83)
+					inferSample83(var78);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			for(int var96 = 0; var96 < N; var96 += 1) {
+				if(!fixedFlag$sample101)
+					inferSample101(var96);
+			}
+		}
+		// Infer the samples in reverse chronological order.
+		else {
+			for(int var96 = (N - ((((N - 1) - 0) % 1) + 1)); var96 >= ((0 - 1) + 1); var96 -= 1) {
+				if(!fixedFlag$sample101)
+					inferSample101(var96);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			for(int var78 = (2 - ((((2 - 1) - 0) % 1) + 1)); var78 >= ((0 - 1) + 1); var78 -= 1) {
+				if(!fixedFlag$sample83)
+					inferSample83(var78);
+			}
+			for(int var19 = (2 - ((((2 - 1) - 0) % 1) + 1)); var19 >= ((0 - 1) + 1); var19 -= 1) {
+				if(!fixedFlag$sample20)
+					inferSample20(var19);
+			}
+		}
+		
+		// Reverse the direction of execution for the next iteration
+		system$gibbsForward = !system$gibbsForward;
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!constrainedFlag$sample20[((var19 - 0) / 1)])
+				drawValueSample20(var19);
+		}
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!constrainedFlag$sample83[((var78 - 0) / 1)])
+				drawValueSample83(var78);
+		}
+		if(!constrainedFlag$sample88)
+			drawValueSample88();
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!constrainedFlag$sample101[((var96 - 0) / 1)])
+				drawValueSample101(var96);
+		}
+	}
+
+	// A method to initialize all the probabilities in the model to 0/Log(1) ready for
+	// the current probabilities to be calculated by calculating the probability of each
+	// sample task, and its effect on the rest of the model.
+	private final void initializeLogProbabilityFields() {
+		// Set the probabilities of the random variable, and the model as a whole to ready
+		// them to be reconstructed by the probability calls for each sample. Sample probabilities
+		// are only reset for samples that are not fixed at a value that has already been
+		// calculated.
+		logProbability$$model = 0.0;
+		logProbability$$evidence = 0.0;
+		logProbability$rawMu = 0.0;
+		logProbability$mu = 0.0;
+		if(!fixedProbFlag$sample20) {
+			for(int var19 = 0; var19 < 2; var19 += 1)
+				logProbability$sample20[((var19 - 0) / 1)] = Double.NaN;
+		}
+		logProbability$sigma = 0.0;
+		if(!fixedProbFlag$sample83)
+			logProbability$var79 = Double.NaN;
+		if(!fixedProbFlag$sample88)
+			logProbability$theta = Double.NaN;
+		logProbability$componentDistribution = Double.NaN;
+		logProbability$component = 0.0;
+		if(!fixedProbFlag$sample101)
+			logProbability$var97 = Double.NaN;
+		logProbability$y = 0.0;
+		if(!fixedProbFlag$sample138) {
+			for(int n = 0; n < N; n += 1)
+				logProbability$sample138[((n - 0) / 1)] = Double.NaN;
+		}
+	}
+
+	// Method for initializing the model into a valid state before commencing inference
+	// etc.
+	@Override
+	public final void initializeModel() {
+		N = length$yObserved;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+			constrainedFlag$sample101[index$constrainedFlag$sample101$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+			constrainedFlag$sample20[index$constrainedFlag$sample20$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+			constrainedFlag$sample83[index$constrainedFlag$sample83$1] = true;
+	}
+
+	// Construct the evidence probabilities.
+	@Override
+	public final void logEvidenceProbabilities() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Call each method in turn to generate the new probability values.
+		if(fixedFlag$sample20)
+			logProbabilityValue$sample20();
+		if(fixedFlag$sample83)
+			logProbabilityValue$sample83();
+		if(fixedFlag$sample88)
+			logProbabilityValue$sample88();
+		if(fixedFlag$sample101)
+			logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model uses distributions
+	// when possible.
+	@Override
+	public final void logModelProbabilitiesDist() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model only uses values.
+	@Override
+	public final void logModelProbabilitiesVal() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to propagate observed values back into the model.
+	@Override
+	public final void propagateObservedValues() {
+		// Deep copy between arrays
+		double[] cv$source1 = yObserved;
+		double[] cv$target1 = y;
+		int cv$length1 = cv$target1.length;
+		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1)
+			cv$target1[cv$index1] = cv$source1[cv$index1];
+	}
+
+	// A method to set array values that depend on the output of a sample task, but are
+	// not directly set by the sample task. This method is called to propagate set values
+	// through the model. Any non-fixed sample values may be sampled to random variables
+	// as part of this process.
+	@Override
+	public final void setIntermediates() {
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+	}
+
+	@Override
+	public String modelCode() {
+		return "/*\n"
+		     + " * Sandwood\n"
+		     + " *\n"
+		     + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+		     + " * \n"
+		     + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+		     + " */\n"
+		     + "\n"
+		     + "package org.sandwood.compiler.tests.parser;\n"
+		     + "\n"
+		     + "public model LowDimMix(double[] yObserved) {\n"
+		     + "    int N = yObserved.length;\n"
+		     + "\n"
+		     + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+		     + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+		     + "    // the constant normalisation factor for the ordered constraint.\n"
+		     + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+		     + "    double[] mu = new double[2];\n"
+		     + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+		     + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+		     + "\n"
+		     + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+		     + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+		     + "\n"
+		     + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+		     + "    double theta = beta(5.0, 5.0).sample();\n"
+		     + "\n"
+		     + "    // Stan likelihood:\n"
+		     + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+		     + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+		     + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+		     + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+		     + "    boolean[] component = componentDistribution.sample(N);\n"
+		     + "    double[] y = new double[N];\n"
+		     + "\n"
+		     + "    for(int n = 0; n < N; n++) {\n"
+		     + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+		     + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+		     + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+		     + "    }\n"
+		     + "\n"
+		     + "    y.observe(yObserved);\n"
+		     + "}\n"
+		     + "";
+	}
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$SingleThreadCPU_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$SingleThreadCPU_modelNoComments.java
@@ -1,0 +1,5188 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.runtime.internal.numericTools.Conjugates;
+import org.sandwood.runtime.internal.numericTools.DistributionSampling;
+import org.sandwood.runtime.internal.numericTools.Gaussian;
+import org.sandwood.runtime.model.ExecutionTarget;
+
+final class LowDimMix$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements LowDimMix$CoreInterface {
+	private int N;
+	private boolean[] component;
+	private boolean[] constrainedFlag$sample101;
+	private boolean[] constrainedFlag$sample20;
+	private boolean[] constrainedFlag$sample83;
+	private boolean constrainedFlag$sample88 = true;
+	private double[] cv$var97$stateProbabilityGlobal;
+	private boolean fixedFlag$sample101 = false;
+	private boolean fixedFlag$sample20 = false;
+	private boolean fixedFlag$sample83 = false;
+	private boolean fixedFlag$sample88 = false;
+	private boolean fixedProbFlag$sample101 = false;
+	private boolean fixedProbFlag$sample138 = false;
+	private boolean fixedProbFlag$sample20 = false;
+	private boolean fixedProbFlag$sample83 = false;
+	private boolean fixedProbFlag$sample88 = false;
+	private boolean[] guard$sample20if124$global;
+	private int length$yObserved;
+	private double logProbability$$evidence;
+	private double logProbability$$model;
+	private double logProbability$component;
+	private double logProbability$componentDistribution;
+	private double logProbability$mu;
+	private double logProbability$rawMu;
+	private double[] logProbability$sample138;
+	private double[] logProbability$sample20;
+	private double logProbability$sigma;
+	private double logProbability$theta;
+	private double logProbability$var79;
+	private double logProbability$var97;
+	private double logProbability$y;
+	private double[] mu;
+	private double[] rawMu;
+	private double[] sigma;
+	private boolean system$gibbsForward = true;
+	private double theta;
+	private double[] y;
+	private double[] yObserved;
+
+	public LowDimMix$SingleThreadCPU(ExecutionTarget target) {
+		super(target);
+	}
+
+	@Override
+	public final int get$N() {
+		return N;
+	}
+
+	@Override
+	public final boolean[] get$component() {
+		return component;
+	}
+
+	@Override
+	public final void set$component(boolean[] cv$value, boolean allocated$) {
+		component = cv$value;
+		fixedProbFlag$sample101 = false;
+		fixedProbFlag$sample138 = false;
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample101() {
+		return fixedFlag$sample101;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample101(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample101 = cv$value;
+		if(allocated$) {
+			for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+				constrainedFlag$sample101[index$constrainedFlag$sample101$1] = fixedFlag$sample101;
+		}
+		fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedProbFlag$sample101);
+		fixedProbFlag$sample138 = (fixedFlag$sample101 && fixedProbFlag$sample138);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample20() {
+		return fixedFlag$sample20;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample20(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample20 = cv$value;
+		if(allocated$) {
+			for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+				constrainedFlag$sample20[index$constrainedFlag$sample20$1] = fixedFlag$sample20;
+		}
+		fixedProbFlag$sample20 = (fixedFlag$sample20 && fixedProbFlag$sample20);
+		fixedProbFlag$sample138 = (fixedFlag$sample20 && fixedProbFlag$sample138);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample83() {
+		return fixedFlag$sample83;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample83(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample83 = cv$value;
+		if(allocated$) {
+			for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+				constrainedFlag$sample83[index$constrainedFlag$sample83$1] = fixedFlag$sample83;
+		}
+		fixedProbFlag$sample83 = (fixedFlag$sample83 && fixedProbFlag$sample83);
+		fixedProbFlag$sample138 = (fixedFlag$sample83 && fixedProbFlag$sample138);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample88() {
+		return fixedFlag$sample88;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample88(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample88 = cv$value;
+		constrainedFlag$sample88 = (fixedFlag$sample88 || constrainedFlag$sample88);
+		fixedProbFlag$sample88 = (fixedFlag$sample88 && fixedProbFlag$sample88);
+		fixedProbFlag$sample101 = (fixedFlag$sample88 && fixedProbFlag$sample101);
+	}
+
+	@Override
+	public final int get$length$yObserved() {
+		return length$yObserved;
+	}
+
+	@Override
+	public final void set$length$yObserved(int cv$value, boolean allocated$) {
+		length$yObserved = cv$value;
+	}
+
+	@Override
+	public final double get$logProbability$$evidence() {
+		return logProbability$$evidence;
+	}
+
+	@Override
+	public final double getCurrentLogProbability() {
+		return logProbability$$model;
+	}
+
+	@Override
+	public final double get$logProbability$component() {
+		return logProbability$component;
+	}
+
+	@Override
+	public final double get$logProbability$componentDistribution() {
+		return logProbability$componentDistribution;
+	}
+
+	@Override
+	public final double get$logProbability$mu() {
+		return logProbability$mu;
+	}
+
+	@Override
+	public final double get$logProbability$rawMu() {
+		return logProbability$rawMu;
+	}
+
+	@Override
+	public final double get$logProbability$sigma() {
+		return logProbability$sigma;
+	}
+
+	@Override
+	public final double get$logProbability$theta() {
+		return logProbability$theta;
+	}
+
+	@Override
+	public final double get$logProbability$y() {
+		return logProbability$y;
+	}
+
+	@Override
+	public final double[] get$mu() {
+		return mu;
+	}
+
+	@Override
+	public final double[] get$rawMu() {
+		return rawMu;
+	}
+
+	@Override
+	public final void set$rawMu(double[] cv$value, boolean allocated$) {
+		rawMu = cv$value;
+		fixedProbFlag$sample20 = false;
+		fixedProbFlag$sample138 = false;
+	}
+
+	@Override
+	public final double[] get$sigma() {
+		return sigma;
+	}
+
+	@Override
+	public final void set$sigma(double[] cv$value, boolean allocated$) {
+		sigma = cv$value;
+		fixedProbFlag$sample83 = false;
+		fixedProbFlag$sample138 = false;
+	}
+
+	@Override
+	public final double get$theta() {
+		return theta;
+	}
+
+	@Override
+	public final void set$theta(double cv$value, boolean allocated$) {
+		theta = cv$value;
+		fixedProbFlag$sample88 = false;
+		fixedProbFlag$sample101 = false;
+	}
+
+	@Override
+	public final double[] get$y() {
+		return y;
+	}
+
+	@Override
+	public final double[] get$yObserved() {
+		return yObserved;
+	}
+
+	@Override
+	public final void set$yObserved(double[] cv$value, boolean allocated$) {
+		yObserved = cv$value;
+	}
+
+	private final void drawValueSample101(int var96) {
+		component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+	}
+
+	private final void drawValueSample20(int var19) {
+		rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		{
+			boolean guard$sample20put43 = false;
+			{
+				if((var19 == 0)) {
+					if(!guard$sample20put43) {
+						guard$sample20put43 = true;
+						{
+							double var39;
+							if((rawMu[0] < rawMu[1]))
+								var39 = rawMu[0];
+							else
+								var39 = rawMu[1];
+							mu[0] = var39;
+						}
+					}
+				}
+			}
+			{
+				if((var19 == 1)) {
+					if(!guard$sample20put43) {
+						guard$sample20put43 = true;
+						{
+							double var39;
+							if((rawMu[0] < rawMu[1]))
+								var39 = rawMu[0];
+							else
+								var39 = rawMu[1];
+							mu[0] = var39;
+						}
+					}
+				}
+			}
+			{
+				if((rawMu[0] < rawMu[1])) {
+					if((var19 == 0)) {
+						if((rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put43) {
+								guard$sample20put43 = true;
+								{
+									double var39;
+									if((rawMu[0] < rawMu[1]))
+										var39 = rawMu[0];
+									else
+										var39 = rawMu[1];
+									mu[0] = var39;
+								}
+							}
+						}
+					}
+				}
+			}
+			{
+				if(!(rawMu[0] < rawMu[1])) {
+					if((var19 == 1)) {
+						if(!(rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put43) {
+								guard$sample20put43 = true;
+								{
+									double var39;
+									if((rawMu[0] < rawMu[1]))
+										var39 = rawMu[0];
+									else
+										var39 = rawMu[1];
+									mu[0] = var39;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		{
+			boolean guard$sample20put63 = false;
+			{
+				if((var19 == 0)) {
+					if(!guard$sample20put63) {
+						guard$sample20put63 = true;
+						{
+							double var57;
+							if((rawMu[0] < rawMu[1]))
+								var57 = rawMu[1];
+							else
+								var57 = rawMu[0];
+							mu[1] = var57;
+						}
+					}
+				}
+			}
+			{
+				if((var19 == 1)) {
+					if(!guard$sample20put63) {
+						guard$sample20put63 = true;
+						{
+							double var57;
+							if((rawMu[0] < rawMu[1]))
+								var57 = rawMu[1];
+							else
+								var57 = rawMu[0];
+							mu[1] = var57;
+						}
+					}
+				}
+			}
+			{
+				if((rawMu[0] < rawMu[1])) {
+					if((var19 == 1)) {
+						if((rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put63) {
+								guard$sample20put63 = true;
+								{
+									double var57;
+									if((rawMu[0] < rawMu[1]))
+										var57 = rawMu[1];
+									else
+										var57 = rawMu[0];
+									mu[1] = var57;
+								}
+							}
+						}
+					}
+				}
+			}
+			{
+				if(!(rawMu[0] < rawMu[1])) {
+					if((var19 == 0)) {
+						if(!(rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put63) {
+								guard$sample20put63 = true;
+								{
+									double var57;
+									if((rawMu[0] < rawMu[1]))
+										var57 = rawMu[1];
+									else
+										var57 = rawMu[0];
+									mu[1] = var57;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private final void drawValueSample83(int var78) {
+		sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+	}
+
+	private final void drawValueSample88() {
+		theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+	}
+
+	private final void inferSample101(int var96) {
+		if(true) {
+			constrainedFlag$sample101[((var96 - 0) / 1)] = false;
+			int cv$numStates = 0;
+			{
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			double[] cv$stateProbabilityLocal = cv$var97$stateProbabilityGlobal;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+				double cv$reachedDistributionSourceRV = 0.0;
+				double cv$accumulatedDistributionProbabilities = 0.0;
+				boolean cv$currentValue;
+				cv$currentValue = (cv$valuePos == 1);
+				boolean var97 = cv$currentValue;
+				{
+					{
+						{
+							component[var96] = cv$currentValue;
+						}
+					}
+				}
+				{
+					cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+					double cv$accumulatedProbabilities = (Math.log(1.0) + (((0.0 <= theta) && (theta <= 1.0))?Math.log((cv$currentValue?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+					{
+						{
+							{
+								for(int n = 0; n < N; n += 1) {
+									if((var96 == n)) {
+										{
+											{
+												{
+													if(component[n]) {
+														double traceTempVariable$componentMu$3_1 = mu[0];
+														{
+															{
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentSigma;
+																							if(component[n])
+																								componentSigma = sigma[0];
+																							else
+																								componentSigma = sigma[1];
+																							double var128 = (componentSigma * componentSigma);
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												boolean[] guard$sample20if124 = guard$sample20if124$global;
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													if(!component[n]) {
+														double traceTempVariable$componentMu$30_1 = mu[1];
+														{
+															{
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentSigma;
+																							if(component[n])
+																								componentSigma = sigma[0];
+																							else
+																								componentSigma = sigma[1];
+																							double var128 = (componentSigma * componentSigma);
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												boolean[] guard$sample20if124 = guard$sample20if124$global;
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n])
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n])
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			{
+																				{
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									double var6 = (2.0 * 2.0);
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					{
+																						{
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											double var6 = (2.0 * 2.0);
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					{
+						{
+							{
+								for(int n = 0; n < N; n += 1) {
+									if((var96 == n)) {
+										{
+											{
+												{
+													if(component[n]) {
+														double traceTempVariable$componentSigma$58_1 = sigma[0];
+														{
+															{
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentMu;
+																							if(component[n])
+																								componentMu = mu[0];
+																							else
+																								componentMu = mu[1];
+																							double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													for(int var78 = 0; var78 < 2; var78 += 1) {
+														if(component[n]) {
+															if((var78 == 0)) {
+																if(component[n]) {
+																	{
+																		{
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							double var63 = (2.0 * 2.0);
+																							if(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)));
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													if(!component[n]) {
+														double traceTempVariable$componentSigma$63_1 = sigma[1];
+														{
+															{
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentMu;
+																							if(component[n])
+																								componentMu = mu[0];
+																							else
+																								componentMu = mu[1];
+																							double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													for(int var78 = 0; var78 < 2; var78 += 1) {
+														if(!component[n]) {
+															if((var78 == 1)) {
+																if(!component[n]) {
+																	{
+																		{
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							double var63 = (2.0 * 2.0);
+																							if(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)));
+																							}
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+						cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+					else {
+						if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+							cv$stateProbabilityValue = cv$accumulatedProbabilities;
+						else
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+					}
+				}
+				cv$stateProbabilityLocal[cv$valuePos] = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+			}
+			if(constrainedFlag$sample101[((var96 - 0) / 1)]) {
+				double cv$logSum = 0.0;
+				{
+					double cv$lseMax = cv$stateProbabilityLocal[0];
+					for(int cv$lseIndex = 1; cv$lseIndex < cv$numStates; cv$lseIndex += 1) {
+						double cv$lseElementValue = cv$stateProbabilityLocal[cv$lseIndex];
+						if((cv$lseMax < cv$lseElementValue))
+							cv$lseMax = cv$lseElementValue;
+					}
+					if((cv$lseMax == Double.NEGATIVE_INFINITY))
+						cv$logSum = Double.NEGATIVE_INFINITY;
+					else {
+						double cv$lseSum = 0.0;
+						for(int cv$lseIndex = 0; cv$lseIndex < cv$numStates; cv$lseIndex += 1)
+							cv$lseSum = (cv$lseSum + Math.exp((cv$stateProbabilityLocal[cv$lseIndex] - cv$lseMax)));
+						cv$logSum = (cv$logSum + (Math.log(cv$lseSum) + cv$lseMax));
+					}
+				}
+				if((cv$logSum == Double.NEGATIVE_INFINITY)) {
+					for(int cv$indexName = 0; cv$indexName < cv$numStates; cv$indexName += 1)
+						cv$stateProbabilityLocal[cv$indexName] = (1.0 / cv$numStates);
+				} else {
+					for(int cv$indexName = 0; cv$indexName < cv$numStates; cv$indexName += 1)
+						cv$stateProbabilityLocal[cv$indexName] = Math.exp((cv$stateProbabilityLocal[cv$indexName] - cv$logSum));
+				}
+				for(int cv$indexName = cv$numStates; cv$indexName < cv$stateProbabilityLocal.length; cv$indexName += 1)
+					cv$stateProbabilityLocal[cv$indexName] = Double.NEGATIVE_INFINITY;
+				boolean var97 = (DistributionSampling.sampleCategorical(RNG$, cv$stateProbabilityLocal, cv$numStates) == 1);
+				{
+					{
+						{
+							component[var96] = var97;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private final void inferSample20(int var19) {
+		if(true) {
+			constrainedFlag$sample20[((var19 - 0) / 1)] = false;
+			int cv$numStates = 0;
+			{
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			double cv$originalValue = rawMu[var19];
+			double cv$originalProbability = 0.0;
+			double cv$var = ((cv$originalValue * cv$originalValue) * (0.1 * 0.1));
+			if((cv$var < (0.1 * 0.1)))
+				cv$var = (0.1 * 0.1);
+			double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+			double cv$proposedProbability = 0.0;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				if((constrainedFlag$sample20[((var19 - 0) / 1)] || (cv$valuePos == 0))) {
+					double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+					double cv$reachedDistributionSourceRV = 0.0;
+					double cv$accumulatedDistributionProbabilities = 0.0;
+					double cv$currentValue;
+					if((cv$valuePos == 0))
+						cv$currentValue = cv$originalValue;
+					else {
+						cv$currentValue = cv$proposedValue;
+						double var20 = cv$proposedValue;
+						{
+							{
+								{
+									rawMu[var19] = cv$currentValue;
+								}
+							}
+						}
+						{
+							boolean guard$sample20put43 = false;
+							{
+								if((var19 == 0)) {
+									if(!guard$sample20put43) {
+										guard$sample20put43 = true;
+										{
+											double var39;
+											if((rawMu[0] < rawMu[1]))
+												var39 = rawMu[0];
+											else
+												var39 = rawMu[1];
+											mu[0] = var39;
+										}
+									}
+								}
+							}
+							{
+								if((var19 == 1)) {
+									if(!guard$sample20put43) {
+										guard$sample20put43 = true;
+										{
+											double var39;
+											if((rawMu[0] < rawMu[1]))
+												var39 = rawMu[0];
+											else
+												var39 = rawMu[1];
+											mu[0] = var39;
+										}
+									}
+								}
+							}
+							{
+								if((rawMu[0] < rawMu[1])) {
+									if((var19 == 0)) {
+										if((rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put43) {
+												guard$sample20put43 = true;
+												{
+													double var39;
+													if((rawMu[0] < rawMu[1]))
+														var39 = rawMu[0];
+													else
+														var39 = rawMu[1];
+													mu[0] = var39;
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								if(!(rawMu[0] < rawMu[1])) {
+									if((var19 == 1)) {
+										if(!(rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put43) {
+												guard$sample20put43 = true;
+												{
+													double var39;
+													if((rawMu[0] < rawMu[1]))
+														var39 = rawMu[0];
+													else
+														var39 = rawMu[1];
+													mu[0] = var39;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						{
+							boolean guard$sample20put63 = false;
+							{
+								if((var19 == 0)) {
+									if(!guard$sample20put63) {
+										guard$sample20put63 = true;
+										{
+											double var57;
+											if((rawMu[0] < rawMu[1]))
+												var57 = rawMu[1];
+											else
+												var57 = rawMu[0];
+											mu[1] = var57;
+										}
+									}
+								}
+							}
+							{
+								if((var19 == 1)) {
+									if(!guard$sample20put63) {
+										guard$sample20put63 = true;
+										{
+											double var57;
+											if((rawMu[0] < rawMu[1]))
+												var57 = rawMu[1];
+											else
+												var57 = rawMu[0];
+											mu[1] = var57;
+										}
+									}
+								}
+							}
+							{
+								if((rawMu[0] < rawMu[1])) {
+									if((var19 == 1)) {
+										if((rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put63) {
+												guard$sample20put63 = true;
+												{
+													double var57;
+													if((rawMu[0] < rawMu[1]))
+														var57 = rawMu[1];
+													else
+														var57 = rawMu[0];
+													mu[1] = var57;
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								if(!(rawMu[0] < rawMu[1])) {
+									if((var19 == 0)) {
+										if(!(rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put63) {
+												guard$sample20put63 = true;
+												{
+													double var57;
+													if((rawMu[0] < rawMu[1]))
+														var57 = rawMu[1];
+													else
+														var57 = rawMu[0];
+													mu[1] = var57;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					{
+						cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+						double var6 = (2.0 * 2.0);
+						double cv$accumulatedProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((cv$currentValue - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+						{
+							{
+								{
+									double traceTempVariable$var36$10_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$10_2 = traceTempVariable$var36$10_1;
+												double traceTempVariable$var115$10_3 = traceTempVariable$var39$10_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((0 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$10_5 = traceTempVariable$var115$10_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var36$11_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$11_2 = traceTempVariable$var36$11_1;
+												double traceTempVariable$var117$11_3 = traceTempVariable$var39$11_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((0 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$11_5 = traceTempVariable$var117$11_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var38$12_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$12_2 = traceTempVariable$var38$12_1;
+												double traceTempVariable$var115$12_3 = traceTempVariable$var39$12_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((0 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$12_5 = traceTempVariable$var115$12_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var38$13_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$13_2 = traceTempVariable$var38$13_1;
+												double traceTempVariable$var117$13_3 = traceTempVariable$var39$13_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((0 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$13_5 = traceTempVariable$var117$13_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var54$14_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$14_2 = traceTempVariable$var54$14_1;
+												double traceTempVariable$var115$14_3 = traceTempVariable$var57$14_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((1 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$14_5 = traceTempVariable$var115$14_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var54$15_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$15_2 = traceTempVariable$var54$15_1;
+												double traceTempVariable$var117$15_3 = traceTempVariable$var57$15_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((1 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$15_5 = traceTempVariable$var117$15_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var56$16_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$16_2 = traceTempVariable$var56$16_1;
+												double traceTempVariable$var115$16_3 = traceTempVariable$var57$16_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((1 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$16_5 = traceTempVariable$var115$16_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var56$17_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$17_2 = traceTempVariable$var56$17_1;
+												double traceTempVariable$var117$17_3 = traceTempVariable$var57$17_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((1 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$17_5 = traceTempVariable$var117$17_3;
+																{
+																	{
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								double var128 = (componentSigma * componentSigma);
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						{
+							{
+								boolean guard$sample20if41 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20if41) {
+											guard$sample20if41 = true;
+											{
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$36_1 = rawMu[0];
+															double traceTempVariable$var115$36_2 = traceTempVariable$var39$36_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$36_4 = traceTempVariable$var115$36_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$38_1 = rawMu[0];
+															double traceTempVariable$var117$38_2 = traceTempVariable$var39$38_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$38_4 = traceTempVariable$var117$38_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$48_1 = 0; index$var19$48_1 < 2; index$var19$48_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$48_1 == 0)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$52_1 = rawMu[1];
+															double traceTempVariable$var115$52_2 = traceTempVariable$var39$52_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$52_4 = traceTempVariable$var115$52_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$54_1 = rawMu[1];
+															double traceTempVariable$var117$54_2 = traceTempVariable$var39$54_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$54_4 = traceTempVariable$var117$54_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$64_1 = 0; index$var19$64_1 < 2; index$var19$64_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$64_1 == 1)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20if41) {
+											guard$sample20if41 = true;
+											{
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$37_1 = rawMu[0];
+															double traceTempVariable$var115$37_2 = traceTempVariable$var39$37_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$37_4 = traceTempVariable$var115$37_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$39_1 = rawMu[0];
+															double traceTempVariable$var117$39_2 = traceTempVariable$var39$39_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$39_4 = traceTempVariable$var117$39_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$49_1 = 0; index$var19$49_1 < 2; index$var19$49_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$49_1 == 0)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$53_1 = rawMu[1];
+															double traceTempVariable$var115$53_2 = traceTempVariable$var39$53_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$53_4 = traceTempVariable$var115$53_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$55_1 = rawMu[1];
+															double traceTempVariable$var117$55_2 = traceTempVariable$var39$55_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$55_4 = traceTempVariable$var117$55_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$65_1 = 0; index$var19$65_1 < 2; index$var19$65_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$65_1 == 1)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						{
+							{
+								boolean guard$sample20if61 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20if61) {
+											guard$sample20if61 = true;
+											{
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$70_1 = rawMu[1];
+															double traceTempVariable$var115$70_2 = traceTempVariable$var57$70_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$70_4 = traceTempVariable$var115$70_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$72_1 = rawMu[1];
+															double traceTempVariable$var117$72_2 = traceTempVariable$var57$72_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$72_4 = traceTempVariable$var117$72_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$82_1 = 0; index$var19$82_1 < 2; index$var19$82_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$82_1 == 1)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$86_1 = rawMu[0];
+															double traceTempVariable$var115$86_2 = traceTempVariable$var57$86_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$86_4 = traceTempVariable$var115$86_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$88_1 = rawMu[0];
+															double traceTempVariable$var117$88_2 = traceTempVariable$var57$88_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$88_4 = traceTempVariable$var117$88_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$98_1 = 0; index$var19$98_1 < 2; index$var19$98_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$98_1 == 0)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20if61) {
+											guard$sample20if61 = true;
+											{
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$71_1 = rawMu[1];
+															double traceTempVariable$var115$71_2 = traceTempVariable$var57$71_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$71_4 = traceTempVariable$var115$71_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$73_1 = rawMu[1];
+															double traceTempVariable$var117$73_2 = traceTempVariable$var57$73_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$73_4 = traceTempVariable$var117$73_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$83_1 = 0; index$var19$83_1 < 2; index$var19$83_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$83_1 == 1)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$87_1 = rawMu[0];
+															double traceTempVariable$var115$87_2 = traceTempVariable$var57$87_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$87_4 = traceTempVariable$var115$87_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$89_1 = rawMu[0];
+															double traceTempVariable$var117$89_2 = traceTempVariable$var57$89_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$89_4 = traceTempVariable$var117$89_2;
+																			{
+																				{
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												double var128 = (componentSigma * componentSigma);
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													{
+														for(int index$var19$99_1 = 0; index$var19$99_1 < 2; index$var19$99_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$99_1 == 0)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		{
+																			{
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+						else {
+							if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+								cv$stateProbabilityValue = cv$accumulatedProbabilities;
+							else
+								cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+						}
+					}
+					if((cv$valuePos == 0))
+						cv$originalProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					else
+						cv$proposedProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					double cv$ratio = (cv$proposedProbability - cv$originalProbability);
+					if((cv$valuePos == 1)) {
+						if(((cv$ratio <= Math.log((0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$))))) || Double.isNaN(cv$ratio))) {
+							double var20 = cv$originalValue;
+							{
+								{
+									{
+										rawMu[var19] = var20;
+									}
+								}
+							}
+							{
+								boolean guard$sample20put43 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20put43) {
+											guard$sample20put43 = true;
+											{
+												double var39;
+												if((rawMu[0] < rawMu[1]))
+													var39 = rawMu[0];
+												else
+													var39 = rawMu[1];
+												mu[0] = var39;
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20put43) {
+											guard$sample20put43 = true;
+											{
+												double var39;
+												if((rawMu[0] < rawMu[1]))
+													var39 = rawMu[0];
+												else
+													var39 = rawMu[1];
+												mu[0] = var39;
+											}
+										}
+									}
+								}
+								{
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put43) {
+													guard$sample20put43 = true;
+													{
+														double var39;
+														if((rawMu[0] < rawMu[1]))
+															var39 = rawMu[0];
+														else
+															var39 = rawMu[1];
+														mu[0] = var39;
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put43) {
+													guard$sample20put43 = true;
+													{
+														double var39;
+														if((rawMu[0] < rawMu[1]))
+															var39 = rawMu[0];
+														else
+															var39 = rawMu[1];
+														mu[0] = var39;
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								boolean guard$sample20put63 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20put63) {
+											guard$sample20put63 = true;
+											{
+												double var57;
+												if((rawMu[0] < rawMu[1]))
+													var57 = rawMu[1];
+												else
+													var57 = rawMu[0];
+												mu[1] = var57;
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20put63) {
+											guard$sample20put63 = true;
+											{
+												double var57;
+												if((rawMu[0] < rawMu[1]))
+													var57 = rawMu[1];
+												else
+													var57 = rawMu[0];
+												mu[1] = var57;
+											}
+										}
+									}
+								}
+								{
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put63) {
+													guard$sample20put63 = true;
+													{
+														double var57;
+														if((rawMu[0] < rawMu[1]))
+															var57 = rawMu[1];
+														else
+															var57 = rawMu[0];
+														mu[1] = var57;
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put63) {
+													guard$sample20put63 = true;
+													{
+														double var57;
+														if((rawMu[0] < rawMu[1]))
+															var57 = rawMu[1];
+														else
+															var57 = rawMu[0];
+														mu[1] = var57;
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private final void inferSample83(int var78) {
+		if(true) {
+			constrainedFlag$sample83[((var78 - 0) / 1)] = false;
+			int cv$numStates = 0;
+			{
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			double cv$originalValue = sigma[var78];
+			double cv$originalProbability = 0.0;
+			double cv$var = ((cv$originalValue * cv$originalValue) * (0.1 * 0.1));
+			if((cv$var < (0.1 * 0.1)))
+				cv$var = (0.1 * 0.1);
+			double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+			double cv$proposedProbability = 0.0;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				if((constrainedFlag$sample83[((var78 - 0) / 1)] || (cv$valuePos == 0))) {
+					double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+					double cv$reachedDistributionSourceRV = 0.0;
+					double cv$accumulatedDistributionProbabilities = 0.0;
+					double cv$currentValue;
+					if((cv$valuePos == 0))
+						cv$currentValue = cv$originalValue;
+					else {
+						cv$currentValue = cv$proposedValue;
+						double var79 = cv$proposedValue;
+						{
+							{
+								{
+									sigma[var78] = cv$currentValue;
+								}
+							}
+						}
+					}
+					{
+						cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+						double var63 = (2.0 * 2.0);
+						double cv$accumulatedProbabilities = (Math.log(1.0) + (((((0.0 <= cv$currentValue) && (cv$currentValue <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((cv$currentValue - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+						{
+							{
+								{
+									double traceTempVariable$var124$2_1 = cv$currentValue;
+									for(int n = 0; n < N; n += 1) {
+										if(component[n]) {
+											if((var78 == 0)) {
+												if(component[n]) {
+													double traceTempVariable$componentSigma$2_3 = traceTempVariable$var124$2_1;
+													{
+														{
+															boolean cv$sampleConstrained = true;
+															if(cv$sampleConstrained) {
+																constrainedFlag$sample83[((var78 - 0) / 1)] = true;
+																double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																{
+																	{
+																		{
+																			{
+																				{
+																					double componentMu;
+																					if(component[n])
+																						componentMu = mu[0];
+																					else
+																						componentMu = mu[1];
+																					double var128 = (traceTempVariable$componentSigma$2_3 * traceTempVariable$componentSigma$2_3);
+																					if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																						else
+																							cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																				}
+																			}
+																		}
+																	}
+																}
+																cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																	cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																else {
+																	if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																		cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																	else
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var126$3_1 = cv$currentValue;
+									for(int n = 0; n < N; n += 1) {
+										if(!component[n]) {
+											if((var78 == 1)) {
+												if(!component[n]) {
+													double traceTempVariable$componentSigma$3_3 = traceTempVariable$var126$3_1;
+													{
+														{
+															boolean cv$sampleConstrained = true;
+															if(cv$sampleConstrained) {
+																constrainedFlag$sample83[((var78 - 0) / 1)] = true;
+																double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																{
+																	{
+																		{
+																			{
+																				{
+																					double componentMu;
+																					if(component[n])
+																						componentMu = mu[0];
+																					else
+																						componentMu = mu[1];
+																					double var128 = (traceTempVariable$componentSigma$3_3 * traceTempVariable$componentSigma$3_3);
+																					if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																					else {
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																						else
+																							cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																					}
+																					cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																				}
+																			}
+																		}
+																	}
+																}
+																cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																	cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																else {
+																	if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																		cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																	else
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+						else {
+							if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+								cv$stateProbabilityValue = cv$accumulatedProbabilities;
+							else
+								cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+						}
+					}
+					if((cv$valuePos == 0))
+						cv$originalProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					else
+						cv$proposedProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					double cv$ratio = (cv$proposedProbability - cv$originalProbability);
+					if((cv$valuePos == 1)) {
+						if(((cv$ratio <= Math.log((0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$))))) || Double.isNaN(cv$ratio))) {
+							double var79 = cv$originalValue;
+							{
+								{
+									{
+										sigma[var78] = var79;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private final void inferSample88() {
+		if(true) {
+			constrainedFlag$sample88 = false;
+			int cv$sum = 0;
+			int cv$count = 0;
+			{
+				{
+					{
+						{
+							{
+								{
+									for(int var96 = 0; var96 < N; var96 += 1) {
+										boolean cv$sampleConstrained = (fixedFlag$sample101 || constrainedFlag$sample101[((var96 - 0) / 1)]);
+										if(cv$sampleConstrained) {
+											constrainedFlag$sample88 = true;
+											{
+												{
+													{
+														{
+															{
+																cv$count = (cv$count + 1);
+																if(component[var96])
+																	cv$sum = (cv$sum + 1);
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			if(constrainedFlag$sample88)
+				theta = Conjugates.sampleConjugateBetaBinomial(RNG$, 5.0, 5.0, cv$sum, cv$count);
+		}
+	}
+
+	private final void logProbabilityValue$sample101() {
+		if(!fixedProbFlag$sample101) {
+			double cv$accumulator = 0.0;
+			double cv$sampleAccumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1) {
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						boolean cv$sampleValue = component[var96];
+						{
+							{
+								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= theta) && (theta <= 1.0))?Math.log((cv$sampleValue?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				cv$sampleReached = true;
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$componentDistribution = cv$sampleAccumulator;
+			logProbability$var97 = cv$sampleAccumulator;
+			logProbability$component = (logProbability$component + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedFlag$sample88);
+		} else {
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1)
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var97;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			logProbability$componentDistribution = cv$rvAccumulator;
+			logProbability$component = (logProbability$component + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	private final void logProbabilityValue$sample138() {
+		if(!fixedProbFlag$sample138) {
+			double cv$accumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1) {
+				double cv$sampleAccumulator = 0.0;
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						double cv$sampleValue = y[n];
+						{
+							{
+								double componentMu;
+								if(component[n])
+									componentMu = mu[0];
+								else
+									componentMu = mu[1];
+								double componentSigma;
+								if(component[n])
+									componentSigma = sigma[0];
+								else
+									componentSigma = sigma[1];
+								double var128 = (componentSigma * componentSigma);
+								double cv$weightedProbability = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				cv$sampleReached = true;
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+				logProbability$sample138[((n - 0) / 1)] = cv$sampleProbability;
+			}
+			logProbability$y = (logProbability$y + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			fixedProbFlag$sample138 = ((fixedFlag$sample20 && fixedFlag$sample83) && fixedFlag$sample101);
+		} else {
+			double cv$accumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1) {
+				double cv$rvAccumulator = 0.0;
+				double cv$sampleValue = logProbability$sample138[((n - 0) / 1)];
+				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+				cv$sampleReached = true;
+				cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			}
+			logProbability$y = (logProbability$y + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	private final void logProbabilityValue$sample20() {
+		if(!fixedProbFlag$sample20) {
+			double cv$accumulator = 0.0;
+			double cv$sampleAccumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						double cv$sampleValue = rawMu[var19];
+						{
+							{
+								double var3 = 0.0;
+								double var6 = (2.0 * 2.0);
+								double cv$weightedProbability = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var3) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+								{
+									boolean guard$put21if41 = false;
+									{
+										if((var19 == 0)) {
+											if(!guard$put21if41)
+												guard$put21if41 = true;
+										}
+									}
+									{
+										if((var19 == 1)) {
+											if(!guard$put21if41)
+												guard$put21if41 = true;
+										}
+									}
+								}
+								{
+									boolean guard$put21if61 = false;
+									{
+										if((var19 == 0)) {
+											if(!guard$put21if61)
+												guard$put21if61 = true;
+										}
+									}
+									{
+										if((var19 == 1)) {
+											if(!guard$put21if61)
+												guard$put21if61 = true;
+										}
+									}
+								}
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				cv$sampleReached = true;
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				logProbability$sample20[((var19 - 0) / 1)] = cv$sampleProbability;
+				boolean cv$guard$mu = false;
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if((rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+				}
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if((rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$rawMu = (logProbability$rawMu + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			fixedProbFlag$sample20 = fixedFlag$sample20;
+		} else {
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				double cv$sampleValue = logProbability$sample20[((var19 - 0) / 1)];
+				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+				cv$sampleReached = true;
+				boolean cv$guard$mu = false;
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if((rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+				}
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if((rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									if(!cv$guard$mu) {
+										cv$guard$mu = true;
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			logProbability$rawMu = (logProbability$rawMu + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	private final void logProbabilityValue$sample83() {
+		if(!fixedProbFlag$sample83) {
+			double cv$accumulator = 0.0;
+			double cv$sampleAccumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int var78 = 0; var78 < 2; var78 += 1) {
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						double cv$sampleValue = sigma[var78];
+						{
+							{
+								double var60 = 0.0;
+								double var63 = (2.0 * 2.0);
+								double var64 = 0.0;
+								double var65 = 1.0E100;
+								double cv$weightedProbability = (Math.log(1.0) + (((((var64 <= cv$sampleValue) && (cv$sampleValue <= var65)) && (var64 < var65)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var60) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((var65 - var60) / Math.sqrt(var63))) - Gaussian.cdf(((var64 - var60) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				cv$sampleReached = true;
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$var79 = cv$sampleAccumulator;
+			logProbability$sigma = (logProbability$sigma + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			fixedProbFlag$sample83 = fixedFlag$sample83;
+		} else {
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			boolean cv$sampleReached = false;
+			for(int var78 = 0; var78 < 2; var78 += 1)
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var79;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			logProbability$sigma = (logProbability$sigma + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	private final void logProbabilityValue$sample88() {
+		if(!fixedProbFlag$sample88) {
+			double cv$accumulator = 0.0;
+			double cv$sampleAccumulator = 0.0;
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			double cv$probabilityReached = 0.0;
+			{
+				{
+					double cv$sampleValue = theta;
+					{
+						{
+							double var81 = 5.0;
+							double var82 = 5.0;
+							double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var81, var82));
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						}
+					}
+				}
+			}
+			if((cv$probabilityReached == 0.0))
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			logProbability$theta = cv$sampleProbability;
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			fixedProbFlag$sample88 = fixedFlag$sample88;
+		} else {
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			double cv$sampleValue = logProbability$theta;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	@Override
+	public final void allocateScratch() {
+		{
+			cv$var97$stateProbabilityGlobal = new double[2];
+		}
+		{
+			int cv$max_var19 = 0;
+			cv$max_var19 = Math.max(cv$max_var19, ((2 - 0) / 1));
+			guard$sample20if124$global = new boolean[cv$max_var19];
+		}
+	}
+
+	@Override
+	public final void allocator() {
+		if(!fixedFlag$sample20) {
+			{
+				rawMu = new double[2];
+			}
+		}
+		{
+			mu = new double[2];
+		}
+		if(!fixedFlag$sample83) {
+			{
+				sigma = new double[2];
+			}
+		}
+		if(!fixedFlag$sample101) {
+			{
+				component = new boolean[length$yObserved];
+			}
+		}
+		{
+			y = new double[length$yObserved];
+		}
+		{
+			constrainedFlag$sample101 = new boolean[((((length$yObserved - 1) - 0) / 1) + 1)];
+		}
+		{
+			constrainedFlag$sample20 = new boolean[((((2 - 1) - 0) / 1) + 1)];
+		}
+		{
+			constrainedFlag$sample83 = new boolean[((((2 - 1) - 0) / 1) + 1)];
+		}
+		{
+			logProbability$sample20 = new double[((((2 - 1) - 0) / 1) + 1)];
+		}
+		{
+			logProbability$sample138 = new double[((((length$yObserved - 1) - 0) / 1) + 1)];
+		}
+		allocateScratch();
+	}
+
+	@Override
+	public final void forwardGeneration() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[0];
+		} else {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[1];
+		}
+		if(!fixedFlag$sample20)
+			mu[0] = var39;
+		double var57 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[1];
+		} else {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[0];
+		}
+		if(!fixedFlag$sample20)
+			mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+		for(int n = 0; n < N; n += 1) {
+			double componentMu;
+			if(component[n])
+				componentMu = mu[0];
+			else
+				componentMu = mu[1];
+			double componentSigma;
+			if(component[n])
+				componentSigma = sigma[0];
+			else
+				componentSigma = sigma[1];
+			y[n] = ((Math.sqrt((componentSigma * componentSigma)) * DistributionSampling.sampleGaussian(RNG$)) + componentMu);
+		}
+	}
+
+	@Override
+	public final void forwardGenerationDistributionsNoOutputsPrime() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	@Override
+	public final void forwardGenerationPrime() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+		for(int n = 0; n < N; n += 1) {
+			double componentMu;
+			if(component[n])
+				componentMu = mu[0];
+			else
+				componentMu = mu[1];
+			double componentSigma;
+			if(component[n])
+				componentSigma = sigma[0];
+			else
+				componentSigma = sigma[1];
+			y[n] = ((Math.sqrt((componentSigma * componentSigma)) * DistributionSampling.sampleGaussian(RNG$)) + componentMu);
+		}
+	}
+
+	@Override
+	public final void forwardGenerationValuesNoOutputs() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[0];
+		} else {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[1];
+		}
+		if(!fixedFlag$sample20)
+			mu[0] = var39;
+		double var57 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[1];
+		} else {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[0];
+		}
+		if(!fixedFlag$sample20)
+			mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	@Override
+	public final void forwardGenerationValuesNoOutputsPrime() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	@Override
+	public final void gibbsRound() {
+		if(system$gibbsForward) {
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				if(!fixedFlag$sample20)
+					inferSample20(var19);
+			}
+			for(int var78 = 0; var78 < 2; var78 += 1) {
+				if(!fixedFlag$sample83)
+					inferSample83(var78);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			for(int var96 = 0; var96 < N; var96 += 1) {
+				if(!fixedFlag$sample101)
+					inferSample101(var96);
+			}
+		} else {
+			for(int var96 = (N - ((((N - 1) - 0) % 1) + 1)); var96 >= ((0 - 1) + 1); var96 -= 1) {
+				if(!fixedFlag$sample101)
+					inferSample101(var96);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			for(int var78 = (2 - ((((2 - 1) - 0) % 1) + 1)); var78 >= ((0 - 1) + 1); var78 -= 1) {
+				if(!fixedFlag$sample83)
+					inferSample83(var78);
+			}
+			for(int var19 = (2 - ((((2 - 1) - 0) % 1) + 1)); var19 >= ((0 - 1) + 1); var19 -= 1) {
+				if(!fixedFlag$sample20)
+					inferSample20(var19);
+			}
+		}
+		system$gibbsForward = !system$gibbsForward;
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!constrainedFlag$sample20[((var19 - 0) / 1)])
+				drawValueSample20(var19);
+		}
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!constrainedFlag$sample83[((var78 - 0) / 1)])
+				drawValueSample83(var78);
+		}
+		if(!constrainedFlag$sample88)
+			drawValueSample88();
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!constrainedFlag$sample101[((var96 - 0) / 1)])
+				drawValueSample101(var96);
+		}
+	}
+
+	private final void initializeLogProbabilityFields() {
+		logProbability$$model = 0.0;
+		logProbability$$evidence = 0.0;
+		logProbability$rawMu = 0.0;
+		logProbability$mu = 0.0;
+		if(!fixedProbFlag$sample20) {
+			for(int var19 = 0; var19 < 2; var19 += 1)
+				logProbability$sample20[((var19 - 0) / 1)] = Double.NaN;
+		}
+		logProbability$sigma = 0.0;
+		if(!fixedProbFlag$sample83)
+			logProbability$var79 = Double.NaN;
+		if(!fixedProbFlag$sample88)
+			logProbability$theta = Double.NaN;
+		logProbability$componentDistribution = Double.NaN;
+		logProbability$component = 0.0;
+		if(!fixedProbFlag$sample101)
+			logProbability$var97 = Double.NaN;
+		logProbability$y = 0.0;
+		if(!fixedProbFlag$sample138) {
+			for(int n = 0; n < N; n += 1)
+				logProbability$sample138[((n - 0) / 1)] = Double.NaN;
+		}
+	}
+
+	@Override
+	public final void initializeModel() {
+		N = length$yObserved;
+		for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+			constrainedFlag$sample101[index$constrainedFlag$sample101$1] = true;
+		for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+			constrainedFlag$sample20[index$constrainedFlag$sample20$1] = true;
+		for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+			constrainedFlag$sample83[index$constrainedFlag$sample83$1] = true;
+	}
+
+	@Override
+	public final void logEvidenceProbabilities() {
+		initializeLogProbabilityFields();
+		if(fixedFlag$sample20)
+			logProbabilityValue$sample20();
+		if(fixedFlag$sample83)
+			logProbabilityValue$sample83();
+		if(fixedFlag$sample88)
+			logProbabilityValue$sample88();
+		if(fixedFlag$sample101)
+			logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	@Override
+	public final void logModelProbabilitiesDist() {
+		initializeLogProbabilityFields();
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	@Override
+	public final void logModelProbabilitiesVal() {
+		initializeLogProbabilityFields();
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	@Override
+	public final void propagateObservedValues() {
+		double[] cv$source1 = yObserved;
+		double[] cv$target1 = y;
+		int cv$length1 = cv$target1.length;
+		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1)
+			cv$target1[cv$index1] = cv$source1[cv$index1];
+	}
+
+	@Override
+	public final void setIntermediates() {
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+	}
+
+	@Override
+	public String modelCode() {
+		return "/*\n"
+		     + " * Sandwood\n"
+		     + " *\n"
+		     + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+		     + " * \n"
+		     + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+		     + " */\n"
+		     + "\n"
+		     + "package org.sandwood.compiler.tests.parser;\n"
+		     + "\n"
+		     + "public model LowDimMix(double[] yObserved) {\n"
+		     + "    int N = yObserved.length;\n"
+		     + "\n"
+		     + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+		     + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+		     + "    // the constant normalisation factor for the ordered constraint.\n"
+		     + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+		     + "    double[] mu = new double[2];\n"
+		     + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+		     + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+		     + "\n"
+		     + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+		     + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+		     + "\n"
+		     + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+		     + "    double theta = beta(5.0, 5.0).sample();\n"
+		     + "\n"
+		     + "    // Stan likelihood:\n"
+		     + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+		     + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+		     + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+		     + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+		     + "    boolean[] component = componentDistribution.sample(N);\n"
+		     + "    double[] y = new double[N];\n"
+		     + "\n"
+		     + "    for(int n = 0; n < N; n++) {\n"
+		     + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+		     + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+		     + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+		     + "    }\n"
+		     + "\n"
+		     + "    y.observe(yObserved);\n"
+		     + "}\n"
+		     + "";
+	}
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$SingleThreadCPU_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$SingleThreadCPU_modelSingle.java
@@ -1,0 +1,7293 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.runtime.internal.numericTools.Conjugates;
+import org.sandwood.runtime.internal.numericTools.DistributionSampling;
+import org.sandwood.runtime.internal.numericTools.Gaussian;
+import org.sandwood.runtime.model.ExecutionTarget;
+
+final class LowDimMix$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements LowDimMix$CoreInterface {
+	
+	// Declare the variables for the model.
+	private int N;
+	private boolean[] component;
+	private boolean[] constrainedFlag$sample101;
+	private boolean[] constrainedFlag$sample20;
+	private boolean[] constrainedFlag$sample83;
+	private boolean constrainedFlag$sample88 = true;
+	private double[] cv$var97$stateProbabilityGlobal;
+	private boolean fixedFlag$sample101 = false;
+	private boolean fixedFlag$sample20 = false;
+	private boolean fixedFlag$sample83 = false;
+	private boolean fixedFlag$sample88 = false;
+	private boolean fixedProbFlag$sample101 = false;
+	private boolean fixedProbFlag$sample138 = false;
+	private boolean fixedProbFlag$sample20 = false;
+	private boolean fixedProbFlag$sample83 = false;
+	private boolean fixedProbFlag$sample88 = false;
+	private boolean[] guard$sample20if124$global;
+	private int length$yObserved;
+	private double logProbability$$evidence;
+	private double logProbability$$model;
+	private double logProbability$component;
+	private double logProbability$componentDistribution;
+	private double logProbability$mu;
+	private double logProbability$rawMu;
+	private double[] logProbability$sample20;
+	private double logProbability$sigma;
+	private double logProbability$theta;
+	private double logProbability$var130;
+	private double logProbability$var79;
+	private double logProbability$var97;
+	private double logProbability$y;
+	private double[] mu;
+	private double[] rawMu;
+	private double[] sigma;
+	private boolean system$gibbsForward = true;
+	private double theta;
+	private double[] y;
+	private double[] yObserved;
+
+	public LowDimMix$SingleThreadCPU(ExecutionTarget target) {
+		super(target);
+	}
+
+	// Getter for N.
+	@Override
+	public final int get$N() {
+		return N;
+	}
+
+	// Getter for component.
+	@Override
+	public final boolean[] get$component() {
+		return component;
+	}
+
+	// Setter for component.
+	@Override
+	public final void set$component(boolean[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of component including if probabilities need
+		// to be updated.
+		component = cv$value;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on component.
+		fixedProbFlag$sample101 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on component.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for fixedFlag$sample101.
+	@Override
+	public final boolean get$fixedFlag$sample101() {
+		return fixedFlag$sample101;
+	}
+
+	// Setter for fixedFlag$sample101.
+	@Override
+	public final void set$fixedFlag$sample101(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample101 including if probabilities
+		// need to be updated.
+		fixedFlag$sample101 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+				constrainedFlag$sample101[index$constrainedFlag$sample101$1] = fixedFlag$sample101;
+		}
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedProbFlag$sample101);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample138 = (fixedFlag$sample101 && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample20.
+	@Override
+	public final boolean get$fixedFlag$sample20() {
+		return fixedFlag$sample20;
+	}
+
+	// Setter for fixedFlag$sample20.
+	@Override
+	public final void set$fixedFlag$sample20(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample20 including if probabilities
+		// need to be updated.
+		fixedFlag$sample20 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+				constrainedFlag$sample20[index$constrainedFlag$sample20$1] = fixedFlag$sample20;
+		}
+		
+		// Should the probability of sample 20 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample20 = (fixedFlag$sample20 && fixedProbFlag$sample20);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample138 = (fixedFlag$sample20 && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample83.
+	@Override
+	public final boolean get$fixedFlag$sample83() {
+		return fixedFlag$sample83;
+	}
+
+	// Setter for fixedFlag$sample83.
+	@Override
+	public final void set$fixedFlag$sample83(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample83 including if probabilities
+		// need to be updated.
+		fixedFlag$sample83 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+				constrainedFlag$sample83[index$constrainedFlag$sample83$1] = fixedFlag$sample83;
+		}
+		
+		// Should the probability of sample 83 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample83 = (fixedFlag$sample83 && fixedProbFlag$sample83);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample138 = (fixedFlag$sample83 && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample88.
+	@Override
+	public final boolean get$fixedFlag$sample88() {
+		return fixedFlag$sample88;
+	}
+
+	// Setter for fixedFlag$sample88.
+	@Override
+	public final void set$fixedFlag$sample88(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample88 including if probabilities
+		// need to be updated.
+		fixedFlag$sample88 = cv$value;
+		constrainedFlag$sample88 = (fixedFlag$sample88 || constrainedFlag$sample88);
+		
+		// Should the probability of sample 88 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample88 = (fixedFlag$sample88 && fixedProbFlag$sample88);
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		fixedProbFlag$sample101 = (fixedFlag$sample88 && fixedProbFlag$sample101);
+	}
+
+	// Getter for length$yObserved.
+	@Override
+	public final int get$length$yObserved() {
+		return length$yObserved;
+	}
+
+	// Setter for length$yObserved.
+	@Override
+	public final void set$length$yObserved(int cv$value, boolean allocated$) {
+		length$yObserved = cv$value;
+	}
+
+	// Getter for logProbability$$evidence.
+	@Override
+	public final double get$logProbability$$evidence() {
+		return logProbability$$evidence;
+	}
+
+	// Getter for the probability of logProbability$$model.
+	@Override
+	public final double getCurrentLogProbability() {
+		return logProbability$$model;
+	}
+
+	// Getter for logProbability$component.
+	@Override
+	public final double get$logProbability$component() {
+		return logProbability$component;
+	}
+
+	// Getter for logProbability$componentDistribution.
+	@Override
+	public final double get$logProbability$componentDistribution() {
+		return logProbability$componentDistribution;
+	}
+
+	// Getter for logProbability$mu.
+	@Override
+	public final double get$logProbability$mu() {
+		return logProbability$mu;
+	}
+
+	// Getter for logProbability$rawMu.
+	@Override
+	public final double get$logProbability$rawMu() {
+		return logProbability$rawMu;
+	}
+
+	// Getter for logProbability$sigma.
+	@Override
+	public final double get$logProbability$sigma() {
+		return logProbability$sigma;
+	}
+
+	// Getter for logProbability$theta.
+	@Override
+	public final double get$logProbability$theta() {
+		return logProbability$theta;
+	}
+
+	// Getter for logProbability$y.
+	@Override
+	public final double get$logProbability$y() {
+		return logProbability$y;
+	}
+
+	// Getter for mu.
+	@Override
+	public final double[] get$mu() {
+		return mu;
+	}
+
+	// Getter for rawMu.
+	@Override
+	public final double[] get$rawMu() {
+		return rawMu;
+	}
+
+	// Setter for rawMu.
+	@Override
+	public final void set$rawMu(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of rawMu including if probabilities need to
+		// be updated.
+		rawMu = cv$value;
+		
+		// Unset the fixed probability flag for sample 20 as it depends on rawMu.
+		fixedProbFlag$sample20 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on rawMu.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for sigma.
+	@Override
+	public final double[] get$sigma() {
+		return sigma;
+	}
+
+	// Setter for sigma.
+	@Override
+	public final void set$sigma(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of sigma including if probabilities need to
+		// be updated.
+		sigma = cv$value;
+		
+		// Unset the fixed probability flag for sample 83 as it depends on sigma.
+		fixedProbFlag$sample83 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on sigma.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for theta.
+	@Override
+	public final double get$theta() {
+		return theta;
+	}
+
+	// Setter for theta.
+	@Override
+	public final void set$theta(double cv$value, boolean allocated$) {
+		// Set flags for all the side effects of theta including if probabilities need to
+		// be updated.
+		theta = cv$value;
+		
+		// Unset the fixed probability flag for sample 88 as it depends on theta.
+		fixedProbFlag$sample88 = false;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on theta.
+		fixedProbFlag$sample101 = false;
+	}
+
+	// Getter for y.
+	@Override
+	public final double[] get$y() {
+		return y;
+	}
+
+	// Getter for yObserved.
+	@Override
+	public final double[] get$yObserved() {
+		return yObserved;
+	}
+
+	// Setter for yObserved.
+	@Override
+	public final void set$yObserved(double[] cv$value, boolean allocated$) {
+		yObserved = cv$value;
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample101
+	private final void drawValueSample101(int var96) {
+		component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample20
+	private final void drawValueSample20(int var19) {
+		rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 41.
+		{
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20put43 = false;
+			{
+				if((var19 == 0)) {
+					if(!guard$sample20put43) {
+						// The body will execute, so should not be executed again
+						guard$sample20put43 = true;
+						{
+							double var39;
+							if((rawMu[0] < rawMu[1]))
+								var39 = rawMu[0];
+							else
+								var39 = rawMu[1];
+							mu[0] = var39;
+						}
+					}
+				}
+			}
+			{
+				if((var19 == 1)) {
+					if(!guard$sample20put43) {
+						// The body will execute, so should not be executed again
+						guard$sample20put43 = true;
+						{
+							double var39;
+							if((rawMu[0] < rawMu[1]))
+								var39 = rawMu[0];
+							else
+								var39 = rawMu[1];
+							mu[0] = var39;
+						}
+					}
+				}
+			}
+			{
+				if((rawMu[0] < rawMu[1])) {
+					if((var19 == 0)) {
+						if((rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put43) {
+								// The body will execute, so should not be executed again
+								guard$sample20put43 = true;
+								{
+									double var39;
+									if((rawMu[0] < rawMu[1]))
+										var39 = rawMu[0];
+									else
+										var39 = rawMu[1];
+									mu[0] = var39;
+								}
+							}
+						}
+					}
+				}
+			}
+			{
+				if(!(rawMu[0] < rawMu[1])) {
+					if((var19 == 1)) {
+						if(!(rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put43) {
+								// The body will execute, so should not be executed again
+								guard$sample20put43 = true;
+								{
+									double var39;
+									if((rawMu[0] < rawMu[1]))
+										var39 = rawMu[0];
+									else
+										var39 = rawMu[1];
+									mu[0] = var39;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 59.
+		{
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20put63 = false;
+			{
+				if((var19 == 0)) {
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						{
+							double var57;
+							if((rawMu[0] < rawMu[1]))
+								var57 = rawMu[1];
+							else
+								var57 = rawMu[0];
+							mu[1] = var57;
+						}
+					}
+				}
+			}
+			{
+				if((var19 == 1)) {
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						{
+							double var57;
+							if((rawMu[0] < rawMu[1]))
+								var57 = rawMu[1];
+							else
+								var57 = rawMu[0];
+							mu[1] = var57;
+						}
+					}
+				}
+			}
+			{
+				if((rawMu[0] < rawMu[1])) {
+					if((var19 == 1)) {
+						if((rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put63) {
+								// The body will execute, so should not be executed again
+								guard$sample20put63 = true;
+								{
+									double var57;
+									if((rawMu[0] < rawMu[1]))
+										var57 = rawMu[1];
+									else
+										var57 = rawMu[0];
+									mu[1] = var57;
+								}
+							}
+						}
+					}
+				}
+			}
+			{
+				if(!(rawMu[0] < rawMu[1])) {
+					if((var19 == 0)) {
+						if(!(rawMu[0] < rawMu[1])) {
+							if(!guard$sample20put63) {
+								// The body will execute, so should not be executed again
+								guard$sample20put63 = true;
+								{
+									double var57;
+									if((rawMu[0] < rawMu[1]))
+										var57 = rawMu[1];
+									else
+										var57 = rawMu[0];
+									mu[1] = var57;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample83
+	private final void drawValueSample83(int var78) {
+		sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample88
+	private final void drawValueSample88() {
+		theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 101 drawn from componentDistribution. Inference was performed using
+	// variable marginalization.
+	private final void inferSample101(int var96) {
+		if(true) {
+			constrainedFlag$sample101[((var96 - 0) / 1)] = false;
+			
+			// Calculate the number of states to evaluate.
+			int cv$numStates = 0;
+			{
+				// variable marginalization
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			
+			// Get a local reference to the scratch space.
+			double[] cv$stateProbabilityLocal = cv$var97$stateProbabilityGlobal;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				// Initialize the summed probabilities to 0.
+				double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+				
+				// Initialize a counter to track the reached distributions.
+				double cv$reachedDistributionSourceRV = 0.0;
+				
+				// Initialize a log space accumulator to take the product of all the distribution
+				// probabilities.
+				double cv$accumulatedDistributionProbabilities = 0.0;
+				
+				// The value currently being tested
+				boolean cv$currentValue;
+				
+				// Value of the variable at this index
+				cv$currentValue = (cv$valuePos == 1);
+				
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				boolean var97 = cv$currentValue;
+				
+				// Guards to ensure that component is only updated when there is a valid path.
+				{
+					{
+						{
+							component[var96] = cv$currentValue;
+						}
+					}
+				}
+				{
+					// Record the reached probability density.
+					cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+					
+					// An accumulator to allow the value for each distribution to be constructed before
+					// it is added to the index probabilities.
+					double cv$accumulatedProbabilities = (Math.log(1.0) + (((0.0 <= theta) && (theta <= 1.0))?Math.log((cv$currentValue?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+					
+					// Processing conditional point124.
+					{
+						// Looking for a path between Sample 101 and consumer double 118.
+						{
+							{
+								for(int n = 0; n < N; n += 1) {
+									if((var96 == n)) {
+										{
+											{
+												{
+													if(component[n]) {
+														double traceTempVariable$componentMu$3_1 = mu[0];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentSigma;
+																							if(component[n])
+																								componentSigma = sigma[0];
+																							else
+																								componentSigma = sigma[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (componentSigma * componentSigma);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$3_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 20 and consumer double 118.
+											{
+												// Guard to check that at most one copy of the code is executed for a given random
+												// variable instance.
+												boolean[] guard$sample20if124 = guard$sample20if124$global;
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((0 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((0 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(component[n]) {
+																if((1 == 0)) {
+																	if(component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(component[n]) {
+																		if((1 == 0)) {
+																			if(component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													if(!component[n]) {
+														double traceTempVariable$componentMu$30_1 = mu[1];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentSigma;
+																							if(component[n])
+																								componentSigma = sigma[0];
+																							else
+																								componentSigma = sigma[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (componentSigma * componentSigma);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$30_1) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 20 and consumer double 118.
+											{
+												// Guard to check that at most one copy of the code is executed for a given random
+												// variable instance.
+												boolean[] guard$sample20if124 = guard$sample20if124$global;
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n])
+																		// Set the flags to false
+																		guard$sample20if124[((var19 - 0) / 1)] = false;
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n])
+																				// Set the flags to false
+																				guard$sample20if124[((var19 - 0) / 1)] = false;
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((0 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((0 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 0)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((var19 == 1)) {
+															if(!component[n]) {
+																if((1 == 1)) {
+																	if(!component[n]) {
+																		if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																			// The body will execute, so should not be executed again
+																			guard$sample20if124[((var19 - 0) / 1)] = true;
+																			
+																			// Processing sample task 20 of consumer random variable null.
+																			{
+																				{
+																					// Set an accumulator to sum the probabilities for each possible configuration of
+																					// inputs.
+																					double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																					
+																					// Set an accumulator to record the consumer distributions not seen. Initially set
+																					// to 1 as seen values will be deducted from this value.
+																					double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																					{
+																						{
+																							{
+																								{
+																									// Constructing a random variable input for use later.
+																									double var6 = (2.0 * 2.0);
+																									
+																									// Record the probability of sample task 20 generating output with current configuration.
+																									if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																									else {
+																										// If the second value is -infinity.
+																										if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																											cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																										else
+																											cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																									}
+																									
+																									// Recorded the probability of reaching sample task 20 with the current configuration.
+																									cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																								}
+																							}
+																						}
+																					}
+																					
+																					// A check to ensure rounding of floating point values can never result in a negative
+																					// value.
+																					cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																					
+																					// Multiply (log space add) in the probability of the sample task to the overall probability
+																					// for this configuration of the source random variable.
+																					if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																						else
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if((rawMu[0] < rawMu[1])) {
+															if((var19 == 1)) {
+																if((rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												{
+													for(int var19 = 0; var19 < 2; var19 += 1) {
+														if(!(rawMu[0] < rawMu[1])) {
+															if((var19 == 0)) {
+																if(!(rawMu[0] < rawMu[1])) {
+																	if(!component[n]) {
+																		if((1 == 1)) {
+																			if(!component[n]) {
+																				if(!guard$sample20if124[((var19 - 0) / 1)]) {
+																					// The body will execute, so should not be executed again
+																					guard$sample20if124[((var19 - 0) / 1)] = true;
+																					
+																					// Processing sample task 20 of consumer random variable null.
+																					{
+																						{
+																							// Set an accumulator to sum the probabilities for each possible configuration of
+																							// inputs.
+																							double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																							
+																							// Set an accumulator to record the consumer distributions not seen. Initially set
+																							// to 1 as seen values will be deducted from this value.
+																							double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																							{
+																								{
+																									{
+																										{
+																											// Constructing a random variable input for use later.
+																											double var6 = (2.0 * 2.0);
+																											
+																											// Record the probability of sample task 20 generating output with current configuration.
+																											if(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																												cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																											else {
+																												// If the second value is -infinity.
+																												if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																													cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+																												else
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((rawMu[var19] - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY)));
+																											}
+																											
+																											// Recorded the probability of reaching sample task 20 with the current configuration.
+																											cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																										}
+																									}
+																								}
+																							}
+																							
+																							// A check to ensure rounding of floating point values can never result in a negative
+																							// value.
+																							cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																							
+																							// Multiply (log space add) in the probability of the sample task to the overall probability
+																							// for this configuration of the source random variable.
+																							if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																								else
+																									cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					
+					// Processing conditional point135.
+					{
+						// Looking for a path between Sample 101 and consumer double 127.
+						{
+							{
+								for(int n = 0; n < N; n += 1) {
+									if((var96 == n)) {
+										{
+											{
+												{
+													if(component[n]) {
+														double traceTempVariable$componentSigma$58_1 = sigma[0];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentMu;
+																							if(component[n])
+																								componentMu = mu[0];
+																							else
+																								componentMu = mu[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 83 and consumer double 127.
+											{
+												{
+													for(int var78 = 0; var78 < 2; var78 += 1) {
+														if(component[n]) {
+															if((var78 == 0)) {
+																if(component[n]) {
+																	// Processing sample task 83 of consumer random variable null.
+																	{
+																		{
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							// Constructing a random variable input for use later.
+																							double var63 = (2.0 * 2.0);
+																							
+																							// Record the probability of sample task 83 generating output with current configuration.
+																							if(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 83 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											{
+												{
+													if(!component[n]) {
+														double traceTempVariable$componentSigma$63_1 = sigma[1];
+														
+														// Processing sample task 138 of consumer random variable null.
+														{
+															{
+																// Flag recording if this sample task of the consuming random variable is constrained.
+																boolean cv$sampleConstrained = true;
+																if(cv$sampleConstrained) {
+																	// Mark that the sample has observed constrained data.
+																	constrainedFlag$sample101[((var96 - 0) / 1)] = true;
+																	
+																	// Set an accumulator to sum the probabilities for each possible configuration of
+																	// inputs.
+																	double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																	
+																	// Set an accumulator to record the consumer distributions not seen. Initially set
+																	// to 1 as seen values will be deducted from this value.
+																	double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																	{
+																		{
+																			{
+																				{
+																					{
+																						{
+																							double componentMu;
+																							if(component[n])
+																								componentMu = mu[0];
+																							else
+																								componentMu = mu[1];
+																							
+																							// Constructing a random variable input for use later.
+																							double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+																							
+																							// Record the probability of sample task 138 generating output with current configuration.
+																							if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 138 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																	
+																	// A check to ensure rounding of floating point values can never result in a negative
+																	// value.
+																	cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																	
+																	// Multiply (log space add) in the probability of the sample task to the overall probability
+																	// for this configuration of the source random variable.
+																	if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																	else {
+																		// If the second value is -infinity.
+																		if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																			cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																		else
+																			cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											
+											// Looking for a path between Sample 83 and consumer double 127.
+											{
+												{
+													for(int var78 = 0; var78 < 2; var78 += 1) {
+														if(!component[n]) {
+															if((var78 == 1)) {
+																if(!component[n]) {
+																	// Processing sample task 83 of consumer random variable null.
+																	{
+																		{
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							// Constructing a random variable input for use later.
+																							double var63 = (2.0 * 2.0);
+																							
+																							// Record the probability of sample task 83 generating output with current configuration.
+																							if(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																								cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																							else {
+																								// If the second value is -infinity.
+																								if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																									cv$accumulatedConsumerProbabilities = (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+																								else
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + (((((0.0 <= sigma[var78]) && (sigma[var78] <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((sigma[var78] - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY)));
+																							}
+																							
+																							// Recorded the probability of reaching sample task 83 with the current configuration.
+																							cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					
+					// Add the values for the source and any standard consumers for this configuration
+					// of arguments to the source.
+					if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+						cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+					else {
+						// If the second value is -infinity.
+						if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+							cv$stateProbabilityValue = cv$accumulatedProbabilities;
+						else
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+					}
+				}
+				
+				// Save the calculated index value into the array of index value probabilities
+				cv$stateProbabilityLocal[cv$valuePos] = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+			}
+			if(constrainedFlag$sample101[((var96 - 0) / 1)]) {
+				// The sum of all the probabilities in log space
+				double cv$logSum = 0.0;
+				
+				// Sum all the values
+				{
+					// Initialize the max to the first element.
+					double cv$lseMax = cv$stateProbabilityLocal[0];
+					
+					// Find max value.
+					for(int cv$lseIndex = 1; cv$lseIndex < cv$numStates; cv$lseIndex += 1) {
+						double cv$lseElementValue = cv$stateProbabilityLocal[cv$lseIndex];
+						if((cv$lseMax < cv$lseElementValue))
+							cv$lseMax = cv$lseElementValue;
+					}
+					
+					// If the maximum value is -infinity return -infinity.
+					if((cv$lseMax == Double.NEGATIVE_INFINITY))
+						cv$logSum = Double.NEGATIVE_INFINITY;
+					
+					// Sum the values in the array.
+					else {
+						// Initialize the sum of the array elements
+						double cv$lseSum = 0.0;
+						
+						// Offset values, move to normal space, and sum.
+						for(int cv$lseIndex = 0; cv$lseIndex < cv$numStates; cv$lseIndex += 1)
+							cv$lseSum = (cv$lseSum + Math.exp((cv$stateProbabilityLocal[cv$lseIndex] - cv$lseMax)));
+						
+						// Increment the value of the target, moving the value back into log space.
+						cv$logSum = (cv$logSum + (Math.log(cv$lseSum) + cv$lseMax));
+					}
+				}
+				
+				// If all the sum is zero, just share the probability evenly.
+				if((cv$logSum == Double.NEGATIVE_INFINITY)) {
+					// Normalize log space values and move to normal space
+					for(int cv$indexName = 0; cv$indexName < cv$numStates; cv$indexName += 1)
+						cv$stateProbabilityLocal[cv$indexName] = (1.0 / cv$numStates);
+				} else {
+					// Normalize log space values and move to normal space
+					for(int cv$indexName = 0; cv$indexName < cv$numStates; cv$indexName += 1)
+						cv$stateProbabilityLocal[cv$indexName] = Math.exp((cv$stateProbabilityLocal[cv$indexName] - cv$logSum));
+				}
+				
+				// Set array values that are not computed for the input to negative infinity.
+				for(int cv$indexName = cv$numStates; cv$indexName < cv$stateProbabilityLocal.length; cv$indexName += 1)
+					cv$stateProbabilityLocal[cv$indexName] = Double.NEGATIVE_INFINITY;
+				
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				boolean var97 = (DistributionSampling.sampleCategorical(RNG$, cv$stateProbabilityLocal, cv$numStates) == 1);
+				
+				// Guards to ensure that component is only updated when there is a valid path.
+				{
+					{
+						{
+							component[var96] = var97;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 20 drawn from Gaussian 7. Inference was performed using Metropolis-Hastings.
+	private final void inferSample20(int var19) {
+		if(true) {
+			constrainedFlag$sample20[((var19 - 0) / 1)] = false;
+			
+			// Calculate the number of states to evaluate.
+			int cv$numStates = 0;
+			{
+				// Metropolis-Hastings
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			
+			// The original value of the sample
+			double cv$originalValue = rawMu[var19];
+			
+			// The probability of the random variable generating the originally sampled value
+			double cv$originalProbability = 0.0;
+			
+			// Calculate a proposed variance.
+			double cv$var = ((cv$originalValue * cv$originalValue) * (0.1 * 0.1));
+			
+			// Ensure the variance is at least 0.01
+			if((cv$var < (0.1 * 0.1)))
+				cv$var = (0.1 * 0.1);
+			
+			// The proposed new value for the sample
+			double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+			
+			// The probability of the random variable generating the new sample value.
+			double cv$proposedProbability = 0.0;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				if((constrainedFlag$sample20[((var19 - 0) / 1)] || (cv$valuePos == 0))) {
+					// Initialize the summed probabilities to 0.
+					double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+					
+					// Initialize a counter to track the reached distributions.
+					double cv$reachedDistributionSourceRV = 0.0;
+					
+					// Initialize a log space accumulator to take the product of all the distribution
+					// probabilities.
+					double cv$accumulatedDistributionProbabilities = 0.0;
+					
+					// The value currently being tested
+					double cv$currentValue;
+					if((cv$valuePos == 0))
+						// Set the current value to the current state of the tree.
+						cv$currentValue = cv$originalValue;
+					else {
+						cv$currentValue = cv$proposedValue;
+						
+						// Update Sample and intermediate values
+						// 
+						// Write out the value of the sample to a temporary variable prior to updating the
+						// intermediate variables.
+						double var20 = cv$proposedValue;
+						
+						// Guards to ensure that rawMu is only updated when there is a valid path.
+						{
+							{
+								{
+									rawMu[var19] = cv$currentValue;
+								}
+							}
+						}
+						
+						// Guards to ensure that mu is only updated when there is a valid path.
+						// 
+						// Looking for a path between Sample 20 and consumer double[] 41.
+						{
+							// Guard to check that at most one copy of the code is executed for a given set of
+							// loop iterations.
+							boolean guard$sample20put43 = false;
+							{
+								if((var19 == 0)) {
+									if(!guard$sample20put43) {
+										// The body will execute, so should not be executed again
+										guard$sample20put43 = true;
+										{
+											double var39;
+											if((rawMu[0] < rawMu[1]))
+												var39 = rawMu[0];
+											else
+												var39 = rawMu[1];
+											mu[0] = var39;
+										}
+									}
+								}
+							}
+							{
+								if((var19 == 1)) {
+									if(!guard$sample20put43) {
+										// The body will execute, so should not be executed again
+										guard$sample20put43 = true;
+										{
+											double var39;
+											if((rawMu[0] < rawMu[1]))
+												var39 = rawMu[0];
+											else
+												var39 = rawMu[1];
+											mu[0] = var39;
+										}
+									}
+								}
+							}
+							{
+								if((rawMu[0] < rawMu[1])) {
+									if((var19 == 0)) {
+										if((rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put43) {
+												// The body will execute, so should not be executed again
+												guard$sample20put43 = true;
+												{
+													double var39;
+													if((rawMu[0] < rawMu[1]))
+														var39 = rawMu[0];
+													else
+														var39 = rawMu[1];
+													mu[0] = var39;
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								if(!(rawMu[0] < rawMu[1])) {
+									if((var19 == 1)) {
+										if(!(rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put43) {
+												// The body will execute, so should not be executed again
+												guard$sample20put43 = true;
+												{
+													double var39;
+													if((rawMu[0] < rawMu[1]))
+														var39 = rawMu[0];
+													else
+														var39 = rawMu[1];
+													mu[0] = var39;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Guards to ensure that mu is only updated when there is a valid path.
+						// 
+						// Looking for a path between Sample 20 and consumer double[] 59.
+						{
+							// Guard to check that at most one copy of the code is executed for a given set of
+							// loop iterations.
+							boolean guard$sample20put63 = false;
+							{
+								if((var19 == 0)) {
+									if(!guard$sample20put63) {
+										// The body will execute, so should not be executed again
+										guard$sample20put63 = true;
+										{
+											double var57;
+											if((rawMu[0] < rawMu[1]))
+												var57 = rawMu[1];
+											else
+												var57 = rawMu[0];
+											mu[1] = var57;
+										}
+									}
+								}
+							}
+							{
+								if((var19 == 1)) {
+									if(!guard$sample20put63) {
+										// The body will execute, so should not be executed again
+										guard$sample20put63 = true;
+										{
+											double var57;
+											if((rawMu[0] < rawMu[1]))
+												var57 = rawMu[1];
+											else
+												var57 = rawMu[0];
+											mu[1] = var57;
+										}
+									}
+								}
+							}
+							{
+								if((rawMu[0] < rawMu[1])) {
+									if((var19 == 1)) {
+										if((rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put63) {
+												// The body will execute, so should not be executed again
+												guard$sample20put63 = true;
+												{
+													double var57;
+													if((rawMu[0] < rawMu[1]))
+														var57 = rawMu[1];
+													else
+														var57 = rawMu[0];
+													mu[1] = var57;
+												}
+											}
+										}
+									}
+								}
+							}
+							{
+								if(!(rawMu[0] < rawMu[1])) {
+									if((var19 == 0)) {
+										if(!(rawMu[0] < rawMu[1])) {
+											if(!guard$sample20put63) {
+												// The body will execute, so should not be executed again
+												guard$sample20put63 = true;
+												{
+													double var57;
+													if((rawMu[0] < rawMu[1]))
+														var57 = rawMu[1];
+													else
+														var57 = rawMu[0];
+													mu[1] = var57;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					{
+						// Record the reached probability density.
+						cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+						
+						// Constructing a random variable input for use later.
+						double var6 = (2.0 * 2.0);
+						
+						// An accumulator to allow the value for each distribution to be constructed before
+						// it is added to the index probabilities.
+						double cv$accumulatedProbabilities = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((cv$currentValue - 0.0) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+						
+						// Processing random variable 129.
+						{
+							// Looking for a path between Sample 20 and consumer Gaussian 129.
+							{
+								{
+									double traceTempVariable$var36$10_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$10_2 = traceTempVariable$var36$10_1;
+												double traceTempVariable$var115$10_3 = traceTempVariable$var39$10_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((0 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$10_5 = traceTempVariable$var115$10_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$10_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var36$11_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$11_2 = traceTempVariable$var36$11_1;
+												double traceTempVariable$var117$11_3 = traceTempVariable$var39$11_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((0 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$11_5 = traceTempVariable$var117$11_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$11_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var38$12_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$12_2 = traceTempVariable$var38$12_1;
+												double traceTempVariable$var115$12_3 = traceTempVariable$var39$12_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((0 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$12_5 = traceTempVariable$var115$12_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$12_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var38$13_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var39$13_2 = traceTempVariable$var38$13_1;
+												double traceTempVariable$var117$13_3 = traceTempVariable$var39$13_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((0 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$13_5 = traceTempVariable$var117$13_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$13_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var54$14_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$14_2 = traceTempVariable$var54$14_1;
+												double traceTempVariable$var115$14_3 = traceTempVariable$var57$14_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((1 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$14_5 = traceTempVariable$var115$14_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$14_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var54$15_1 = cv$currentValue;
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$15_2 = traceTempVariable$var54$15_1;
+												double traceTempVariable$var117$15_3 = traceTempVariable$var57$15_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((1 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$15_5 = traceTempVariable$var117$15_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$15_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var56$16_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$16_2 = traceTempVariable$var56$16_1;
+												double traceTempVariable$var115$16_3 = traceTempVariable$var57$16_2;
+												for(int n = 0; n < N; n += 1) {
+													if(component[n]) {
+														if((1 == 0)) {
+															if(component[n]) {
+																double traceTempVariable$componentMu$16_5 = traceTempVariable$var115$16_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$16_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var56$17_1 = cv$currentValue;
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												double traceTempVariable$var57$17_2 = traceTempVariable$var56$17_1;
+												double traceTempVariable$var117$17_3 = traceTempVariable$var57$17_2;
+												for(int n = 0; n < N; n += 1) {
+													if(!component[n]) {
+														if((1 == 1)) {
+															if(!component[n]) {
+																double traceTempVariable$componentMu$17_5 = traceTempVariable$var117$17_3;
+																
+																// Processing sample task 138 of consumer random variable null.
+																{
+																	{
+																		// Flag recording if this sample task of the consuming random variable is constrained.
+																		boolean cv$sampleConstrained = true;
+																		if(cv$sampleConstrained) {
+																			// Mark that the sample has observed constrained data.
+																			constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																			
+																			// Set an accumulator to sum the probabilities for each possible configuration of
+																			// inputs.
+																			double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																			
+																			// Set an accumulator to record the consumer distributions not seen. Initially set
+																			// to 1 as seen values will be deducted from this value.
+																			double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																			{
+																				{
+																					{
+																						{
+																							{
+																								double componentSigma;
+																								if(component[n])
+																									componentSigma = sigma[0];
+																								else
+																									componentSigma = sigma[1];
+																								
+																								// Constructing a random variable input for use later.
+																								double var128 = (componentSigma * componentSigma);
+																								
+																								// Record the probability of sample task 138 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$17_5) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 138 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																			}
+																			
+																			// A check to ensure rounding of floating point values can never result in a negative
+																			// value.
+																			cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																			
+																			// Multiply (log space add) in the probability of the sample task to the overall probability
+																			// for this configuration of the source random variable.
+																			if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																				cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																			else {
+																				// If the second value is -infinity.
+																				if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																					cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																				else
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Processing conditional point41.
+						{
+							// Looking for a path between Sample 20 and consumer double 39.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20if41 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20if41) {
+											// The body will execute, so should not be executed again
+											guard$sample20if41 = true;
+											{
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$36_1 = rawMu[0];
+															double traceTempVariable$var115$36_2 = traceTempVariable$var39$36_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$36_4 = traceTempVariable$var115$36_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$36_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$38_1 = rawMu[0];
+															double traceTempVariable$var117$38_2 = traceTempVariable$var39$38_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$38_4 = traceTempVariable$var117$38_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$38_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$48_1 = 0; index$var19$48_1 < 2; index$var19$48_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$48_1 == 0)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$48_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$52_1 = rawMu[1];
+															double traceTempVariable$var115$52_2 = traceTempVariable$var39$52_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$52_4 = traceTempVariable$var115$52_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$52_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$54_1 = rawMu[1];
+															double traceTempVariable$var117$54_2 = traceTempVariable$var39$54_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$54_4 = traceTempVariable$var117$54_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$54_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$64_1 = 0; index$var19$64_1 < 2; index$var19$64_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$64_1 == 1)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$64_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20if41) {
+											// The body will execute, so should not be executed again
+											guard$sample20if41 = true;
+											{
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$37_1 = rawMu[0];
+															double traceTempVariable$var115$37_2 = traceTempVariable$var39$37_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$37_4 = traceTempVariable$var115$37_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$37_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$39_1 = rawMu[0];
+															double traceTempVariable$var117$39_2 = traceTempVariable$var39$39_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$39_4 = traceTempVariable$var117$39_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$39_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$49_1 = 0; index$var19$49_1 < 2; index$var19$49_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$49_1 == 0)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$49_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 41 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$53_1 = rawMu[1];
+															double traceTempVariable$var115$53_2 = traceTempVariable$var39$53_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((0 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$53_4 = traceTempVariable$var115$53_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$53_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var39$55_1 = rawMu[1];
+															double traceTempVariable$var117$55_2 = traceTempVariable$var39$55_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((0 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$55_4 = traceTempVariable$var117$55_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$55_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 39.
+												{
+													{
+														for(int index$var19$65_1 = 0; index$var19$65_1 < 2; index$var19$65_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$65_1 == 1)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$65_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Processing conditional point61.
+						{
+							// Looking for a path between Sample 20 and consumer double 57.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20if61 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20if61) {
+											// The body will execute, so should not be executed again
+											guard$sample20if61 = true;
+											{
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$70_1 = rawMu[1];
+															double traceTempVariable$var115$70_2 = traceTempVariable$var57$70_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$70_4 = traceTempVariable$var115$70_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$70_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$72_1 = rawMu[1];
+															double traceTempVariable$var117$72_2 = traceTempVariable$var57$72_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$72_4 = traceTempVariable$var117$72_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$72_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$82_1 = 0; index$var19$82_1 < 2; index$var19$82_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$82_1 == 1)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$82_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$86_1 = rawMu[0];
+															double traceTempVariable$var115$86_2 = traceTempVariable$var57$86_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$86_4 = traceTempVariable$var115$86_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$86_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$88_1 = rawMu[0];
+															double traceTempVariable$var117$88_2 = traceTempVariable$var57$88_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$88_4 = traceTempVariable$var117$88_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$88_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$98_1 = 0; index$var19$98_1 < 2; index$var19$98_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$98_1 == 0)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$98_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20if61) {
+											// The body will execute, so should not be executed again
+											guard$sample20if61 = true;
+											{
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$71_1 = rawMu[1];
+															double traceTempVariable$var115$71_2 = traceTempVariable$var57$71_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$71_4 = traceTempVariable$var115$71_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$71_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if((rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$73_1 = rawMu[1];
+															double traceTempVariable$var117$73_2 = traceTempVariable$var57$73_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$73_4 = traceTempVariable$var117$73_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$73_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$83_1 = 0; index$var19$83_1 < 2; index$var19$83_1 += 1) {
+															if((rawMu[0] < rawMu[1])) {
+																if((index$var19$83_1 == 1)) {
+																	if((rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$83_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between If 61 and consumer Gaussian 129.
+												{
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$87_1 = rawMu[0];
+															double traceTempVariable$var115$87_2 = traceTempVariable$var57$87_1;
+															for(int n = 0; n < N; n += 1) {
+																if(component[n]) {
+																	if((1 == 0)) {
+																		if(component[n]) {
+																			double traceTempVariable$componentMu$87_4 = traceTempVariable$var115$87_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$87_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													{
+														if(!(rawMu[0] < rawMu[1])) {
+															double traceTempVariable$var57$89_1 = rawMu[0];
+															double traceTempVariable$var117$89_2 = traceTempVariable$var57$89_1;
+															for(int n = 0; n < N; n += 1) {
+																if(!component[n]) {
+																	if((1 == 1)) {
+																		if(!component[n]) {
+																			double traceTempVariable$componentMu$89_4 = traceTempVariable$var117$89_2;
+																			
+																			// Processing sample task 138 of consumer random variable null.
+																			{
+																				{
+																					// Flag recording if this sample task of the consuming random variable is constrained.
+																					boolean cv$sampleConstrained = true;
+																					if(cv$sampleConstrained) {
+																						// Mark that the sample has observed constrained data.
+																						constrainedFlag$sample20[((var19 - 0) / 1)] = true;
+																						
+																						// Set an accumulator to sum the probabilities for each possible configuration of
+																						// inputs.
+																						double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																						
+																						// Set an accumulator to record the consumer distributions not seen. Initially set
+																						// to 1 as seen values will be deducted from this value.
+																						double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																						{
+																							{
+																								{
+																									{
+																										{
+																											{
+																												double componentSigma;
+																												if(component[n])
+																													componentSigma = sigma[0];
+																												else
+																													componentSigma = sigma[1];
+																												
+																												// Constructing a random variable input for use later.
+																												double var128 = (componentSigma * componentSigma);
+																												
+																												// Record the probability of sample task 138 generating output with current configuration.
+																												if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																													cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																												else {
+																													// If the second value is -infinity.
+																													if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																														cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																													else
+																														cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$componentMu$89_4) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																												}
+																												
+																												// Recorded the probability of reaching sample task 138 with the current configuration.
+																												cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						
+																						// A check to ensure rounding of floating point values can never result in a negative
+																						// value.
+																						cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																						
+																						// Multiply (log space add) in the probability of the sample task to the overall probability
+																						// for this configuration of the source random variable.
+																						if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																							cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																						else {
+																							// If the second value is -infinity.
+																							if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																								cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																							else
+																								cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+												
+												// Looking for a path between Sample 20 and consumer double 57.
+												{
+													{
+														for(int index$var19$99_1 = 0; index$var19$99_1 < 2; index$var19$99_1 += 1) {
+															if(!(rawMu[0] < rawMu[1])) {
+																if((index$var19$99_1 == 0)) {
+																	if(!(rawMu[0] < rawMu[1])) {
+																		// Processing sample task 20 of consumer random variable null.
+																		{
+																			{
+																				// Set an accumulator to sum the probabilities for each possible configuration of
+																				// inputs.
+																				double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																				
+																				// Set an accumulator to record the consumer distributions not seen. Initially set
+																				// to 1 as seen values will be deducted from this value.
+																				double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																				{
+																					{
+																						{
+																							{
+																								// Record the probability of sample task 20 generating output with current configuration.
+																								if(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																									cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																								else {
+																									// If the second value is -infinity.
+																									if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																										cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY));
+																									else
+																										cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < (2.0 * 2.0))?(DistributionSampling.logProbabilityGaussian(((rawMu[index$var19$99_1] - 0.0) / Math.sqrt((2.0 * 2.0)))) - (0.5 * Math.log((2.0 * 2.0)))):Double.NEGATIVE_INFINITY)));
+																								}
+																								
+																								// Recorded the probability of reaching sample task 20 with the current configuration.
+																								cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																							}
+																						}
+																					}
+																				}
+																				
+																				// A check to ensure rounding of floating point values can never result in a negative
+																				// value.
+																				cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																				
+																				// Multiply (log space add) in the probability of the sample task to the overall probability
+																				// for this configuration of the source random variable.
+																				if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																					cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																				else {
+																					// If the second value is -infinity.
+																					if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																						cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																					else
+																						cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Add the values for the source and any standard consumers for this configuration
+						// of arguments to the source.
+						if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+						else {
+							// If the second value is -infinity.
+							if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+								cv$stateProbabilityValue = cv$accumulatedProbabilities;
+							else
+								cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// Save the probability of the original value.
+					if((cv$valuePos == 0))
+						cv$originalProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// Save the probability of the proposed value.
+					else
+						cv$proposedProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// The probability ration for the proposed value and the current value.
+					double cv$ratio = (cv$proposedProbability - cv$originalProbability);
+					
+					// Test if the probability of the sample is sufficient to keep the value. This needs
+					// to be less than or equal as otherwise if the proposed value is not possible and
+					// the random value is 0 an impossible value will be accepted.
+					if((cv$valuePos == 1)) {
+						if(((cv$ratio <= Math.log((0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$))))) || Double.isNaN(cv$ratio))) {
+							// If it is not revert the changes.
+							// 
+							// Set the sample value
+							// Write out the value of the sample to a temporary variable prior to updating the
+							// intermediate variables.
+							double var20 = cv$originalValue;
+							
+							// Guards to ensure that rawMu is only updated when there is a valid path.
+							{
+								{
+									{
+										rawMu[var19] = var20;
+									}
+								}
+							}
+							
+							// Guards to ensure that mu is only updated when there is a valid path.
+							// 
+							// Looking for a path between Sample 20 and consumer double[] 41.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20put43 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20put43) {
+											// The body will execute, so should not be executed again
+											guard$sample20put43 = true;
+											{
+												double var39;
+												if((rawMu[0] < rawMu[1]))
+													var39 = rawMu[0];
+												else
+													var39 = rawMu[1];
+												mu[0] = var39;
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20put43) {
+											// The body will execute, so should not be executed again
+											guard$sample20put43 = true;
+											{
+												double var39;
+												if((rawMu[0] < rawMu[1]))
+													var39 = rawMu[0];
+												else
+													var39 = rawMu[1];
+												mu[0] = var39;
+											}
+										}
+									}
+								}
+								{
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if((rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put43) {
+													// The body will execute, so should not be executed again
+													guard$sample20put43 = true;
+													{
+														double var39;
+														if((rawMu[0] < rawMu[1]))
+															var39 = rawMu[0];
+														else
+															var39 = rawMu[1];
+														mu[0] = var39;
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put43) {
+													// The body will execute, so should not be executed again
+													guard$sample20put43 = true;
+													{
+														double var39;
+														if((rawMu[0] < rawMu[1]))
+															var39 = rawMu[0];
+														else
+															var39 = rawMu[1];
+														mu[0] = var39;
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+							
+							// Guards to ensure that mu is only updated when there is a valid path.
+							// 
+							// Looking for a path between Sample 20 and consumer double[] 59.
+							{
+								// Guard to check that at most one copy of the code is executed for a given set of
+								// loop iterations.
+								boolean guard$sample20put63 = false;
+								{
+									if((var19 == 0)) {
+										if(!guard$sample20put63) {
+											// The body will execute, so should not be executed again
+											guard$sample20put63 = true;
+											{
+												double var57;
+												if((rawMu[0] < rawMu[1]))
+													var57 = rawMu[1];
+												else
+													var57 = rawMu[0];
+												mu[1] = var57;
+											}
+										}
+									}
+								}
+								{
+									if((var19 == 1)) {
+										if(!guard$sample20put63) {
+											// The body will execute, so should not be executed again
+											guard$sample20put63 = true;
+											{
+												double var57;
+												if((rawMu[0] < rawMu[1]))
+													var57 = rawMu[1];
+												else
+													var57 = rawMu[0];
+												mu[1] = var57;
+											}
+										}
+									}
+								}
+								{
+									if((rawMu[0] < rawMu[1])) {
+										if((var19 == 1)) {
+											if((rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put63) {
+													// The body will execute, so should not be executed again
+													guard$sample20put63 = true;
+													{
+														double var57;
+														if((rawMu[0] < rawMu[1]))
+															var57 = rawMu[1];
+														else
+															var57 = rawMu[0];
+														mu[1] = var57;
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									if(!(rawMu[0] < rawMu[1])) {
+										if((var19 == 0)) {
+											if(!(rawMu[0] < rawMu[1])) {
+												if(!guard$sample20put63) {
+													// The body will execute, so should not be executed again
+													guard$sample20put63 = true;
+													{
+														double var57;
+														if((rawMu[0] < rawMu[1]))
+															var57 = rawMu[1];
+														else
+															var57 = rawMu[0];
+														mu[1] = var57;
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 83 drawn from TruncatedGaussian 66. Inference was performed using
+	// Metropolis-Hastings.
+	private final void inferSample83(int var78) {
+		if(true) {
+			constrainedFlag$sample83[((var78 - 0) / 1)] = false;
+			
+			// Calculate the number of states to evaluate.
+			int cv$numStates = 0;
+			{
+				// Metropolis-Hastings
+				cv$numStates = Math.max(cv$numStates, 2);
+			}
+			
+			// The original value of the sample
+			double cv$originalValue = sigma[var78];
+			
+			// The probability of the random variable generating the originally sampled value
+			double cv$originalProbability = 0.0;
+			
+			// Calculate a proposed variance.
+			double cv$var = ((cv$originalValue * cv$originalValue) * (0.1 * 0.1));
+			
+			// Ensure the variance is at least 0.01
+			if((cv$var < (0.1 * 0.1)))
+				cv$var = (0.1 * 0.1);
+			
+			// The proposed new value for the sample
+			double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+			
+			// The probability of the random variable generating the new sample value.
+			double cv$proposedProbability = 0.0;
+			for(int cv$valuePos = 0; cv$valuePos < cv$numStates; cv$valuePos += 1) {
+				if((constrainedFlag$sample83[((var78 - 0) / 1)] || (cv$valuePos == 0))) {
+					// Initialize the summed probabilities to 0.
+					double cv$stateProbabilityValue = Double.NEGATIVE_INFINITY;
+					
+					// Initialize a counter to track the reached distributions.
+					double cv$reachedDistributionSourceRV = 0.0;
+					
+					// Initialize a log space accumulator to take the product of all the distribution
+					// probabilities.
+					double cv$accumulatedDistributionProbabilities = 0.0;
+					
+					// The value currently being tested
+					double cv$currentValue;
+					if((cv$valuePos == 0))
+						// Set the current value to the current state of the tree.
+						cv$currentValue = cv$originalValue;
+					else {
+						cv$currentValue = cv$proposedValue;
+						
+						// Update Sample and intermediate values
+						// 
+						// Write out the value of the sample to a temporary variable prior to updating the
+						// intermediate variables.
+						double var79 = cv$proposedValue;
+						
+						// Guards to ensure that sigma is only updated when there is a valid path.
+						{
+							{
+								{
+									sigma[var78] = cv$currentValue;
+								}
+							}
+						}
+					}
+					{
+						// Record the reached probability density.
+						cv$reachedDistributionSourceRV = (cv$reachedDistributionSourceRV + 1.0);
+						
+						// Constructing a random variable input for use later.
+						double var63 = (2.0 * 2.0);
+						
+						// An accumulator to allow the value for each distribution to be constructed before
+						// it is added to the index probabilities.
+						double cv$accumulatedProbabilities = (Math.log(1.0) + (((((0.0 <= cv$currentValue) && (cv$currentValue <= 1.0E100)) && (0.0 < 1.0E100)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((cv$currentValue - 0.0) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt(var63))) - Gaussian.cdf(((0.0 - 0.0) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+						
+						// Processing random variable 129.
+						{
+							// Looking for a path between Sample 83 and consumer Gaussian 129.
+							{
+								{
+									double traceTempVariable$var124$2_1 = cv$currentValue;
+									for(int n = 0; n < N; n += 1) {
+										if(component[n]) {
+											if((var78 == 0)) {
+												if(component[n]) {
+													double traceTempVariable$componentSigma$2_3 = traceTempVariable$var124$2_1;
+													
+													// Processing sample task 138 of consumer random variable null.
+													{
+														{
+															// Flag recording if this sample task of the consuming random variable is constrained.
+															boolean cv$sampleConstrained = true;
+															if(cv$sampleConstrained) {
+																// Mark that the sample has observed constrained data.
+																constrainedFlag$sample83[((var78 - 0) / 1)] = true;
+																
+																// Set an accumulator to sum the probabilities for each possible configuration of
+																// inputs.
+																double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																
+																// Set an accumulator to record the consumer distributions not seen. Initially set
+																// to 1 as seen values will be deducted from this value.
+																double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																{
+																	{
+																		{
+																			{
+																				{
+																					double componentMu;
+																					if(component[n])
+																						componentMu = mu[0];
+																					else
+																						componentMu = mu[1];
+																					
+																					// Constructing a random variable input for use later.
+																					double var128 = (traceTempVariable$componentSigma$2_3 * traceTempVariable$componentSigma$2_3);
+																					
+																					// Record the probability of sample task 138 generating output with current configuration.
+																					if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																						else
+																							cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																					}
+																					
+																					// Recorded the probability of reaching sample task 138 with the current configuration.
+																					cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																				}
+																			}
+																		}
+																	}
+																}
+																
+																// A check to ensure rounding of floating point values can never result in a negative
+																// value.
+																cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																
+																// Multiply (log space add) in the probability of the sample task to the overall probability
+																// for this configuration of the source random variable.
+																if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																	cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																else {
+																	// If the second value is -infinity.
+																	if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																		cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																	else
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								{
+									double traceTempVariable$var126$3_1 = cv$currentValue;
+									for(int n = 0; n < N; n += 1) {
+										if(!component[n]) {
+											if((var78 == 1)) {
+												if(!component[n]) {
+													double traceTempVariable$componentSigma$3_3 = traceTempVariable$var126$3_1;
+													
+													// Processing sample task 138 of consumer random variable null.
+													{
+														{
+															// Flag recording if this sample task of the consuming random variable is constrained.
+															boolean cv$sampleConstrained = true;
+															if(cv$sampleConstrained) {
+																// Mark that the sample has observed constrained data.
+																constrainedFlag$sample83[((var78 - 0) / 1)] = true;
+																
+																// Set an accumulator to sum the probabilities for each possible configuration of
+																// inputs.
+																double cv$accumulatedConsumerProbabilities = Double.NEGATIVE_INFINITY;
+																
+																// Set an accumulator to record the consumer distributions not seen. Initially set
+																// to 1 as seen values will be deducted from this value.
+																double cv$consumerDistributionProbabilityAccumulator = 1.0;
+																{
+																	{
+																		{
+																			{
+																				{
+																					double componentMu;
+																					if(component[n])
+																						componentMu = mu[0];
+																					else
+																						componentMu = mu[1];
+																					
+																					// Constructing a random variable input for use later.
+																					double var128 = (traceTempVariable$componentSigma$3_3 * traceTempVariable$componentSigma$3_3);
+																					
+																					// Record the probability of sample task 138 generating output with current configuration.
+																					if(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) < cv$accumulatedConsumerProbabilities))
+																						cv$accumulatedConsumerProbabilities = (Math.log((Math.exp(((Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities);
+																					else {
+																						// If the second value is -infinity.
+																						if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																							cv$accumulatedConsumerProbabilities = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+																						else
+																							cv$accumulatedConsumerProbabilities = (Math.log((Math.exp((cv$accumulatedConsumerProbabilities - (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)))) + 1)) + (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY)));
+																					}
+																					
+																					// Recorded the probability of reaching sample task 138 with the current configuration.
+																					cv$consumerDistributionProbabilityAccumulator = (cv$consumerDistributionProbabilityAccumulator - 1.0);
+																				}
+																			}
+																		}
+																	}
+																}
+																
+																// A check to ensure rounding of floating point values can never result in a negative
+																// value.
+																cv$consumerDistributionProbabilityAccumulator = Math.max(cv$consumerDistributionProbabilityAccumulator, 0.0);
+																
+																// Multiply (log space add) in the probability of the sample task to the overall probability
+																// for this configuration of the source random variable.
+																if((Math.log(cv$consumerDistributionProbabilityAccumulator) < cv$accumulatedConsumerProbabilities))
+																	cv$accumulatedProbabilities = ((Math.log((Math.exp((Math.log(cv$consumerDistributionProbabilityAccumulator) - cv$accumulatedConsumerProbabilities)) + 1)) + cv$accumulatedConsumerProbabilities) + cv$accumulatedProbabilities);
+																else {
+																	// If the second value is -infinity.
+																	if((cv$accumulatedConsumerProbabilities == Double.NEGATIVE_INFINITY))
+																		cv$accumulatedProbabilities = (Math.log(cv$consumerDistributionProbabilityAccumulator) + cv$accumulatedProbabilities);
+																	else
+																		cv$accumulatedProbabilities = ((Math.log((Math.exp((cv$accumulatedConsumerProbabilities - Math.log(cv$consumerDistributionProbabilityAccumulator))) + 1)) + Math.log(cv$consumerDistributionProbabilityAccumulator)) + cv$accumulatedProbabilities);
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						
+						// Add the values for the source and any standard consumers for this configuration
+						// of arguments to the source.
+						if((cv$accumulatedProbabilities < cv$stateProbabilityValue))
+							cv$stateProbabilityValue = (Math.log((Math.exp((cv$accumulatedProbabilities - cv$stateProbabilityValue)) + 1)) + cv$stateProbabilityValue);
+						else {
+							// If the second value is -infinity.
+							if((cv$stateProbabilityValue == Double.NEGATIVE_INFINITY))
+								cv$stateProbabilityValue = cv$accumulatedProbabilities;
+							else
+								cv$stateProbabilityValue = (Math.log((Math.exp((cv$stateProbabilityValue - cv$accumulatedProbabilities)) + 1)) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// Save the probability of the original value.
+					if((cv$valuePos == 0))
+						cv$originalProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// Save the probability of the proposed value.
+					else
+						cv$proposedProbability = ((cv$stateProbabilityValue - Math.log(cv$reachedDistributionSourceRV)) + cv$accumulatedDistributionProbabilities);
+					
+					// The probability ration for the proposed value and the current value.
+					double cv$ratio = (cv$proposedProbability - cv$originalProbability);
+					
+					// Test if the probability of the sample is sufficient to keep the value. This needs
+					// to be less than or equal as otherwise if the proposed value is not possible and
+					// the random value is 0 an impossible value will be accepted.
+					if((cv$valuePos == 1)) {
+						if(((cv$ratio <= Math.log((0.0 + ((1.0 - 0.0) * DistributionSampling.sampleUniform(RNG$))))) || Double.isNaN(cv$ratio))) {
+							// If it is not revert the changes.
+							// 
+							// Set the sample value
+							// Write out the value of the sample to a temporary variable prior to updating the
+							// intermediate variables.
+							double var79 = cv$originalValue;
+							
+							// Guards to ensure that sigma is only updated when there is a valid path.
+							{
+								{
+									{
+										sigma[var78] = var79;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 88 drawn from Beta 83. Inference was performed using a Beta to Bernoulli/Binomial
+	// conjugate prior.
+	private final void inferSample88() {
+		if(true) {
+			constrainedFlag$sample88 = false;
+			
+			// Local variable to record the number of true samples.
+			int cv$sum = 0;
+			
+			// Local variable to record the number of samples.
+			int cv$count = 0;
+			{
+				// Processing random variable 85.
+				{
+					{
+						{
+							// Processing sample task 101 of consumer random variable componentDistribution.
+							{
+								{
+									for(int var96 = 0; var96 < N; var96 += 1) {
+										// Flag recording if this sample task of the consuming random variable is constrained.
+										boolean cv$sampleConstrained = (fixedFlag$sample101 || constrainedFlag$sample101[((var96 - 0) / 1)]);
+										if(cv$sampleConstrained) {
+											// Mark that the sample has observed constrained data.
+											constrainedFlag$sample88 = true;
+											{
+												{
+													{
+														{
+															{
+																// Include the value sampled by task 101 from random variable componentDistribution.
+																// Increment the number of samples.
+																cv$count = (cv$count + 1);
+																
+																// If the sample value was positive increase the count
+																if(component[var96])
+																	cv$sum = (cv$sum + 1);
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			if(constrainedFlag$sample88)
+				// Write out the new value of the sample.
+				theta = Conjugates.sampleConjugateBetaBinomial(RNG$, 5.0, 5.0, cv$sum, cv$count);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample101 using sampled
+	// values.
+	private final void logProbabilityValue$sample101() {
+		// Determine if we need to calculate the values for sample task 101 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample101) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						boolean cv$sampleValue = component[var96];
+						{
+							{
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + (((0.0 <= theta) && (theta <= 1.0))?Math.log((cv$sampleValue?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			if(cv$sampleReached)
+				logProbability$componentDistribution = cv$sampleAccumulator;
+			
+			// Only update the sample if it was reached, otherwise the NaN will be
+			// erroneously over written.
+			if(cv$sampleReached)
+				// Store the random variable instance probability
+				logProbability$var97 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			logProbability$component = (logProbability$component + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedFlag$sample88);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1)
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var97;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			if(cv$sampleReached)
+				logProbability$componentDistribution = cv$rvAccumulator;
+			
+			// Update the variable probability
+			logProbability$component = (logProbability$component + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample138 using sampled
+	// values.
+	private final void logProbabilityValue$sample138() {
+		// Determine if we need to calculate the values for sample task 138 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample138) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						double cv$sampleValue = y[n];
+						{
+							{
+								double componentMu;
+								if(component[n])
+									componentMu = mu[0];
+								else
+									componentMu = mu[1];
+								double componentSigma;
+								if(component[n])
+									componentSigma = sigma[0];
+								else
+									componentSigma = sigma[1];
+								double var128 = (componentSigma * componentSigma);
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - componentMu) / Math.sqrt(var128))) - (0.5 * Math.log(var128))):Double.NEGATIVE_INFINITY));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Only update the sample if it was reached, otherwise the NaN will be
+			// erroneously over written.
+			if(cv$sampleReached)
+				// Store the random variable instance probability
+				logProbability$var130 = cv$accumulator;
+			
+			// Update the variable probability
+			logProbability$y = (logProbability$y + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample138 = ((fixedFlag$sample20 && fixedFlag$sample83) && fixedFlag$sample101);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1)
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var130;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Update the variable probability
+			logProbability$y = (logProbability$y + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample20 using sampled
+	// values.
+	private final void logProbabilityValue$sample20() {
+		// Determine if we need to calculate the values for sample task 20 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample20) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						double cv$sampleValue = rawMu[var19];
+						{
+							{
+								double var3 = 0.0;
+								double var6 = (2.0 * 2.0);
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + ((0.0 < var6)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var3) / Math.sqrt(var6))) - (0.5 * Math.log(var6))):Double.NEGATIVE_INFINITY));
+								
+								// Looking for a path between Put 21 and consumer double 39.
+								{
+									// Guard to check that at most one copy of the code is executed for a given set of
+									// loop iterations.
+									boolean guard$put21if41 = false;
+									{
+										if((var19 == 0)) {
+											if(!guard$put21if41)
+												// The body will execute, so should not be executed again
+												guard$put21if41 = true;
+										}
+									}
+									{
+										if((var19 == 1)) {
+											if(!guard$put21if41)
+												// The body will execute, so should not be executed again
+												guard$put21if41 = true;
+										}
+									}
+								}
+								
+								// Looking for a path between Put 21 and consumer double 57.
+								{
+									// Guard to check that at most one copy of the code is executed for a given set of
+									// loop iterations.
+									boolean guard$put21if61 = false;
+									{
+										if((var19 == 0)) {
+											if(!guard$put21if61)
+												// The body will execute, so should not be executed again
+												guard$put21if61 = true;
+										}
+									}
+									{
+										if((var19 == 1)) {
+											if(!guard$put21if61)
+												// The body will execute, so should not be executed again
+												guard$put21if61 = true;
+										}
+									}
+								}
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+				
+				// Only update the sample if it was reached, otherwise the NaN will be
+				// erroneously over written.
+				if(cv$sampleReached)
+					// Store the sample task probability
+					logProbability$sample20[((var19 - 0) / 1)] = cv$sampleProbability;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleProbability);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Update the variable probability
+			logProbability$rawMu = (logProbability$rawMu + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample20 = fixedFlag$sample20;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				double cv$sampleValue = logProbability$sample20[((var19 - 0) / 1)];
+				cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				{
+					{
+						if((rawMu[0] < rawMu[1])) {
+							if((var19 == 1)) {
+								if((rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+					{
+						if(!(rawMu[0] < rawMu[1])) {
+							if((var19 == 0)) {
+								if(!(rawMu[0] < rawMu[1])) {
+									// If the probability of the variable has not already been updated
+									if(!cv$guard$mu) {
+										// Set the guard so the update is only applied once.
+										cv$guard$mu = true;
+										
+										// Update the variable probability
+										logProbability$mu = (logProbability$mu + cv$sampleValue);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Update the variable probability
+			logProbability$rawMu = (logProbability$rawMu + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample83 using sampled
+	// values.
+	private final void logProbabilityValue$sample83() {
+		// Determine if we need to calculate the values for sample task 83 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample83) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var78 = 0; var78 < 2; var78 += 1) {
+				// An accumulator for log probabilities.
+				double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				
+				// An accumulator for the distributed probability space covered.
+				double cv$probabilityReached = 0.0;
+				{
+					{
+						// The sample value to calculate the probability of generating
+						double cv$sampleValue = sigma[var78];
+						{
+							{
+								double var60 = 0.0;
+								double var63 = (2.0 * 2.0);
+								double var64 = 0.0;
+								double var65 = 1.0E100;
+								
+								// Store the value of the function call, so the function call is only made once.
+								double cv$weightedProbability = (Math.log(1.0) + (((((var64 <= cv$sampleValue) && (cv$sampleValue <= var65)) && (var64 < var65)) && (0.0 < var63))?(((0.0 < var63)?(DistributionSampling.logProbabilityGaussian(((cv$sampleValue - var60) / Math.sqrt(var63))) - (0.5 * Math.log(var63))):Double.NEGATIVE_INFINITY) - Math.log((Gaussian.cdf(((var65 - var60) / Math.sqrt(var63))) - Gaussian.cdf(((var64 - var60) / Math.sqrt(var63)))))):Double.NEGATIVE_INFINITY));
+								
+								// Add the probability of this sample task to the distribution accumulator.
+								if((cv$weightedProbability < cv$distributionAccumulator))
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+								else {
+									// If the second value is -infinity.
+									if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+										cv$distributionAccumulator = cv$weightedProbability;
+									else
+										cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+								}
+								
+								// Add the probability of this distribution configuration to the accumulator.
+								cv$probabilityReached = (cv$probabilityReached + 1.0);
+							}
+						}
+					}
+				}
+				if((cv$probabilityReached == 0.0))
+					// Return negative infinity if no distribution probability space is reached.
+					cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+				else
+					// Scale the probability relative to the observed distribution space.
+					cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+				double cv$sampleProbability = cv$distributionAccumulator;
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			}
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Only update the sample if it was reached, otherwise the NaN will be
+			// erroneously over written.
+			if(cv$sampleReached)
+				// Store the random variable instance probability
+				logProbability$var79 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			logProbability$sigma = (logProbability$sigma + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample83 = fixedFlag$sample83;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var78 = 0; var78 < 2; var78 += 1)
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+			double cv$sampleValue = logProbability$var79;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Update the variable probability
+			logProbability$sigma = (logProbability$sigma + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample88 using sampled
+	// values.
+	private final void logProbabilityValue$sample88() {
+		// Determine if we need to calculate the values for sample task 88 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample88) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// An accumulator for log probabilities.
+			double cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			
+			// An accumulator for the distributed probability space covered.
+			double cv$probabilityReached = 0.0;
+			{
+				{
+					// The sample value to calculate the probability of generating
+					double cv$sampleValue = theta;
+					{
+						{
+							double var81 = 5.0;
+							double var82 = 5.0;
+							
+							// Store the value of the function call, so the function call is only made once.
+							double cv$weightedProbability = (Math.log(1.0) + DistributionSampling.logProbabilityBeta(cv$sampleValue, var81, var82));
+							
+							// Add the probability of this sample task to the distribution accumulator.
+							if((cv$weightedProbability < cv$distributionAccumulator))
+								cv$distributionAccumulator = (Math.log((Math.exp((cv$weightedProbability - cv$distributionAccumulator)) + 1)) + cv$distributionAccumulator);
+							else {
+								// If the second value is -infinity.
+								if((cv$distributionAccumulator == Double.NEGATIVE_INFINITY))
+									cv$distributionAccumulator = cv$weightedProbability;
+								else
+									cv$distributionAccumulator = (Math.log((Math.exp((cv$distributionAccumulator - cv$weightedProbability)) + 1)) + cv$weightedProbability);
+							}
+							
+							// Add the probability of this distribution configuration to the accumulator.
+							cv$probabilityReached = (cv$probabilityReached + 1.0);
+						}
+					}
+				}
+			}
+			if((cv$probabilityReached == 0.0))
+				// Return negative infinity if no distribution probability space is reached.
+				cv$distributionAccumulator = Double.NEGATIVE_INFINITY;
+			else
+				// Scale the probability relative to the observed distribution space.
+				cv$distributionAccumulator = (cv$distributionAccumulator - Math.log(cv$probabilityReached));
+			double cv$sampleProbability = cv$distributionAccumulator;
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$sampleProbability);
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			cv$accumulator = (cv$accumulator + cv$sampleAccumulator);
+			
+			// Store the sample task probability
+			logProbability$theta = cv$sampleProbability;
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample88 = fixedFlag$sample88;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			double cv$rvAccumulator = 0.0;
+			double cv$sampleValue = logProbability$theta;
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			cv$accumulator = (cv$accumulator + cv$rvAccumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Method to allocate space temporary variables used by the inference methods. Allocating
+	// here prevents repeated allocation and deallocation, and makes the code more amenable
+	// to GPU execution.
+	@Override
+	public final void allocateScratch() {
+		// Allocate scratch space.
+		// Constructor for cv$var97$stateProbabilityGlobal
+		{
+			// Allocation of cv$var97$stateProbabilityGlobal for single threaded execution
+			cv$var97$stateProbabilityGlobal = new double[2];
+		}
+		
+		// Constructor for guard$sample20if124$global
+		{
+			// Calculate the largest index of var19 that is possible and allocate an array to
+			// hold the guard for each of these.
+			int cv$max_var19 = 0;
+			cv$max_var19 = Math.max(cv$max_var19, ((2 - 0) / 1));
+			
+			// Allocation of guard$sample20if124$global for single threaded execution
+			guard$sample20if124$global = new boolean[cv$max_var19];
+		}
+	}
+
+	// Method to allocate space for model inputs and outputs.
+	@Override
+	public final void allocator() {
+		// If rawMu has not been set already allocate space.
+		if(!fixedFlag$sample20) {
+			// Constructor for rawMu
+			{
+				rawMu = new double[2];
+			}
+		}
+		
+		// Constructor for mu
+		{
+			mu = new double[2];
+		}
+		
+		// If sigma has not been set already allocate space.
+		if(!fixedFlag$sample83) {
+			// Constructor for sigma
+			{
+				sigma = new double[2];
+			}
+		}
+		
+		// If component has not been set already allocate space.
+		if(!fixedFlag$sample101) {
+			// Constructor for component
+			{
+				component = new boolean[length$yObserved];
+			}
+		}
+		
+		// Constructor for y
+		{
+			y = new double[length$yObserved];
+		}
+		
+		// Constructor for constrainedFlag$sample101
+		{
+			constrainedFlag$sample101 = new boolean[((((length$yObserved - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for constrainedFlag$sample20
+		{
+			constrainedFlag$sample20 = new boolean[((((2 - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for constrainedFlag$sample83
+		{
+			constrainedFlag$sample83 = new boolean[((((2 - 1) - 0) / 1) + 1)];
+		}
+		
+		// Constructor for logProbability$sample20
+		{
+			logProbability$sample20 = new double[((((2 - 1) - 0) / 1) + 1)];
+		}
+		
+		// Allocate scratch space
+		allocateScratch();
+	}
+
+	// Method to execute the model code conventionally.
+	@Override
+	public final void forwardGeneration() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[0];
+		} else {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[1];
+		}
+		if(!fixedFlag$sample20)
+			mu[0] = var39;
+		double var57 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[1];
+		} else {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[0];
+		}
+		if(!fixedFlag$sample20)
+			mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+		for(int n = 0; n < N; n += 1) {
+			double componentMu;
+			if(component[n])
+				componentMu = mu[0];
+			else
+				componentMu = mu[1];
+			double componentSigma;
+			if(component[n])
+				componentSigma = sigma[0];
+			else
+				componentSigma = sigma[1];
+			y[n] = ((Math.sqrt((componentSigma * componentSigma)) * DistributionSampling.sampleGaussian(RNG$)) + componentMu);
+		}
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are calculated
+	// and stored.
+	@Override
+	public final void forwardGenerationDistributionsNoOutputsPrime() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	// Method to execute the model code conventionally with priming of fixed intermediate
+	// variables.
+	@Override
+	public final void forwardGenerationPrime() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+		for(int n = 0; n < N; n += 1) {
+			double componentMu;
+			if(component[n])
+				componentMu = mu[0];
+			else
+				componentMu = mu[1];
+			double componentSigma;
+			if(component[n])
+				componentSigma = sigma[0];
+			else
+				componentSigma = sigma[1];
+			y[n] = ((Math.sqrt((componentSigma * componentSigma)) * DistributionSampling.sampleGaussian(RNG$)) + componentMu);
+		}
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Distributions are collapsed to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputs() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[0];
+		} else {
+			if(!fixedFlag$sample20)
+				var39 = rawMu[1];
+		}
+		if(!fixedFlag$sample20)
+			mu[0] = var39;
+		double var57 = 0.0;
+		if((rawMu[0] < rawMu[1])) {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[1];
+		} else {
+			if(!fixedFlag$sample20)
+				var57 = rawMu[0];
+		}
+		if(!fixedFlag$sample20)
+			mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are collapsed
+	// to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputsPrime() {
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!fixedFlag$sample20)
+				rawMu[var19] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleGaussian(RNG$)) + 0.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!fixedFlag$sample83)
+				sigma[var78] = ((Math.sqrt((2.0 * 2.0)) * DistributionSampling.sampleTruncatedGaussian(RNG$, ((0.0 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((0.0 - 0.0) / Math.sqrt((2.0 * 2.0)))), ((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0))), Gaussian.cdf(((1.0E100 - 0.0) / Math.sqrt((2.0 * 2.0)))))) + 0.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!fixedFlag$sample101)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	// Method to execute one round of Gibbs sampling.
+	@Override
+	public final void gibbsRound() {
+		// Infer the samples in chronological order.
+		if(system$gibbsForward) {
+			for(int var19 = 0; var19 < 2; var19 += 1) {
+				if(!fixedFlag$sample20)
+					inferSample20(var19);
+			}
+			for(int var78 = 0; var78 < 2; var78 += 1) {
+				if(!fixedFlag$sample83)
+					inferSample83(var78);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			for(int var96 = 0; var96 < N; var96 += 1) {
+				if(!fixedFlag$sample101)
+					inferSample101(var96);
+			}
+		}
+		// Infer the samples in reverse chronological order.
+		else {
+			for(int var96 = (N - ((((N - 1) - 0) % 1) + 1)); var96 >= ((0 - 1) + 1); var96 -= 1) {
+				if(!fixedFlag$sample101)
+					inferSample101(var96);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			for(int var78 = (2 - ((((2 - 1) - 0) % 1) + 1)); var78 >= ((0 - 1) + 1); var78 -= 1) {
+				if(!fixedFlag$sample83)
+					inferSample83(var78);
+			}
+			for(int var19 = (2 - ((((2 - 1) - 0) % 1) + 1)); var19 >= ((0 - 1) + 1); var19 -= 1) {
+				if(!fixedFlag$sample20)
+					inferSample20(var19);
+			}
+		}
+		
+		// Reverse the direction of execution for the next iteration
+		system$gibbsForward = !system$gibbsForward;
+		for(int var19 = 0; var19 < 2; var19 += 1) {
+			if(!constrainedFlag$sample20[((var19 - 0) / 1)])
+				drawValueSample20(var19);
+		}
+		for(int var78 = 0; var78 < 2; var78 += 1) {
+			if(!constrainedFlag$sample83[((var78 - 0) / 1)])
+				drawValueSample83(var78);
+		}
+		if(!constrainedFlag$sample88)
+			drawValueSample88();
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!constrainedFlag$sample101[((var96 - 0) / 1)])
+				drawValueSample101(var96);
+		}
+	}
+
+	// A method to initialize all the probabilities in the model to 0/Log(1) ready for
+	// the current probabilities to be calculated by calculating the probability of each
+	// sample task, and its effect on the rest of the model.
+	private final void initializeLogProbabilityFields() {
+		// Set the probabilities of the random variable, and the model as a whole to ready
+		// them to be reconstructed by the probability calls for each sample. Sample probabilities
+		// are only reset for samples that are not fixed at a value that has already been
+		// calculated.
+		logProbability$$model = 0.0;
+		logProbability$$evidence = 0.0;
+		logProbability$rawMu = 0.0;
+		logProbability$mu = 0.0;
+		if(!fixedProbFlag$sample20) {
+			for(int var19 = 0; var19 < 2; var19 += 1)
+				logProbability$sample20[((var19 - 0) / 1)] = Double.NaN;
+		}
+		logProbability$sigma = 0.0;
+		if(!fixedProbFlag$sample83)
+			logProbability$var79 = Double.NaN;
+		if(!fixedProbFlag$sample88)
+			logProbability$theta = Double.NaN;
+		logProbability$componentDistribution = Double.NaN;
+		logProbability$component = 0.0;
+		if(!fixedProbFlag$sample101)
+			logProbability$var97 = Double.NaN;
+		logProbability$y = 0.0;
+		if(!fixedProbFlag$sample138)
+			logProbability$var130 = Double.NaN;
+	}
+
+	// Method for initializing the model into a valid state before commencing inference
+	// etc.
+	@Override
+	public final void initializeModel() {
+		N = length$yObserved;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+			constrainedFlag$sample101[index$constrainedFlag$sample101$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+			constrainedFlag$sample20[index$constrainedFlag$sample20$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+			constrainedFlag$sample83[index$constrainedFlag$sample83$1] = true;
+	}
+
+	// Construct the evidence probabilities.
+	@Override
+	public final void logEvidenceProbabilities() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Call each method in turn to generate the new probability values.
+		if(fixedFlag$sample20)
+			logProbabilityValue$sample20();
+		if(fixedFlag$sample83)
+			logProbabilityValue$sample83();
+		if(fixedFlag$sample88)
+			logProbabilityValue$sample88();
+		if(fixedFlag$sample101)
+			logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model uses distributions
+	// when possible.
+	@Override
+	public final void logModelProbabilitiesDist() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model only uses values.
+	@Override
+	public final void logModelProbabilitiesVal() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to propagate observed values back into the model.
+	@Override
+	public final void propagateObservedValues() {
+		// Deep copy between arrays
+		double[] cv$source1 = yObserved;
+		double[] cv$target1 = y;
+		int cv$length1 = cv$target1.length;
+		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1)
+			cv$target1[cv$index1] = cv$source1[cv$index1];
+	}
+
+	// A method to set array values that depend on the output of a sample task, but are
+	// not directly set by the sample task. This method is called to propagate set values
+	// through the model. Any non-fixed sample values may be sampled to random variables
+	// as part of this process.
+	@Override
+	public final void setIntermediates() {
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+	}
+
+	@Override
+	public String modelCode() {
+		return "/*\n"
+		     + " * Sandwood\n"
+		     + " *\n"
+		     + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+		     + " * \n"
+		     + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+		     + " */\n"
+		     + "\n"
+		     + "package org.sandwood.compiler.tests.parser;\n"
+		     + "\n"
+		     + "public model LowDimMix(double[] yObserved) {\n"
+		     + "    int N = yObserved.length;\n"
+		     + "\n"
+		     + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+		     + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+		     + "    // the constant normalisation factor for the ordered constraint.\n"
+		     + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+		     + "    double[] mu = new double[2];\n"
+		     + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+		     + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+		     + "\n"
+		     + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+		     + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+		     + "\n"
+		     + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+		     + "    double theta = beta(5.0, 5.0).sample();\n"
+		     + "\n"
+		     + "    // Stan likelihood:\n"
+		     + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+		     + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+		     + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+		     + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+		     + "    boolean[] component = componentDistribution.sample(N);\n"
+		     + "    double[] y = new double[N];\n"
+		     + "\n"
+		     + "    for(int n = 0; n < N; n++) {\n"
+		     + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+		     + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+		     + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+		     + "    }\n"
+		     + "\n"
+		     + "    y.observe(yObserved);\n"
+		     + "}\n"
+		     + "";
+	}
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$SingleThreadCPU_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$SingleThreadCPU_optimisedModel.java
@@ -1,0 +1,4273 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.runtime.internal.numericTools.Conjugates;
+import org.sandwood.runtime.internal.numericTools.DistributionSampling;
+import org.sandwood.runtime.model.ExecutionTarget;
+
+final class LowDimMix$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements LowDimMix$CoreInterface {
+	
+	// Declare the variables for the model.
+	private int N;
+	private boolean[] component;
+	private boolean[] constrainedFlag$sample101;
+	private boolean[] constrainedFlag$sample20;
+	private boolean[] constrainedFlag$sample83;
+	private boolean constrainedFlag$sample88 = true;
+	private double[] cv$var97$stateProbabilityGlobal;
+	private boolean fixedFlag$sample101 = false;
+	private boolean fixedFlag$sample20 = false;
+	private boolean fixedFlag$sample83 = false;
+	private boolean fixedFlag$sample88 = false;
+	private boolean fixedProbFlag$sample101 = false;
+	private boolean fixedProbFlag$sample138 = false;
+	private boolean fixedProbFlag$sample20 = false;
+	private boolean fixedProbFlag$sample83 = false;
+	private boolean fixedProbFlag$sample88 = false;
+	private boolean[] guard$sample20if124$global;
+	private int length$yObserved;
+	private double logProbability$$evidence;
+	private double logProbability$$model;
+	private double logProbability$component;
+	private double logProbability$componentDistribution;
+	private double logProbability$mu;
+	private double logProbability$rawMu;
+	private double[] logProbability$sample138;
+	private double[] logProbability$sample20;
+	private double logProbability$sigma;
+	private double logProbability$theta;
+	private double logProbability$var79;
+	private double logProbability$var97;
+	private double logProbability$y;
+	private double[] mu;
+	private double[] rawMu;
+	private double[] sigma;
+	private boolean system$gibbsForward = true;
+	private double theta;
+	private double[] y;
+	private double[] yObserved;
+
+	public LowDimMix$SingleThreadCPU(ExecutionTarget target) {
+		super(target);
+	}
+
+	// Getter for N.
+	@Override
+	public final int get$N() {
+		return N;
+	}
+
+	// Getter for component.
+	@Override
+	public final boolean[] get$component() {
+		return component;
+	}
+
+	// Setter for component.
+	@Override
+	public final void set$component(boolean[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of component including if probabilities need
+		// to be updated.
+		component = cv$value;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on component.
+		fixedProbFlag$sample101 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on component.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for fixedFlag$sample101.
+	@Override
+	public final boolean get$fixedFlag$sample101() {
+		return fixedFlag$sample101;
+	}
+
+	// Setter for fixedFlag$sample101.
+	@Override
+	public final void set$fixedFlag$sample101(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample101 including if probabilities
+		// need to be updated.
+		fixedFlag$sample101 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+				// Substituted "fixedFlag$sample101" with its value "cv$value".
+				constrainedFlag$sample101[index$constrainedFlag$sample101$1] = cv$value;
+		}
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample101" with its value "cv$value".
+		fixedProbFlag$sample101 = (cv$value && fixedProbFlag$sample101);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample101" with its value "cv$value".
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample20.
+	@Override
+	public final boolean get$fixedFlag$sample20() {
+		return fixedFlag$sample20;
+	}
+
+	// Setter for fixedFlag$sample20.
+	@Override
+	public final void set$fixedFlag$sample20(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample20 including if probabilities
+		// need to be updated.
+		fixedFlag$sample20 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+				// Substituted "fixedFlag$sample20" with its value "cv$value".
+				constrainedFlag$sample20[index$constrainedFlag$sample20$1] = cv$value;
+		}
+		
+		// Should the probability of sample 20 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample20" with its value "cv$value".
+		fixedProbFlag$sample20 = (cv$value && fixedProbFlag$sample20);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample20" with its value "cv$value".
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample83.
+	@Override
+	public final boolean get$fixedFlag$sample83() {
+		return fixedFlag$sample83;
+	}
+
+	// Setter for fixedFlag$sample83.
+	@Override
+	public final void set$fixedFlag$sample83(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample83 including if probabilities
+		// need to be updated.
+		fixedFlag$sample83 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+				// Substituted "fixedFlag$sample83" with its value "cv$value".
+				constrainedFlag$sample83[index$constrainedFlag$sample83$1] = cv$value;
+		}
+		
+		// Should the probability of sample 83 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample83" with its value "cv$value".
+		fixedProbFlag$sample83 = (cv$value && fixedProbFlag$sample83);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample83" with its value "cv$value".
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample88.
+	@Override
+	public final boolean get$fixedFlag$sample88() {
+		return fixedFlag$sample88;
+	}
+
+	// Setter for fixedFlag$sample88.
+	@Override
+	public final void set$fixedFlag$sample88(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample88 including if probabilities
+		// need to be updated.
+		fixedFlag$sample88 = cv$value;
+		
+		// Substituted "fixedFlag$sample88" with its value "cv$value".
+		constrainedFlag$sample88 = (cv$value || constrainedFlag$sample88);
+		
+		// Should the probability of sample 88 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample88" with its value "cv$value".
+		fixedProbFlag$sample88 = (cv$value && fixedProbFlag$sample88);
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample88" with its value "cv$value".
+		fixedProbFlag$sample101 = (cv$value && fixedProbFlag$sample101);
+	}
+
+	// Getter for length$yObserved.
+	@Override
+	public final int get$length$yObserved() {
+		return length$yObserved;
+	}
+
+	// Setter for length$yObserved.
+	@Override
+	public final void set$length$yObserved(int cv$value, boolean allocated$) {
+		length$yObserved = cv$value;
+	}
+
+	// Getter for logProbability$$evidence.
+	@Override
+	public final double get$logProbability$$evidence() {
+		return logProbability$$evidence;
+	}
+
+	// Getter for the probability of logProbability$$model.
+	@Override
+	public final double getCurrentLogProbability() {
+		return logProbability$$model;
+	}
+
+	// Getter for logProbability$component.
+	@Override
+	public final double get$logProbability$component() {
+		return logProbability$component;
+	}
+
+	// Getter for logProbability$componentDistribution.
+	@Override
+	public final double get$logProbability$componentDistribution() {
+		return logProbability$componentDistribution;
+	}
+
+	// Getter for logProbability$mu.
+	@Override
+	public final double get$logProbability$mu() {
+		return logProbability$mu;
+	}
+
+	// Getter for logProbability$rawMu.
+	@Override
+	public final double get$logProbability$rawMu() {
+		return logProbability$rawMu;
+	}
+
+	// Getter for logProbability$sigma.
+	@Override
+	public final double get$logProbability$sigma() {
+		return logProbability$sigma;
+	}
+
+	// Getter for logProbability$theta.
+	@Override
+	public final double get$logProbability$theta() {
+		return logProbability$theta;
+	}
+
+	// Getter for logProbability$y.
+	@Override
+	public final double get$logProbability$y() {
+		return logProbability$y;
+	}
+
+	// Getter for mu.
+	@Override
+	public final double[] get$mu() {
+		return mu;
+	}
+
+	// Getter for rawMu.
+	@Override
+	public final double[] get$rawMu() {
+		return rawMu;
+	}
+
+	// Setter for rawMu.
+	@Override
+	public final void set$rawMu(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of rawMu including if probabilities need to
+		// be updated.
+		rawMu = cv$value;
+		
+		// Unset the fixed probability flag for sample 20 as it depends on rawMu.
+		fixedProbFlag$sample20 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on rawMu.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for sigma.
+	@Override
+	public final double[] get$sigma() {
+		return sigma;
+	}
+
+	// Setter for sigma.
+	@Override
+	public final void set$sigma(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of sigma including if probabilities need to
+		// be updated.
+		sigma = cv$value;
+		
+		// Unset the fixed probability flag for sample 83 as it depends on sigma.
+		fixedProbFlag$sample83 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on sigma.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for theta.
+	@Override
+	public final double get$theta() {
+		return theta;
+	}
+
+	// Setter for theta.
+	@Override
+	public final void set$theta(double cv$value, boolean allocated$) {
+		// Set flags for all the side effects of theta including if probabilities need to
+		// be updated.
+		theta = cv$value;
+		
+		// Unset the fixed probability flag for sample 88 as it depends on theta.
+		fixedProbFlag$sample88 = false;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on theta.
+		fixedProbFlag$sample101 = false;
+	}
+
+	// Getter for y.
+	@Override
+	public final double[] get$y() {
+		return y;
+	}
+
+	// Getter for yObserved.
+	@Override
+	public final double[] get$yObserved() {
+		return yObserved;
+	}
+
+	// Setter for yObserved.
+	@Override
+	public final void set$yObserved(double[] cv$value, boolean allocated$) {
+		yObserved = cv$value;
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample101
+	private final void drawValueSample101(int var96) {
+		component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample20
+	private final void drawValueSample20(int var19) {
+		rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 41.
+		// 
+		// Guard to check that at most one copy of the code is executed for a given set of
+		// loop iterations.
+		boolean guard$sample20put43 = false;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((var19 == 0)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put43 = true;
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(((var19 == 1) && !guard$sample20put43)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put43 = true;
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put43 = true;
+			mu[0] = rawMu[0];
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+			mu[0] = rawMu[1];
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 59.
+		// 
+		// Guard to check that at most one copy of the code is executed for a given set of
+		// loop iterations.
+		boolean guard$sample20put63 = false;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((var19 == 0)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put63 = true;
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((var19 == 1)) {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20put63) {
+				// The body will execute, so should not be executed again
+				guard$sample20put63 = true;
+				double var57;
+				if((rawMu[0] < rawMu[1]))
+					var57 = rawMu[1];
+				else
+					var57 = rawMu[0];
+				mu[1] = var57;
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+				// The body will execute, so should not be executed again
+				guard$sample20put63 = true;
+				mu[1] = rawMu[1];
+			}
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+			mu[1] = rawMu[0];
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample83
+	private final void drawValueSample83(int var78) {
+		sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample88
+	private final void drawValueSample88() {
+		theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 101 drawn from componentDistribution. Inference was performed using
+	// variable marginalization.
+	private final void inferSample101(int var96) {
+		{
+			// Guards to ensure that component is only updated when there is a valid path.
+			// 
+			// Variable declaration of cv$currentValue moved.
+			// Declaration comment was:
+			// The value currently being tested
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			component[var96] = false;
+			
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Variable declaration of cv$currentValue moved.
+			// Declaration comment was:
+			// The value currently being tested
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			double cv$accumulatedProbabilities = (((0.0 <= theta) && (theta <= 1.0))?Math.log((1.0 - theta)):Double.NEGATIVE_INFINITY);
+			
+			// Processing conditional point124.
+			// 
+			// Looking for a path between Sample 101 and consumer double 118.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(component[var96]) {
+				{
+					// Variable declaration of componentSigma moved.
+					double componentSigma = sigma[0];
+					
+					// Constructing a random variable input for use later.
+					double var128 = (componentSigma * componentSigma);
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 138 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Substituted "n" with its value "var96".
+					cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				}
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = false;
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1]))
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[0] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124$global[0]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124$global[1]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((rawMu[0] < rawMu[1]) && !guard$sample20if124$global[0])) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124$global[1])) {
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				double traceTempVariable$componentSigma$58_1 = sigma[0];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				// 
+				// Substituted "componentMu" with its value "mu[0]".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 83 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Looking for a path between Sample 83 and consumer double 127.
+				// 
+				// Unrolled loop
+				// 
+				// Processing sample task 83 of consumer random variable null.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((((0.0 <= sigma[0]) && (sigma[0] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[0] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			else {
+				{
+					// Variable declaration of componentSigma moved.
+					double componentSigma = sigma[1];
+					
+					// Constructing a random variable input for use later.
+					double var128 = (componentSigma * componentSigma);
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 138 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Substituted "n" with its value "var96".
+					cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				}
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = false;
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1]))
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[0] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124$global[0]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124$global[1]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((rawMu[0] < rawMu[1]) && !guard$sample20if124$global[1])) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124$global[0])) {
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				double traceTempVariable$componentSigma$63_1 = sigma[1];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				// 
+				// Substituted "componentMu" with its value "mu[1]".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 83 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Processing sample task 83 of consumer random variable null.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((((0.0 <= sigma[1]) && (sigma[1] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[1] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Save the calculated index value into the array of index value probabilities
+			// 
+			// Get a local reference to the scratch space.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			cv$var97$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
+		}
+		
+		// Guards to ensure that component is only updated when there is a valid path.
+		// 
+		// Variable declaration of cv$currentValue moved.
+		// Declaration comment was:
+		// The value currently being tested
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		component[var96] = true;
+		
+		// An accumulator to allow the value for each distribution to be constructed before
+		// it is added to the index probabilities.
+		// 
+		// Variable declaration of cv$currentValue moved.
+		// Declaration comment was:
+		// The value currently being tested
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		double cv$accumulatedProbabilities = (((0.0 <= theta) && (theta <= 1.0))?Math.log(theta):Double.NEGATIVE_INFINITY);
+		
+		// Processing conditional point124.
+		// 
+		// Looking for a path between Sample 101 and consumer double 118.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(component[var96]) {
+			{
+				// Variable declaration of componentSigma moved.
+				double componentSigma = sigma[0];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (componentSigma * componentSigma);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			// 
+			// Guard to check that at most one copy of the code is executed for a given random
+			// variable instance.
+			guard$sample20if124$global[0] = false;
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			// 
+			// Guard to check that at most one copy of the code is executed for a given random
+			// variable instance.
+			guard$sample20if124$global[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((rawMu[0] < rawMu[1]))
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			else
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124$global[0]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124$global[1]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20if124$global[0])) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124$global[1])) {
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			double traceTempVariable$componentSigma$58_1 = sigma[0];
+			
+			// Mark that the sample has observed constrained data.
+			constrainedFlag$sample101[var96] = true;
+			
+			// Constructing a random variable input for use later.
+			double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 138 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Substituted "n" with its value "var96".
+			// 
+			// Substituted "componentMu" with its value "mu[0]".
+			cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 83 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Looking for a path between Sample 83 and consumer double 127.
+			// 
+			// Unrolled loop
+			// 
+			// Processing sample task 83 of consumer random variable null.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Constructing a random variable input for use later.
+			cv$accumulatedProbabilities = ((((0.0 <= sigma[0]) && (sigma[0] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[0] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		else {
+			{
+				// Variable declaration of componentSigma moved.
+				double componentSigma = sigma[1];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (componentSigma * componentSigma);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			// 
+			// Guard to check that at most one copy of the code is executed for a given random
+			// variable instance.
+			guard$sample20if124$global[0] = false;
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			// 
+			// Guard to check that at most one copy of the code is executed for a given random
+			// variable instance.
+			guard$sample20if124$global[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((rawMu[0] < rawMu[1]))
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			else
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124$global[0]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124$global[1]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20if124$global[1])) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124$global[0])) {
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			double traceTempVariable$componentSigma$63_1 = sigma[1];
+			
+			// Mark that the sample has observed constrained data.
+			constrainedFlag$sample101[var96] = true;
+			
+			// Constructing a random variable input for use later.
+			double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 138 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Substituted "n" with its value "var96".
+			// 
+			// Substituted "componentMu" with its value "mu[1]".
+			cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 83 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Processing sample task 83 of consumer random variable null.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Constructing a random variable input for use later.
+			cv$accumulatedProbabilities = ((((0.0 <= sigma[1]) && (sigma[1] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[1] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+		}
+		
+		// Save the calculated index value into the array of index value probabilities
+		// 
+		// Get a local reference to the scratch space.
+		// 
+		// Record the reached probability density.
+		// 
+		// Initialize a counter to track the reached distributions.
+		cv$var97$stateProbabilityGlobal[1] = cv$accumulatedProbabilities;
+		if(constrainedFlag$sample101[var96]) {
+			// This value is not used before it is set again, so removing the value declaration.
+			// 
+			// The sum of all the probabilities in log space
+			double cv$logSum;
+			
+			// Sum all the values
+			// 
+			// Initialize the max to the first element.
+			// 
+			// Get a local reference to the scratch space.
+			double cv$lseMax = cv$var97$stateProbabilityGlobal[0];
+			
+			// Unrolled loop
+			// 
+			// Get a local reference to the scratch space.
+			double cv$lseElementValue = cv$var97$stateProbabilityGlobal[1];
+			if((cv$lseMax < cv$lseElementValue))
+				cv$lseMax = cv$lseElementValue;
+			
+			// If the maximum value is -infinity return -infinity.
+			if((cv$lseMax == Double.NEGATIVE_INFINITY))
+				cv$logSum = Double.NEGATIVE_INFINITY;
+			
+			// Sum the values in the array.
+			else
+				// Increment the value of the target, moving the value back into log space.
+				// 
+				// The sum of all the probabilities in log space
+				// 
+				// Get a local reference to the scratch space.
+				// 
+				// Get a local reference to the scratch space.
+				// 
+				// Initialize the sum of the array elements
+				cv$logSum = (Math.log((Math.exp((cv$var97$stateProbabilityGlobal[0] - cv$lseMax)) + Math.exp((cv$var97$stateProbabilityGlobal[1] - cv$lseMax)))) + cv$lseMax);
+			
+			// If all the sum is zero, just share the probability evenly.
+			if((cv$logSum == Double.NEGATIVE_INFINITY)) {
+				// Unrolled loop
+				// Get a local reference to the scratch space.
+				cv$var97$stateProbabilityGlobal[0] = 0.5;
+				
+				// Get a local reference to the scratch space.
+				cv$var97$stateProbabilityGlobal[1] = 0.5;
+			} else {
+				// Unrolled loop
+				// Get a local reference to the scratch space.
+				cv$var97$stateProbabilityGlobal[0] = Math.exp((cv$var97$stateProbabilityGlobal[0] - cv$logSum));
+				
+				// Get a local reference to the scratch space.
+				cv$var97$stateProbabilityGlobal[1] = Math.exp((cv$var97$stateProbabilityGlobal[1] - cv$logSum));
+			}
+			
+			// Set array values that are not computed for the input to negative infinity.
+			// 
+			// Get a local reference to the scratch space.
+			for(int cv$indexName = 2; cv$indexName < cv$var97$stateProbabilityGlobal.length; cv$indexName += 1)
+				// Get a local reference to the scratch space.
+				cv$var97$stateProbabilityGlobal[cv$indexName] = Double.NEGATIVE_INFINITY;
+			
+			// Guards to ensure that component is only updated when there is a valid path.
+			// 
+			// Write out the value of the sample to a temporary variable prior to updating the
+			// intermediate variables.
+			// 
+			// cv$numStates's comment
+			// variable marginalization
+			component[var96] = (DistributionSampling.sampleCategorical(RNG$, cv$var97$stateProbabilityGlobal, 2) == 1);
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 20 drawn from Gaussian 7. Inference was performed using Metropolis-Hastings.
+	private final void inferSample20(int var19) {
+		constrainedFlag$sample20[var19] = false;
+		
+		// The original value of the sample
+		double cv$originalValue = rawMu[var19];
+		
+		// This value is not used before it is set again, so removing the value declaration.
+		// 
+		// The probability of the random variable generating the originally sampled value
+		double cv$originalProbability;
+		
+		// Calculate a proposed variance.
+		double cv$var = ((cv$originalValue * cv$originalValue) * 0.010000000000000002);
+		
+		// Ensure the variance is at least 0.01
+		if((cv$var < 0.010000000000000002))
+			cv$var = 0.010000000000000002;
+		
+		// The proposed new value for the sample
+		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+		{
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			// 
+			// Set the current value to the current state of the tree.
+			double cv$accumulatedProbabilities = (DistributionSampling.logProbabilityGaussian((cv$originalValue / 2.0)) - 0.6931471805599453);
+			
+			// Looking for a path between Sample 20 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[0];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Set the current value to the current state of the tree.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 1)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							// 
+							// Set the current value to the current state of the tree.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							// 
+							// Set the current value to the current state of the tree.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[1];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Set the current value to the current state of the tree.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Processing conditional point41.
+			// 
+			// Looking for a path between Sample 20 and consumer double 39.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if41 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if41 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$36_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$36_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$52_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$52_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if41)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$37_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$37_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$53_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$53_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Processing conditional point61.
+			// 
+			// Looking for a path between Sample 20 and consumer double 57.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if61 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if61 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$72_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$72_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$88_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$88_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if61)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$73_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$73_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$89_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$89_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(constrainedFlag$sample20[var19]) {
+			{
+				// Guards to ensure that rawMu is only updated when there is a valid path.
+				rawMu[var19] = cv$proposedValue;
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put43 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((var19 == 1) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					mu[0] = rawMu[0];
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+					mu[0] = rawMu[1];
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put63 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put63 = true;
+					double var57;
+					if((rawMu[0] < rawMu[1]))
+						var57 = rawMu[1];
+					else
+						var57 = rawMu[0];
+					mu[1] = var57;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 1)) {
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						double var57;
+						if((rawMu[0] < rawMu[1]))
+							var57 = rawMu[1];
+						else
+							var57 = rawMu[0];
+						mu[1] = var57;
+					}
+					
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						mu[1] = rawMu[1];
+					}
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+					mu[1] = rawMu[0];
+			}
+			
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			double cv$accumulatedProbabilities = (DistributionSampling.logProbabilityGaussian((cv$proposedValue / 2.0)) - 0.6931471805599453);
+			
+			// Looking for a path between Sample 20 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[0];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 1)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[1];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Processing conditional point41.
+			// 
+			// Looking for a path between Sample 20 and consumer double 39.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if41 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if41 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$36_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$36_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$52_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$52_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if41)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$37_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$37_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$53_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$53_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Processing conditional point61.
+			// 
+			// Looking for a path between Sample 20 and consumer double 57.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if61 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if61 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$72_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$72_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$88_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$88_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if61)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$73_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$73_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$89_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$89_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// The probability ration for the proposed value and the current value.
+			// 
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			double cv$ratio = (cv$accumulatedProbabilities - cv$originalProbability);
+			
+			// Test if the probability of the sample is sufficient to keep the value. This needs
+			// to be less than or equal as otherwise if the proposed value is not possible and
+			// the random value is 0 an impossible value will be accepted.
+			if(((cv$ratio <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN(cv$ratio))) {
+				// If it is not revert the changes.
+				// 
+				// Set the sample value
+				// Guards to ensure that rawMu is only updated when there is a valid path.
+				// 
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				rawMu[var19] = cv$originalValue;
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put43 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((var19 == 1) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					mu[0] = rawMu[0];
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+					mu[0] = rawMu[1];
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put63 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put63 = true;
+					double var57;
+					if((rawMu[0] < rawMu[1]))
+						var57 = rawMu[1];
+					else
+						var57 = rawMu[0];
+					mu[1] = var57;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 1)) {
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						double var57;
+						if((rawMu[0] < rawMu[1]))
+							var57 = rawMu[1];
+						else
+							var57 = rawMu[0];
+						mu[1] = var57;
+					}
+					
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						mu[1] = rawMu[1];
+					}
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+					mu[1] = rawMu[0];
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 83 drawn from TruncatedGaussian 66. Inference was performed using
+	// Metropolis-Hastings.
+	private final void inferSample83(int var78) {
+		constrainedFlag$sample83[var78] = false;
+		
+		// The original value of the sample
+		double cv$originalValue = sigma[var78];
+		
+		// This value is not used before it is set again, so removing the value declaration.
+		// 
+		// The probability of the random variable generating the originally sampled value
+		double cv$originalProbability;
+		
+		// Calculate a proposed variance.
+		double cv$var = ((cv$originalValue * cv$originalValue) * 0.010000000000000002);
+		
+		// Ensure the variance is at least 0.01
+		if((cv$var < 0.010000000000000002))
+			cv$var = 0.010000000000000002;
+		
+		// The proposed new value for the sample
+		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+		{
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			// 
+			// Set the current value to the current state of the tree.
+			double cv$accumulatedProbabilities = (((0.0 <= cv$originalValue) && (cv$originalValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$originalValue / 2.0)):Double.NEGATIVE_INFINITY);
+			
+			// Looking for a path between Sample 83 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 0)) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[0] = true;
+						
+						// Constructing a random variable input for use later.
+						// 
+						// Set the current value to the current state of the tree.
+						double var128 = (cv$originalValue * cv$originalValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[0]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 1)) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[1] = true;
+						
+						// Constructing a random variable input for use later.
+						// 
+						// Set the current value to the current state of the tree.
+						double var128 = (cv$originalValue * cv$originalValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[1]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(constrainedFlag$sample83[var78]) {
+			// Guards to ensure that sigma is only updated when there is a valid path.
+			sigma[var78] = cv$proposedValue;
+			
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			double cv$accumulatedProbabilities = (((0.0 <= cv$proposedValue) && (cv$proposedValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$proposedValue / 2.0)):Double.NEGATIVE_INFINITY);
+			
+			// Looking for a path between Sample 83 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 0)) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[0] = true;
+						
+						// Constructing a random variable input for use later.
+						double var128 = (cv$proposedValue * cv$proposedValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[0]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 1)) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[1] = true;
+						
+						// Constructing a random variable input for use later.
+						double var128 = (cv$proposedValue * cv$proposedValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[1]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// The probability ration for the proposed value and the current value.
+			// 
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			double cv$ratio = (cv$accumulatedProbabilities - cv$originalProbability);
+			
+			// Test if the probability of the sample is sufficient to keep the value. This needs
+			// to be less than or equal as otherwise if the proposed value is not possible and
+			// the random value is 0 an impossible value will be accepted.
+			if(((cv$ratio <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN(cv$ratio)))
+				// If it is not revert the changes.
+				// 
+				// Set the sample value
+				// 
+				// Guards to ensure that sigma is only updated when there is a valid path.
+				// 
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				sigma[var78] = cv$originalValue;
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 88 drawn from Beta 83. Inference was performed using a Beta to Bernoulli/Binomial
+	// conjugate prior.
+	private final void inferSample88() {
+		constrainedFlag$sample88 = false;
+		
+		// Local variable to record the number of true samples.
+		int cv$sum = 0;
+		
+		// Local variable to record the number of samples.
+		int cv$count = 0;
+		
+		// Processing random variable 85.
+		// 
+		// Processing sample task 101 of consumer random variable componentDistribution.
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((fixedFlag$sample101 || constrainedFlag$sample101[var96])) {
+				// Mark that the sample has observed constrained data.
+				constrainedFlag$sample88 = true;
+				
+				// Include the value sampled by task 101 from random variable componentDistribution.
+				// 
+				// Increment the number of samples.
+				cv$count = (cv$count + 1);
+				
+				// If the sample value was positive increase the count
+				if(component[var96])
+					cv$sum = (cv$sum + 1);
+			}
+		}
+		if(constrainedFlag$sample88)
+			// Write out the new value of the sample.
+			theta = Conjugates.sampleConjugateBetaBinomial(RNG$, 5.0, 5.0, cv$sum, cv$count);
+	}
+
+	// Calculate the probability of the samples represented by sample101 using sampled
+	// values.
+	private final void logProbabilityValue$sample101() {
+		// Determine if we need to calculate the values for sample task 101 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample101) {
+			// Generating probabilities for sample task
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			for(int var96 = 0; var96 < N; var96 += 1)
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= theta) && (theta <= 1.0))?Math.log((component[var96]?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+			logProbability$componentDistribution = cv$sampleAccumulator;
+			
+			// Store the random variable instance probability
+			logProbability$var97 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$component = (logProbability$component + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedFlag$sample88);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			logProbability$componentDistribution = logProbability$var97;
+			
+			// Update the variable probability
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$component = (logProbability$component + logProbability$var97);
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$var97);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				// Variable declaration of cv$accumulator moved.
+				logProbability$$evidence = (logProbability$$evidence + logProbability$var97);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample138 using sampled
+	// values.
+	private final void logProbabilityValue$sample138() {
+		// Determine if we need to calculate the values for sample task 138 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample138) {
+			// Generating probabilities for sample task
+			// Accumulator for probabilities of instances of the random variable
+			double cv$accumulator = 0.0;
+			for(int n = 0; n < N; n += 1) {
+				double componentMu;
+				if(component[n])
+					componentMu = mu[0];
+				else
+					componentMu = mu[1];
+				double componentSigma;
+				if(component[n])
+					componentSigma = sigma[0];
+				else
+					componentSigma = sigma[1];
+				double var128 = (componentSigma * componentSigma);
+				
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				double cv$distributionAccumulator = ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY);
+				
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+				
+				// Store the sample task probability
+				logProbability$sample138[n] = cv$distributionAccumulator;
+			}
+			
+			// Update the variable probability
+			logProbability$y = (logProbability$y + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample138 = ((fixedFlag$sample20 && fixedFlag$sample83) && fixedFlag$sample101);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			double cv$accumulator = 0.0;
+			for(int n = 0; n < N; n += 1)
+				cv$accumulator = (cv$accumulator + logProbability$sample138[n]);
+			
+			// Update the variable probability
+			logProbability$y = (logProbability$y + cv$accumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample20 using sampled
+	// values.
+	private final void logProbabilityValue$sample20() {
+		// Determine if we need to calculate the values for sample task 20 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample20) {
+			// Generating probabilities for sample task
+			// This value is not used before it is set again, so removing the value declaration.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator;
+			{
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				double cv$weightedProbability = (DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) - 0.6931471805599453);
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				cv$sampleAccumulator = cv$weightedProbability;
+				
+				// Store the sample task probability
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				logProbability$sample20[0] = cv$weightedProbability;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					// Set the guard so the update is only applied once.
+					cv$guard$mu = true;
+					
+					// Update the variable probability
+					// 
+					// Scale the probability relative to the observed distribution space.
+					// 
+					// Add the probability of this distribution configuration to the accumulator.
+					// 
+					// An accumulator for the distributed probability space covered.
+					logProbability$mu = (logProbability$mu + cv$weightedProbability);
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !cv$guard$mu))
+					// Update the variable probability
+					// 
+					// Scale the probability relative to the observed distribution space.
+					// 
+					// Add the probability of this distribution configuration to the accumulator.
+					// 
+					// An accumulator for the distributed probability space covered.
+					logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			}
+			
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$weightedProbability = (DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) - 0.6931471805599453);
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$weightedProbability);
+			
+			// Store the sample task probability
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			logProbability$sample20[1] = cv$weightedProbability;
+			
+			// Guard to ensure that mu is only updated once for this probability.
+			boolean cv$guard$mu = false;
+			
+			// Add probability to constructed variables that have guards, so need per sample probabilities
+			// from the combined probability
+			// 
+			// Looking for a path between Sample 20 and consumer double[] 41.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Guard to ensure that mu is only updated once for this probability.
+			if(!(rawMu[0] < rawMu[1])) {
+				// Set the guard so the update is only applied once.
+				cv$guard$mu = true;
+				
+				// Update the variable probability
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			}
+			
+			// Looking for a path between Sample 20 and consumer double[] 59.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !cv$guard$mu))
+				// Update the variable probability
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$rawMu = (logProbability$rawMu + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample20 = fixedFlag$sample20;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// This value is not used before it is set again, so removing the value declaration.
+			double cv$rvAccumulator;
+			{
+				double cv$sampleValue = logProbability$sample20[0];
+				cv$rvAccumulator = cv$sampleValue;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					// Set the guard so the update is only applied once.
+					cv$guard$mu = true;
+					
+					// Update the variable probability
+					logProbability$mu = (logProbability$mu + cv$sampleValue);
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !cv$guard$mu))
+					// Update the variable probability
+					logProbability$mu = (logProbability$mu + cv$sampleValue);
+			}
+			double cv$sampleValue = logProbability$sample20[1];
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			
+			// Guard to ensure that mu is only updated once for this probability.
+			boolean cv$guard$mu = false;
+			
+			// Add probability to constructed variables that have guards, so need per sample probabilities
+			// from the combined probability
+			// 
+			// Looking for a path between Sample 20 and consumer double[] 41.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Guard to ensure that mu is only updated once for this probability.
+			if(!(rawMu[0] < rawMu[1])) {
+				// Set the guard so the update is only applied once.
+				cv$guard$mu = true;
+				
+				// Update the variable probability
+				logProbability$mu = (logProbability$mu + cv$sampleValue);
+			}
+			
+			// Looking for a path between Sample 20 and consumer double[] 59.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !cv$guard$mu))
+				// Update the variable probability
+				logProbability$mu = (logProbability$mu + cv$sampleValue);
+			
+			// Update the variable probability
+			logProbability$rawMu = (logProbability$rawMu + cv$rvAccumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$rvAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$rvAccumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample83 using sampled
+	// values.
+	private final void logProbabilityValue$sample83() {
+		// Determine if we need to calculate the values for sample task 83 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample83) {
+			// Generating probabilities for sample task
+			// This value is not used before it is set again, so removing the value declaration.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = sigma[0];
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				cv$sampleAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$sampleValue / 2.0)):Double.NEGATIVE_INFINITY);
+			}
+			
+			// The sample value to calculate the probability of generating
+			double cv$sampleValue = sigma[1];
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$sampleValue / 2.0)):Double.NEGATIVE_INFINITY));
+			
+			// Store the random variable instance probability
+			logProbability$var79 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$sigma = (logProbability$sigma + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample83 = fixedFlag$sample83;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// Update the variable probability
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$sigma = (logProbability$sigma + logProbability$var79);
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$var79);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				// Variable declaration of cv$accumulator moved.
+				logProbability$$evidence = (logProbability$$evidence + logProbability$var79);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample88 using sampled
+	// values.
+	private final void logProbabilityValue$sample88() {
+		// Determine if we need to calculate the values for sample task 88 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample88) {
+			// Generating probabilities for sample task
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(theta, 5.0, 5.0);
+			
+			// Store the sample task probability
+			logProbability$theta = cv$distributionAccumulator;
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			// Declaration comment was:
+			// Accumulator for probabilities of instances of the random variable
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				// Variable declaration of cv$accumulator moved.
+				// Declaration comment was:
+				// Accumulator for probabilities of instances of the random variable
+				// 
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				// 
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				logProbability$$evidence = (logProbability$$evidence + cv$distributionAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample88 = fixedFlag$sample88;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$theta);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				// Variable declaration of cv$accumulator moved.
+				logProbability$$evidence = (logProbability$$evidence + logProbability$theta);
+		}
+	}
+
+	// Method to allocate space temporary variables used by the inference methods. Allocating
+	// here prevents repeated allocation and deallocation, and makes the code more amenable
+	// to GPU execution.
+	@Override
+	public final void allocateScratch() {
+		// Allocate scratch space.
+		// Constructor for cv$var97$stateProbabilityGlobal
+		// 
+		// Allocation of cv$var97$stateProbabilityGlobal for single threaded execution
+		cv$var97$stateProbabilityGlobal = new double[2];
+		
+		// Allocation of guard$sample20if124$global for single threaded execution
+		guard$sample20if124$global = new boolean[2];
+	}
+
+	// Method to allocate space for model inputs and outputs.
+	@Override
+	public final void allocator() {
+		// If rawMu has not been set already allocate space.
+		if(!fixedFlag$sample20)
+			// Constructor for rawMu
+			rawMu = new double[2];
+		
+		// Constructor for mu
+		mu = new double[2];
+		
+		// If sigma has not been set already allocate space.
+		if(!fixedFlag$sample83)
+			// Constructor for sigma
+			sigma = new double[2];
+		
+		// If component has not been set already allocate space.
+		if(!fixedFlag$sample101)
+			// Constructor for component
+			component = new boolean[length$yObserved];
+		
+		// Constructor for y
+		y = new double[length$yObserved];
+		
+		// Constructor for constrainedFlag$sample101
+		constrainedFlag$sample101 = new boolean[length$yObserved];
+		
+		// Constructor for constrainedFlag$sample20
+		constrainedFlag$sample20 = new boolean[2];
+		
+		// Constructor for constrainedFlag$sample83
+		constrainedFlag$sample83 = new boolean[2];
+		
+		// Constructor for logProbability$sample20
+		logProbability$sample20 = new double[2];
+		
+		// Constructor for logProbability$sample138
+		logProbability$sample138 = new double[length$yObserved];
+		
+		// Allocate scratch space
+		allocateScratch();
+	}
+
+	// Method to execute the model code conventionally.
+	@Override
+	public final void forwardGeneration() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+		for(int n = 0; n < N; n += 1) {
+			double componentMu;
+			if(component[n])
+				componentMu = mu[0];
+			else
+				componentMu = mu[1];
+			double componentSigma;
+			if(component[n])
+				componentSigma = sigma[0];
+			else
+				componentSigma = sigma[1];
+			y[n] = ((componentSigma * DistributionSampling.sampleGaussian(RNG$)) + componentMu);
+		}
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are calculated
+	// and stored.
+	@Override
+	public final void forwardGenerationDistributionsNoOutputsPrime() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	// Method to execute the model code conventionally with priming of fixed intermediate
+	// variables.
+	@Override
+	public final void forwardGenerationPrime() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+		for(int n = 0; n < N; n += 1) {
+			double componentMu;
+			if(component[n])
+				componentMu = mu[0];
+			else
+				componentMu = mu[1];
+			double componentSigma;
+			if(component[n])
+				componentSigma = sigma[0];
+			else
+				componentSigma = sigma[1];
+			y[n] = ((componentSigma * DistributionSampling.sampleGaussian(RNG$)) + componentMu);
+		}
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Distributions are collapsed to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputs() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are collapsed
+	// to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputsPrime() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	// Method to execute one round of Gibbs sampling.
+	@Override
+	public final void gibbsRound() {
+		// Infer the samples in chronological order.
+		if(system$gibbsForward) {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample20) {
+				inferSample20(0);
+				inferSample20(1);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample83) {
+				inferSample83(0);
+				inferSample83(1);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample101) {
+				for(int var96 = 0; var96 < N; var96 += 1)
+					inferSample101(var96);
+			}
+		}
+		// Infer the samples in reverse chronological order.
+		else {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample101) {
+				for(int var96 = (N - 1); var96 >= 0; var96 -= 1)
+					inferSample101(var96);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample83) {
+				inferSample83(1);
+				inferSample83(0);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample20) {
+				inferSample20(1);
+				inferSample20(0);
+			}
+		}
+		
+		// Reverse the direction of execution for the next iteration
+		system$gibbsForward = !system$gibbsForward;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!constrainedFlag$sample20[0])
+			drawValueSample20(0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!constrainedFlag$sample20[1])
+			drawValueSample20(1);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!constrainedFlag$sample83[0])
+			drawValueSample83(0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!constrainedFlag$sample83[1])
+			drawValueSample83(1);
+		if(!constrainedFlag$sample88)
+			drawValueSample88();
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!constrainedFlag$sample101[var96])
+				drawValueSample101(var96);
+		}
+	}
+
+	// A method to initialize all the probabilities in the model to 0/Log(1) ready for
+	// the current probabilities to be calculated by calculating the probability of each
+	// sample task, and its effect on the rest of the model.
+	private final void initializeLogProbabilityFields() {
+		// Set the probabilities of the random variable, and the model as a whole to ready
+		// them to be reconstructed by the probability calls for each sample. Sample probabilities
+		// are only reset for samples that are not fixed at a value that has already been
+		// calculated.
+		logProbability$$model = 0.0;
+		logProbability$$evidence = 0.0;
+		logProbability$rawMu = 0.0;
+		logProbability$mu = 0.0;
+		if(!fixedProbFlag$sample20) {
+			// Unrolled loop
+			logProbability$sample20[0] = Double.NaN;
+			logProbability$sample20[1] = Double.NaN;
+		}
+		logProbability$sigma = 0.0;
+		if(!fixedProbFlag$sample83)
+			logProbability$var79 = Double.NaN;
+		if(!fixedProbFlag$sample88)
+			logProbability$theta = Double.NaN;
+		logProbability$componentDistribution = Double.NaN;
+		logProbability$component = 0.0;
+		if(!fixedProbFlag$sample101)
+			logProbability$var97 = Double.NaN;
+		logProbability$y = 0.0;
+		if(!fixedProbFlag$sample138) {
+			for(int n = 0; n < N; n += 1)
+				logProbability$sample138[n] = Double.NaN;
+		}
+	}
+
+	// Method for initializing the model into a valid state before commencing inference
+	// etc.
+	@Override
+	public final void initializeModel() {
+		N = length$yObserved;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+			constrainedFlag$sample101[index$constrainedFlag$sample101$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+			constrainedFlag$sample20[index$constrainedFlag$sample20$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+			constrainedFlag$sample83[index$constrainedFlag$sample83$1] = true;
+	}
+
+	// Construct the evidence probabilities.
+	@Override
+	public final void logEvidenceProbabilities() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Call each method in turn to generate the new probability values.
+		if(fixedFlag$sample20)
+			logProbabilityValue$sample20();
+		if(fixedFlag$sample83)
+			logProbabilityValue$sample83();
+		if(fixedFlag$sample88)
+			logProbabilityValue$sample88();
+		if(fixedFlag$sample101)
+			logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model uses distributions
+	// when possible.
+	@Override
+	public final void logModelProbabilitiesDist() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model only uses values.
+	@Override
+	public final void logModelProbabilitiesVal() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to propagate observed values back into the model.
+	@Override
+	public final void propagateObservedValues() {
+		// Propagating values back from observations into the models intermediate variables.
+		// 
+		// Deep copy between arrays
+		int cv$length1 = y.length;
+		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1)
+			y[cv$index1] = yObserved[cv$index1];
+	}
+
+	// A method to set array values that depend on the output of a sample task, but are
+	// not directly set by the sample task. This method is called to propagate set values
+	// through the model. Any non-fixed sample values may be sampled to random variables
+	// as part of this process.
+	@Override
+	public final void setIntermediates() {
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+	}
+
+	@Override
+	public String modelCode() {
+		return "/*\n"
+		     + " * Sandwood\n"
+		     + " *\n"
+		     + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+		     + " * \n"
+		     + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+		     + " */\n"
+		     + "\n"
+		     + "package org.sandwood.compiler.tests.parser;\n"
+		     + "\n"
+		     + "public model LowDimMix(double[] yObserved) {\n"
+		     + "    int N = yObserved.length;\n"
+		     + "\n"
+		     + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+		     + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+		     + "    // the constant normalisation factor for the ordered constraint.\n"
+		     + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+		     + "    double[] mu = new double[2];\n"
+		     + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+		     + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+		     + "\n"
+		     + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+		     + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+		     + "\n"
+		     + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+		     + "    double theta = beta(5.0, 5.0).sample();\n"
+		     + "\n"
+		     + "    // Stan likelihood:\n"
+		     + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+		     + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+		     + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+		     + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+		     + "    boolean[] component = componentDistribution.sample(N);\n"
+		     + "    double[] y = new double[N];\n"
+		     + "\n"
+		     + "    for(int n = 0; n < N; n++) {\n"
+		     + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+		     + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+		     + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+		     + "    }\n"
+		     + "\n"
+		     + "    y.observe(yObserved);\n"
+		     + "}\n"
+		     + "";
+	}
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$SingleThreadCPU_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$SingleThreadCPU_optimisedModelNoComments.java
@@ -1,0 +1,1504 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.runtime.internal.numericTools.Conjugates;
+import org.sandwood.runtime.internal.numericTools.DistributionSampling;
+import org.sandwood.runtime.model.ExecutionTarget;
+
+final class LowDimMix$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements LowDimMix$CoreInterface {
+	private int N;
+	private boolean[] component;
+	private boolean[] constrainedFlag$sample101;
+	private boolean[] constrainedFlag$sample20;
+	private boolean[] constrainedFlag$sample83;
+	private boolean constrainedFlag$sample88 = true;
+	private double[] cv$var97$stateProbabilityGlobal;
+	private boolean fixedFlag$sample101 = false;
+	private boolean fixedFlag$sample20 = false;
+	private boolean fixedFlag$sample83 = false;
+	private boolean fixedFlag$sample88 = false;
+	private boolean fixedProbFlag$sample101 = false;
+	private boolean fixedProbFlag$sample138 = false;
+	private boolean fixedProbFlag$sample20 = false;
+	private boolean fixedProbFlag$sample83 = false;
+	private boolean fixedProbFlag$sample88 = false;
+	private boolean[] guard$sample20if124$global;
+	private int length$yObserved;
+	private double logProbability$$evidence;
+	private double logProbability$$model;
+	private double logProbability$component;
+	private double logProbability$componentDistribution;
+	private double logProbability$mu;
+	private double logProbability$rawMu;
+	private double[] logProbability$sample138;
+	private double[] logProbability$sample20;
+	private double logProbability$sigma;
+	private double logProbability$theta;
+	private double logProbability$var79;
+	private double logProbability$var97;
+	private double logProbability$y;
+	private double[] mu;
+	private double[] rawMu;
+	private double[] sigma;
+	private boolean system$gibbsForward = true;
+	private double theta;
+	private double[] y;
+	private double[] yObserved;
+
+	public LowDimMix$SingleThreadCPU(ExecutionTarget target) {
+		super(target);
+	}
+
+	@Override
+	public final int get$N() {
+		return N;
+	}
+
+	@Override
+	public final boolean[] get$component() {
+		return component;
+	}
+
+	@Override
+	public final void set$component(boolean[] cv$value, boolean allocated$) {
+		component = cv$value;
+		fixedProbFlag$sample101 = false;
+		fixedProbFlag$sample138 = false;
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample101() {
+		return fixedFlag$sample101;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample101(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample101 = cv$value;
+		if(allocated$) {
+			for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+				constrainedFlag$sample101[index$constrainedFlag$sample101$1] = cv$value;
+		}
+		fixedProbFlag$sample101 = (cv$value && fixedProbFlag$sample101);
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample20() {
+		return fixedFlag$sample20;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample20(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample20 = cv$value;
+		if(allocated$) {
+			for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+				constrainedFlag$sample20[index$constrainedFlag$sample20$1] = cv$value;
+		}
+		fixedProbFlag$sample20 = (cv$value && fixedProbFlag$sample20);
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample83() {
+		return fixedFlag$sample83;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample83(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample83 = cv$value;
+		if(allocated$) {
+			for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+				constrainedFlag$sample83[index$constrainedFlag$sample83$1] = cv$value;
+		}
+		fixedProbFlag$sample83 = (cv$value && fixedProbFlag$sample83);
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	@Override
+	public final boolean get$fixedFlag$sample88() {
+		return fixedFlag$sample88;
+	}
+
+	@Override
+	public final void set$fixedFlag$sample88(boolean cv$value, boolean allocated$) {
+		fixedFlag$sample88 = cv$value;
+		constrainedFlag$sample88 = (cv$value || constrainedFlag$sample88);
+		fixedProbFlag$sample88 = (cv$value && fixedProbFlag$sample88);
+		fixedProbFlag$sample101 = (cv$value && fixedProbFlag$sample101);
+	}
+
+	@Override
+	public final int get$length$yObserved() {
+		return length$yObserved;
+	}
+
+	@Override
+	public final void set$length$yObserved(int cv$value, boolean allocated$) {
+		length$yObserved = cv$value;
+	}
+
+	@Override
+	public final double get$logProbability$$evidence() {
+		return logProbability$$evidence;
+	}
+
+	@Override
+	public final double getCurrentLogProbability() {
+		return logProbability$$model;
+	}
+
+	@Override
+	public final double get$logProbability$component() {
+		return logProbability$component;
+	}
+
+	@Override
+	public final double get$logProbability$componentDistribution() {
+		return logProbability$componentDistribution;
+	}
+
+	@Override
+	public final double get$logProbability$mu() {
+		return logProbability$mu;
+	}
+
+	@Override
+	public final double get$logProbability$rawMu() {
+		return logProbability$rawMu;
+	}
+
+	@Override
+	public final double get$logProbability$sigma() {
+		return logProbability$sigma;
+	}
+
+	@Override
+	public final double get$logProbability$theta() {
+		return logProbability$theta;
+	}
+
+	@Override
+	public final double get$logProbability$y() {
+		return logProbability$y;
+	}
+
+	@Override
+	public final double[] get$mu() {
+		return mu;
+	}
+
+	@Override
+	public final double[] get$rawMu() {
+		return rawMu;
+	}
+
+	@Override
+	public final void set$rawMu(double[] cv$value, boolean allocated$) {
+		rawMu = cv$value;
+		fixedProbFlag$sample20 = false;
+		fixedProbFlag$sample138 = false;
+	}
+
+	@Override
+	public final double[] get$sigma() {
+		return sigma;
+	}
+
+	@Override
+	public final void set$sigma(double[] cv$value, boolean allocated$) {
+		sigma = cv$value;
+		fixedProbFlag$sample83 = false;
+		fixedProbFlag$sample138 = false;
+	}
+
+	@Override
+	public final double get$theta() {
+		return theta;
+	}
+
+	@Override
+	public final void set$theta(double cv$value, boolean allocated$) {
+		theta = cv$value;
+		fixedProbFlag$sample88 = false;
+		fixedProbFlag$sample101 = false;
+	}
+
+	@Override
+	public final double[] get$y() {
+		return y;
+	}
+
+	@Override
+	public final double[] get$yObserved() {
+		return yObserved;
+	}
+
+	@Override
+	public final void set$yObserved(double[] cv$value, boolean allocated$) {
+		yObserved = cv$value;
+	}
+
+	private final void drawValueSample101(int var96) {
+		component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+	}
+
+	private final void drawValueSample20(int var19) {
+		rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		boolean guard$sample20put43 = false;
+		if((var19 == 0)) {
+			guard$sample20put43 = true;
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+		}
+		if(((var19 == 1) && !guard$sample20put43)) {
+			guard$sample20put43 = true;
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+		}
+		if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+			guard$sample20put43 = true;
+			mu[0] = rawMu[0];
+		}
+		if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+			mu[0] = rawMu[1];
+		boolean guard$sample20put63 = false;
+		if((var19 == 0)) {
+			guard$sample20put63 = true;
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		if((var19 == 1)) {
+			if(!guard$sample20put63) {
+				guard$sample20put63 = true;
+				double var57;
+				if((rawMu[0] < rawMu[1]))
+					var57 = rawMu[1];
+				else
+					var57 = rawMu[0];
+				mu[1] = var57;
+			}
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+				guard$sample20put63 = true;
+				mu[1] = rawMu[1];
+			}
+		}
+		if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+			mu[1] = rawMu[0];
+	}
+
+	private final void drawValueSample83(int var78) {
+		sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+	}
+
+	private final void drawValueSample88() {
+		theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+	}
+
+	private final void inferSample101(int var96) {
+		{
+			component[var96] = false;
+			double cv$accumulatedProbabilities = (((0.0 <= theta) && (theta <= 1.0))?Math.log((1.0 - theta)):Double.NEGATIVE_INFINITY);
+			if(component[var96]) {
+				{
+					double componentSigma = sigma[0];
+					double var128 = (componentSigma * componentSigma);
+					cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				}
+				guard$sample20if124$global[0] = false;
+				guard$sample20if124$global[1] = false;
+				if((rawMu[0] < rawMu[1]))
+					guard$sample20if124$global[0] = false;
+				else
+					guard$sample20if124$global[1] = false;
+				if(!guard$sample20if124$global[0]) {
+					guard$sample20if124$global[0] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				if(!guard$sample20if124$global[1]) {
+					guard$sample20if124$global[1] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				if(((rawMu[0] < rawMu[1]) && !guard$sample20if124$global[0])) {
+					guard$sample20if124$global[0] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124$global[1])) {
+					guard$sample20if124$global[1] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				double traceTempVariable$componentSigma$58_1 = sigma[0];
+				double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				cv$accumulatedProbabilities = ((((0.0 <= sigma[0]) && (sigma[0] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[0] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			} else {
+				{
+					double componentSigma = sigma[1];
+					double var128 = (componentSigma * componentSigma);
+					cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				}
+				guard$sample20if124$global[0] = false;
+				guard$sample20if124$global[1] = false;
+				if((rawMu[0] < rawMu[1]))
+					guard$sample20if124$global[1] = false;
+				else
+					guard$sample20if124$global[0] = false;
+				if(!guard$sample20if124$global[0]) {
+					guard$sample20if124$global[0] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				if(!guard$sample20if124$global[1]) {
+					guard$sample20if124$global[1] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				if(((rawMu[0] < rawMu[1]) && !guard$sample20if124$global[1])) {
+					guard$sample20if124$global[1] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124$global[0])) {
+					guard$sample20if124$global[0] = true;
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				double traceTempVariable$componentSigma$63_1 = sigma[1];
+				double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				cv$accumulatedProbabilities = ((((0.0 <= sigma[1]) && (sigma[1] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[1] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			cv$var97$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
+		}
+		component[var96] = true;
+		double cv$accumulatedProbabilities = (((0.0 <= theta) && (theta <= 1.0))?Math.log(theta):Double.NEGATIVE_INFINITY);
+		if(component[var96]) {
+			{
+				double componentSigma = sigma[0];
+				double var128 = (componentSigma * componentSigma);
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			guard$sample20if124$global[0] = false;
+			guard$sample20if124$global[1] = false;
+			if((rawMu[0] < rawMu[1]))
+				guard$sample20if124$global[0] = false;
+			else
+				guard$sample20if124$global[1] = false;
+			if(!guard$sample20if124$global[0]) {
+				guard$sample20if124$global[0] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			if(!guard$sample20if124$global[1]) {
+				guard$sample20if124$global[1] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20if124$global[0])) {
+				guard$sample20if124$global[0] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124$global[1])) {
+				guard$sample20if124$global[1] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			double traceTempVariable$componentSigma$58_1 = sigma[0];
+			constrainedFlag$sample101[var96] = true;
+			double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+			cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			cv$accumulatedProbabilities = ((((0.0 <= sigma[0]) && (sigma[0] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[0] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+		} else {
+			{
+				double componentSigma = sigma[1];
+				double var128 = (componentSigma * componentSigma);
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			guard$sample20if124$global[0] = false;
+			guard$sample20if124$global[1] = false;
+			if((rawMu[0] < rawMu[1]))
+				guard$sample20if124$global[1] = false;
+			else
+				guard$sample20if124$global[0] = false;
+			if(!guard$sample20if124$global[0]) {
+				guard$sample20if124$global[0] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			if(!guard$sample20if124$global[1]) {
+				guard$sample20if124$global[1] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20if124$global[1])) {
+				guard$sample20if124$global[1] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124$global[0])) {
+				guard$sample20if124$global[0] = true;
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			double traceTempVariable$componentSigma$63_1 = sigma[1];
+			constrainedFlag$sample101[var96] = true;
+			double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+			cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			cv$accumulatedProbabilities = ((((0.0 <= sigma[1]) && (sigma[1] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[1] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+		}
+		cv$var97$stateProbabilityGlobal[1] = cv$accumulatedProbabilities;
+		if(constrainedFlag$sample101[var96]) {
+			double cv$logSum;
+			double cv$lseMax = cv$var97$stateProbabilityGlobal[0];
+			double cv$lseElementValue = cv$var97$stateProbabilityGlobal[1];
+			if((cv$lseMax < cv$lseElementValue))
+				cv$lseMax = cv$lseElementValue;
+			if((cv$lseMax == Double.NEGATIVE_INFINITY))
+				cv$logSum = Double.NEGATIVE_INFINITY;
+			else
+				cv$logSum = (Math.log((Math.exp((cv$var97$stateProbabilityGlobal[0] - cv$lseMax)) + Math.exp((cv$var97$stateProbabilityGlobal[1] - cv$lseMax)))) + cv$lseMax);
+			if((cv$logSum == Double.NEGATIVE_INFINITY)) {
+				cv$var97$stateProbabilityGlobal[0] = 0.5;
+				cv$var97$stateProbabilityGlobal[1] = 0.5;
+			} else {
+				cv$var97$stateProbabilityGlobal[0] = Math.exp((cv$var97$stateProbabilityGlobal[0] - cv$logSum));
+				cv$var97$stateProbabilityGlobal[1] = Math.exp((cv$var97$stateProbabilityGlobal[1] - cv$logSum));
+			}
+			for(int cv$indexName = 2; cv$indexName < cv$var97$stateProbabilityGlobal.length; cv$indexName += 1)
+				cv$var97$stateProbabilityGlobal[cv$indexName] = Double.NEGATIVE_INFINITY;
+			component[var96] = (DistributionSampling.sampleCategorical(RNG$, cv$var97$stateProbabilityGlobal, 2) == 1);
+		}
+	}
+
+	private final void inferSample20(int var19) {
+		constrainedFlag$sample20[var19] = false;
+		double cv$originalValue = rawMu[var19];
+		double cv$originalProbability;
+		double cv$var = ((cv$originalValue * cv$originalValue) * 0.010000000000000002);
+		if((cv$var < 0.010000000000000002))
+			cv$var = 0.010000000000000002;
+		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+		{
+			double cv$accumulatedProbabilities = (DistributionSampling.logProbabilityGaussian((cv$originalValue / 2.0)) - 0.6931471805599453);
+			if(((rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						constrainedFlag$sample20[0] = true;
+						double componentSigma = sigma[0];
+						double var128 = (componentSigma * componentSigma);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			if((var19 == 1)) {
+				if((rawMu[0] < rawMu[1])) {
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				} else {
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+			}
+			if((!(rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						constrainedFlag$sample20[0] = true;
+						double componentSigma = sigma[1];
+						double var128 = (componentSigma * componentSigma);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			boolean guard$sample20if41 = false;
+			if((var19 == 0)) {
+				guard$sample20if41 = true;
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$36_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$36_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var115$52_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$52_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			if(((var19 == 1) && !guard$sample20if41)) {
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$37_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$37_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var115$53_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$53_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			boolean guard$sample20if61 = false;
+			if((var19 == 0)) {
+				guard$sample20if61 = true;
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$72_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$72_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var117$88_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$88_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			if(((var19 == 1) && !guard$sample20if61)) {
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$73_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$73_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var117$89_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$89_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		if(constrainedFlag$sample20[var19]) {
+			{
+				rawMu[var19] = cv$proposedValue;
+				boolean guard$sample20put43 = false;
+				if((var19 == 0)) {
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				if(((var19 == 1) && !guard$sample20put43)) {
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+					guard$sample20put43 = true;
+					mu[0] = rawMu[0];
+				}
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+					mu[0] = rawMu[1];
+				boolean guard$sample20put63 = false;
+				if((var19 == 0)) {
+					guard$sample20put63 = true;
+					double var57;
+					if((rawMu[0] < rawMu[1]))
+						var57 = rawMu[1];
+					else
+						var57 = rawMu[0];
+					mu[1] = var57;
+				}
+				if((var19 == 1)) {
+					if(!guard$sample20put63) {
+						guard$sample20put63 = true;
+						double var57;
+						if((rawMu[0] < rawMu[1]))
+							var57 = rawMu[1];
+						else
+							var57 = rawMu[0];
+						mu[1] = var57;
+					}
+					if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+						guard$sample20put63 = true;
+						mu[1] = rawMu[1];
+					}
+				}
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+					mu[1] = rawMu[0];
+			}
+			double cv$accumulatedProbabilities = (DistributionSampling.logProbabilityGaussian((cv$proposedValue / 2.0)) - 0.6931471805599453);
+			if(((rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						constrainedFlag$sample20[0] = true;
+						double componentSigma = sigma[0];
+						double var128 = (componentSigma * componentSigma);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			if((var19 == 1)) {
+				if((rawMu[0] < rawMu[1])) {
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				} else {
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+			}
+			if((!(rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						constrainedFlag$sample20[0] = true;
+						double componentSigma = sigma[1];
+						double var128 = (componentSigma * componentSigma);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			boolean guard$sample20if41 = false;
+			if((var19 == 0)) {
+				guard$sample20if41 = true;
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$36_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$36_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var115$52_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$52_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			if(((var19 == 1) && !guard$sample20if41)) {
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$37_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$37_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var115$53_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[0];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$53_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			boolean guard$sample20if61 = false;
+			if((var19 == 0)) {
+				guard$sample20if61 = true;
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$72_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$72_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var117$88_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[0] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$88_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			if(((var19 == 1) && !guard$sample20if61)) {
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$73_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$73_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				} else {
+					double traceTempVariable$var117$89_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							constrainedFlag$sample20[1] = true;
+							double componentSigma = sigma[1];
+							double var128 = (componentSigma * componentSigma);
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$89_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			double cv$ratio = (cv$accumulatedProbabilities - cv$originalProbability);
+			if(((cv$ratio <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN(cv$ratio))) {
+				rawMu[var19] = cv$originalValue;
+				boolean guard$sample20put43 = false;
+				if((var19 == 0)) {
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				if(((var19 == 1) && !guard$sample20put43)) {
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+					guard$sample20put43 = true;
+					mu[0] = rawMu[0];
+				}
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+					mu[0] = rawMu[1];
+				boolean guard$sample20put63 = false;
+				if((var19 == 0)) {
+					guard$sample20put63 = true;
+					double var57;
+					if((rawMu[0] < rawMu[1]))
+						var57 = rawMu[1];
+					else
+						var57 = rawMu[0];
+					mu[1] = var57;
+				}
+				if((var19 == 1)) {
+					if(!guard$sample20put63) {
+						guard$sample20put63 = true;
+						double var57;
+						if((rawMu[0] < rawMu[1]))
+							var57 = rawMu[1];
+						else
+							var57 = rawMu[0];
+						mu[1] = var57;
+					}
+					if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+						guard$sample20put63 = true;
+						mu[1] = rawMu[1];
+					}
+				}
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+					mu[1] = rawMu[0];
+			}
+		}
+	}
+
+	private final void inferSample83(int var78) {
+		constrainedFlag$sample83[var78] = false;
+		double cv$originalValue = sigma[var78];
+		double cv$originalProbability;
+		double cv$var = ((cv$originalValue * cv$originalValue) * 0.010000000000000002);
+		if((cv$var < 0.010000000000000002))
+			cv$var = 0.010000000000000002;
+		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+		{
+			double cv$accumulatedProbabilities = (((0.0 <= cv$originalValue) && (cv$originalValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$originalValue / 2.0)):Double.NEGATIVE_INFINITY);
+			if((var78 == 0)) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						constrainedFlag$sample83[0] = true;
+						double var128 = (cv$originalValue * cv$originalValue);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			if((var78 == 1)) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						constrainedFlag$sample83[1] = true;
+						double var128 = (cv$originalValue * cv$originalValue);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		if(constrainedFlag$sample83[var78]) {
+			sigma[var78] = cv$proposedValue;
+			double cv$accumulatedProbabilities = (((0.0 <= cv$proposedValue) && (cv$proposedValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$proposedValue / 2.0)):Double.NEGATIVE_INFINITY);
+			if((var78 == 0)) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						constrainedFlag$sample83[0] = true;
+						double var128 = (cv$proposedValue * cv$proposedValue);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			if((var78 == 1)) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						constrainedFlag$sample83[1] = true;
+						double var128 = (cv$proposedValue * cv$proposedValue);
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			double cv$ratio = (cv$accumulatedProbabilities - cv$originalProbability);
+			if(((cv$ratio <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN(cv$ratio)))
+				sigma[var78] = cv$originalValue;
+		}
+	}
+
+	private final void inferSample88() {
+		constrainedFlag$sample88 = false;
+		int cv$sum = 0;
+		int cv$count = 0;
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if((fixedFlag$sample101 || constrainedFlag$sample101[var96])) {
+				constrainedFlag$sample88 = true;
+				cv$count = (cv$count + 1);
+				if(component[var96])
+					cv$sum = (cv$sum + 1);
+			}
+		}
+		if(constrainedFlag$sample88)
+			theta = Conjugates.sampleConjugateBetaBinomial(RNG$, 5.0, 5.0, cv$sum, cv$count);
+	}
+
+	private final void logProbabilityValue$sample101() {
+		if(!fixedProbFlag$sample101) {
+			double cv$sampleAccumulator = 0.0;
+			for(int var96 = 0; var96 < N; var96 += 1)
+				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= theta) && (theta <= 1.0))?Math.log((component[var96]?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+			logProbability$componentDistribution = cv$sampleAccumulator;
+			logProbability$var97 = cv$sampleAccumulator;
+			logProbability$component = (logProbability$component + cv$sampleAccumulator);
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedFlag$sample88);
+		} else {
+			logProbability$componentDistribution = logProbability$var97;
+			logProbability$component = (logProbability$component + logProbability$var97);
+			logProbability$$model = (logProbability$$model + logProbability$var97);
+			if(fixedFlag$sample101)
+				logProbability$$evidence = (logProbability$$evidence + logProbability$var97);
+		}
+	}
+
+	private final void logProbabilityValue$sample138() {
+		if(!fixedProbFlag$sample138) {
+			double cv$accumulator = 0.0;
+			for(int n = 0; n < N; n += 1) {
+				double componentMu;
+				if(component[n])
+					componentMu = mu[0];
+				else
+					componentMu = mu[1];
+				double componentSigma;
+				if(component[n])
+					componentSigma = sigma[0];
+				else
+					componentSigma = sigma[1];
+				double var128 = (componentSigma * componentSigma);
+				double cv$distributionAccumulator = ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY);
+				cv$accumulator = (cv$accumulator + cv$distributionAccumulator);
+				logProbability$sample138[n] = cv$distributionAccumulator;
+			}
+			logProbability$y = (logProbability$y + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+			fixedProbFlag$sample138 = ((fixedFlag$sample20 && fixedFlag$sample83) && fixedFlag$sample101);
+		} else {
+			double cv$accumulator = 0.0;
+			for(int n = 0; n < N; n += 1)
+				cv$accumulator = (cv$accumulator + logProbability$sample138[n]);
+			logProbability$y = (logProbability$y + cv$accumulator);
+			logProbability$$model = (logProbability$$model + cv$accumulator);
+			logProbability$$evidence = (logProbability$$evidence + cv$accumulator);
+		}
+	}
+
+	private final void logProbabilityValue$sample20() {
+		if(!fixedProbFlag$sample20) {
+			double cv$sampleAccumulator;
+			{
+				double cv$weightedProbability = (DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) - 0.6931471805599453);
+				cv$sampleAccumulator = cv$weightedProbability;
+				logProbability$sample20[0] = cv$weightedProbability;
+				boolean cv$guard$mu = false;
+				if((rawMu[0] < rawMu[1])) {
+					cv$guard$mu = true;
+					logProbability$mu = (logProbability$mu + cv$weightedProbability);
+				}
+				if((!(rawMu[0] < rawMu[1]) && !cv$guard$mu))
+					logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			}
+			double cv$weightedProbability = (DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) - 0.6931471805599453);
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$weightedProbability);
+			logProbability$sample20[1] = cv$weightedProbability;
+			boolean cv$guard$mu = false;
+			if(!(rawMu[0] < rawMu[1])) {
+				cv$guard$mu = true;
+				logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			}
+			if(((rawMu[0] < rawMu[1]) && !cv$guard$mu))
+				logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			logProbability$rawMu = (logProbability$rawMu + cv$sampleAccumulator);
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			fixedProbFlag$sample20 = fixedFlag$sample20;
+		} else {
+			double cv$rvAccumulator;
+			{
+				double cv$sampleValue = logProbability$sample20[0];
+				cv$rvAccumulator = cv$sampleValue;
+				boolean cv$guard$mu = false;
+				if((rawMu[0] < rawMu[1])) {
+					cv$guard$mu = true;
+					logProbability$mu = (logProbability$mu + cv$sampleValue);
+				}
+				if((!(rawMu[0] < rawMu[1]) && !cv$guard$mu))
+					logProbability$mu = (logProbability$mu + cv$sampleValue);
+			}
+			double cv$sampleValue = logProbability$sample20[1];
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			boolean cv$guard$mu = false;
+			if(!(rawMu[0] < rawMu[1])) {
+				cv$guard$mu = true;
+				logProbability$mu = (logProbability$mu + cv$sampleValue);
+			}
+			if(((rawMu[0] < rawMu[1]) && !cv$guard$mu))
+				logProbability$mu = (logProbability$mu + cv$sampleValue);
+			logProbability$rawMu = (logProbability$rawMu + cv$rvAccumulator);
+			logProbability$$model = (logProbability$$model + cv$rvAccumulator);
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$rvAccumulator);
+		}
+	}
+
+	private final void logProbabilityValue$sample83() {
+		if(!fixedProbFlag$sample83) {
+			double cv$sampleAccumulator;
+			{
+				double cv$sampleValue = sigma[0];
+				cv$sampleAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$sampleValue / 2.0)):Double.NEGATIVE_INFINITY);
+			}
+			double cv$sampleValue = sigma[1];
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$sampleValue / 2.0)):Double.NEGATIVE_INFINITY));
+			logProbability$var79 = cv$sampleAccumulator;
+			logProbability$sigma = (logProbability$sigma + cv$sampleAccumulator);
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			fixedProbFlag$sample83 = fixedFlag$sample83;
+		} else {
+			logProbability$sigma = (logProbability$sigma + logProbability$var79);
+			logProbability$$model = (logProbability$$model + logProbability$var79);
+			if(fixedFlag$sample83)
+				logProbability$$evidence = (logProbability$$evidence + logProbability$var79);
+		}
+	}
+
+	private final void logProbabilityValue$sample88() {
+		if(!fixedProbFlag$sample88) {
+			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(theta, 5.0, 5.0);
+			logProbability$theta = cv$distributionAccumulator;
+			logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + cv$distributionAccumulator);
+			fixedProbFlag$sample88 = fixedFlag$sample88;
+		} else {
+			logProbability$$model = (logProbability$$model + logProbability$theta);
+			if(fixedFlag$sample88)
+				logProbability$$evidence = (logProbability$$evidence + logProbability$theta);
+		}
+	}
+
+	@Override
+	public final void allocateScratch() {
+		cv$var97$stateProbabilityGlobal = new double[2];
+		guard$sample20if124$global = new boolean[2];
+	}
+
+	@Override
+	public final void allocator() {
+		if(!fixedFlag$sample20)
+			rawMu = new double[2];
+		mu = new double[2];
+		if(!fixedFlag$sample83)
+			sigma = new double[2];
+		if(!fixedFlag$sample101)
+			component = new boolean[length$yObserved];
+		y = new double[length$yObserved];
+		constrainedFlag$sample101 = new boolean[length$yObserved];
+		constrainedFlag$sample20 = new boolean[2];
+		constrainedFlag$sample83 = new boolean[2];
+		logProbability$sample20 = new double[2];
+		logProbability$sample138 = new double[length$yObserved];
+		allocateScratch();
+	}
+
+	@Override
+	public final void forwardGeneration() {
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+		for(int n = 0; n < N; n += 1) {
+			double componentMu;
+			if(component[n])
+				componentMu = mu[0];
+			else
+				componentMu = mu[1];
+			double componentSigma;
+			if(component[n])
+				componentSigma = sigma[0];
+			else
+				componentSigma = sigma[1];
+			y[n] = ((componentSigma * DistributionSampling.sampleGaussian(RNG$)) + componentMu);
+		}
+	}
+
+	@Override
+	public final void forwardGenerationDistributionsNoOutputsPrime() {
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	@Override
+	public final void forwardGenerationPrime() {
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+		for(int n = 0; n < N; n += 1) {
+			double componentMu;
+			if(component[n])
+				componentMu = mu[0];
+			else
+				componentMu = mu[1];
+			double componentSigma;
+			if(component[n])
+				componentSigma = sigma[0];
+			else
+				componentSigma = sigma[1];
+			y[n] = ((componentSigma * DistributionSampling.sampleGaussian(RNG$)) + componentMu);
+		}
+	}
+
+	@Override
+	public final void forwardGenerationValuesNoOutputs() {
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	@Override
+	public final void forwardGenerationValuesNoOutputsPrime() {
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	@Override
+	public final void gibbsRound() {
+		if(system$gibbsForward) {
+			if(!fixedFlag$sample20) {
+				inferSample20(0);
+				inferSample20(1);
+			}
+			if(!fixedFlag$sample83) {
+				inferSample83(0);
+				inferSample83(1);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			if(!fixedFlag$sample101) {
+				for(int var96 = 0; var96 < N; var96 += 1)
+					inferSample101(var96);
+			}
+		} else {
+			if(!fixedFlag$sample101) {
+				for(int var96 = (N - 1); var96 >= 0; var96 -= 1)
+					inferSample101(var96);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			if(!fixedFlag$sample83) {
+				inferSample83(1);
+				inferSample83(0);
+			}
+			if(!fixedFlag$sample20) {
+				inferSample20(1);
+				inferSample20(0);
+			}
+		}
+		system$gibbsForward = !system$gibbsForward;
+		if(!constrainedFlag$sample20[0])
+			drawValueSample20(0);
+		if(!constrainedFlag$sample20[1])
+			drawValueSample20(1);
+		if(!constrainedFlag$sample83[0])
+			drawValueSample83(0);
+		if(!constrainedFlag$sample83[1])
+			drawValueSample83(1);
+		if(!constrainedFlag$sample88)
+			drawValueSample88();
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!constrainedFlag$sample101[var96])
+				drawValueSample101(var96);
+		}
+	}
+
+	private final void initializeLogProbabilityFields() {
+		logProbability$$model = 0.0;
+		logProbability$$evidence = 0.0;
+		logProbability$rawMu = 0.0;
+		logProbability$mu = 0.0;
+		if(!fixedProbFlag$sample20) {
+			logProbability$sample20[0] = Double.NaN;
+			logProbability$sample20[1] = Double.NaN;
+		}
+		logProbability$sigma = 0.0;
+		if(!fixedProbFlag$sample83)
+			logProbability$var79 = Double.NaN;
+		if(!fixedProbFlag$sample88)
+			logProbability$theta = Double.NaN;
+		logProbability$componentDistribution = Double.NaN;
+		logProbability$component = 0.0;
+		if(!fixedProbFlag$sample101)
+			logProbability$var97 = Double.NaN;
+		logProbability$y = 0.0;
+		if(!fixedProbFlag$sample138) {
+			for(int n = 0; n < N; n += 1)
+				logProbability$sample138[n] = Double.NaN;
+		}
+	}
+
+	@Override
+	public final void initializeModel() {
+		N = length$yObserved;
+		for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+			constrainedFlag$sample101[index$constrainedFlag$sample101$1] = true;
+		for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+			constrainedFlag$sample20[index$constrainedFlag$sample20$1] = true;
+		for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+			constrainedFlag$sample83[index$constrainedFlag$sample83$1] = true;
+	}
+
+	@Override
+	public final void logEvidenceProbabilities() {
+		initializeLogProbabilityFields();
+		if(fixedFlag$sample20)
+			logProbabilityValue$sample20();
+		if(fixedFlag$sample83)
+			logProbabilityValue$sample83();
+		if(fixedFlag$sample88)
+			logProbabilityValue$sample88();
+		if(fixedFlag$sample101)
+			logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	@Override
+	public final void logModelProbabilitiesDist() {
+		initializeLogProbabilityFields();
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	@Override
+	public final void logModelProbabilitiesVal() {
+		initializeLogProbabilityFields();
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	@Override
+	public final void propagateObservedValues() {
+		int cv$length1 = y.length;
+		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1)
+			y[cv$index1] = yObserved[cv$index1];
+	}
+
+	@Override
+	public final void setIntermediates() {
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+	}
+
+	@Override
+	public String modelCode() {
+		return "/*\n"
+		     + " * Sandwood\n"
+		     + " *\n"
+		     + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+		     + " * \n"
+		     + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+		     + " */\n"
+		     + "\n"
+		     + "package org.sandwood.compiler.tests.parser;\n"
+		     + "\n"
+		     + "public model LowDimMix(double[] yObserved) {\n"
+		     + "    int N = yObserved.length;\n"
+		     + "\n"
+		     + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+		     + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+		     + "    // the constant normalisation factor for the ordered constraint.\n"
+		     + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+		     + "    double[] mu = new double[2];\n"
+		     + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+		     + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+		     + "\n"
+		     + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+		     + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+		     + "\n"
+		     + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+		     + "    double theta = beta(5.0, 5.0).sample();\n"
+		     + "\n"
+		     + "    // Stan likelihood:\n"
+		     + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+		     + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+		     + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+		     + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+		     + "    boolean[] component = componentDistribution.sample(N);\n"
+		     + "    double[] y = new double[N];\n"
+		     + "\n"
+		     + "    for(int n = 0; n < N; n++) {\n"
+		     + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+		     + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+		     + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+		     + "    }\n"
+		     + "\n"
+		     + "    y.observe(yObserved);\n"
+		     + "}\n"
+		     + "";
+	}
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$SingleThreadCPU_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix$SingleThreadCPU_optimisedModelSingle.java
@@ -1,0 +1,4300 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.runtime.internal.numericTools.Conjugates;
+import org.sandwood.runtime.internal.numericTools.DistributionSampling;
+import org.sandwood.runtime.model.ExecutionTarget;
+
+final class LowDimMix$SingleThreadCPU extends org.sandwood.runtime.internal.model.CoreModelSingleThreadCPU implements LowDimMix$CoreInterface {
+	
+	// Declare the variables for the model.
+	private int N;
+	private boolean[] component;
+	private boolean[] constrainedFlag$sample101;
+	private boolean[] constrainedFlag$sample20;
+	private boolean[] constrainedFlag$sample83;
+	private boolean constrainedFlag$sample88 = true;
+	private double[] cv$var97$stateProbabilityGlobal;
+	private boolean fixedFlag$sample101 = false;
+	private boolean fixedFlag$sample20 = false;
+	private boolean fixedFlag$sample83 = false;
+	private boolean fixedFlag$sample88 = false;
+	private boolean fixedProbFlag$sample101 = false;
+	private boolean fixedProbFlag$sample138 = false;
+	private boolean fixedProbFlag$sample20 = false;
+	private boolean fixedProbFlag$sample83 = false;
+	private boolean fixedProbFlag$sample88 = false;
+	private boolean[] guard$sample20if124$global;
+	private int length$yObserved;
+	private double logProbability$$evidence;
+	private double logProbability$$model;
+	private double logProbability$component;
+	private double logProbability$componentDistribution;
+	private double logProbability$mu;
+	private double logProbability$rawMu;
+	private double[] logProbability$sample20;
+	private double logProbability$sigma;
+	private double logProbability$theta;
+	private double logProbability$var130;
+	private double logProbability$var79;
+	private double logProbability$var97;
+	private double logProbability$y;
+	private double[] mu;
+	private double[] rawMu;
+	private double[] sigma;
+	private boolean system$gibbsForward = true;
+	private double theta;
+	private double[] y;
+	private double[] yObserved;
+
+	public LowDimMix$SingleThreadCPU(ExecutionTarget target) {
+		super(target);
+	}
+
+	// Getter for N.
+	@Override
+	public final int get$N() {
+		return N;
+	}
+
+	// Getter for component.
+	@Override
+	public final boolean[] get$component() {
+		return component;
+	}
+
+	// Setter for component.
+	@Override
+	public final void set$component(boolean[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of component including if probabilities need
+		// to be updated.
+		component = cv$value;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on component.
+		fixedProbFlag$sample101 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on component.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for fixedFlag$sample101.
+	@Override
+	public final boolean get$fixedFlag$sample101() {
+		return fixedFlag$sample101;
+	}
+
+	// Setter for fixedFlag$sample101.
+	@Override
+	public final void set$fixedFlag$sample101(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample101 including if probabilities
+		// need to be updated.
+		fixedFlag$sample101 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+				// Substituted "fixedFlag$sample101" with its value "cv$value".
+				constrainedFlag$sample101[index$constrainedFlag$sample101$1] = cv$value;
+		}
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample101" with its value "cv$value".
+		fixedProbFlag$sample101 = (cv$value && fixedProbFlag$sample101);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample101" with its value "cv$value".
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample20.
+	@Override
+	public final boolean get$fixedFlag$sample20() {
+		return fixedFlag$sample20;
+	}
+
+	// Setter for fixedFlag$sample20.
+	@Override
+	public final void set$fixedFlag$sample20(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample20 including if probabilities
+		// need to be updated.
+		fixedFlag$sample20 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+				// Substituted "fixedFlag$sample20" with its value "cv$value".
+				constrainedFlag$sample20[index$constrainedFlag$sample20$1] = cv$value;
+		}
+		
+		// Should the probability of sample 20 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample20" with its value "cv$value".
+		fixedProbFlag$sample20 = (cv$value && fixedProbFlag$sample20);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample20" with its value "cv$value".
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample83.
+	@Override
+	public final boolean get$fixedFlag$sample83() {
+		return fixedFlag$sample83;
+	}
+
+	// Setter for fixedFlag$sample83.
+	@Override
+	public final void set$fixedFlag$sample83(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample83 including if probabilities
+		// need to be updated.
+		fixedFlag$sample83 = cv$value;
+		
+		// If the model has been allocated update the constraints flags
+		if(allocated$) {
+			// Set all the values in the array
+			for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+				// Substituted "fixedFlag$sample83" with its value "cv$value".
+				constrainedFlag$sample83[index$constrainedFlag$sample83$1] = cv$value;
+		}
+		
+		// Should the probability of sample 83 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample83" with its value "cv$value".
+		fixedProbFlag$sample83 = (cv$value && fixedProbFlag$sample83);
+		
+		// Should the probability of sample 138 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample83" with its value "cv$value".
+		fixedProbFlag$sample138 = (cv$value && fixedProbFlag$sample138);
+	}
+
+	// Getter for fixedFlag$sample88.
+	@Override
+	public final boolean get$fixedFlag$sample88() {
+		return fixedFlag$sample88;
+	}
+
+	// Setter for fixedFlag$sample88.
+	@Override
+	public final void set$fixedFlag$sample88(boolean cv$value, boolean allocated$) {
+		// Set flags for all the side effects of fixedFlag$sample88 including if probabilities
+		// need to be updated.
+		fixedFlag$sample88 = cv$value;
+		
+		// Substituted "fixedFlag$sample88" with its value "cv$value".
+		constrainedFlag$sample88 = (cv$value || constrainedFlag$sample88);
+		
+		// Should the probability of sample 88 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample88" with its value "cv$value".
+		fixedProbFlag$sample88 = (cv$value && fixedProbFlag$sample88);
+		
+		// Should the probability of sample 101 be set to fixed. This will only every change
+		// the flag to false.
+		// 
+		// Substituted "fixedFlag$sample88" with its value "cv$value".
+		fixedProbFlag$sample101 = (cv$value && fixedProbFlag$sample101);
+	}
+
+	// Getter for length$yObserved.
+	@Override
+	public final int get$length$yObserved() {
+		return length$yObserved;
+	}
+
+	// Setter for length$yObserved.
+	@Override
+	public final void set$length$yObserved(int cv$value, boolean allocated$) {
+		length$yObserved = cv$value;
+	}
+
+	// Getter for logProbability$$evidence.
+	@Override
+	public final double get$logProbability$$evidence() {
+		return logProbability$$evidence;
+	}
+
+	// Getter for the probability of logProbability$$model.
+	@Override
+	public final double getCurrentLogProbability() {
+		return logProbability$$model;
+	}
+
+	// Getter for logProbability$component.
+	@Override
+	public final double get$logProbability$component() {
+		return logProbability$component;
+	}
+
+	// Getter for logProbability$componentDistribution.
+	@Override
+	public final double get$logProbability$componentDistribution() {
+		return logProbability$componentDistribution;
+	}
+
+	// Getter for logProbability$mu.
+	@Override
+	public final double get$logProbability$mu() {
+		return logProbability$mu;
+	}
+
+	// Getter for logProbability$rawMu.
+	@Override
+	public final double get$logProbability$rawMu() {
+		return logProbability$rawMu;
+	}
+
+	// Getter for logProbability$sigma.
+	@Override
+	public final double get$logProbability$sigma() {
+		return logProbability$sigma;
+	}
+
+	// Getter for logProbability$theta.
+	@Override
+	public final double get$logProbability$theta() {
+		return logProbability$theta;
+	}
+
+	// Getter for logProbability$y.
+	@Override
+	public final double get$logProbability$y() {
+		return logProbability$y;
+	}
+
+	// Getter for mu.
+	@Override
+	public final double[] get$mu() {
+		return mu;
+	}
+
+	// Getter for rawMu.
+	@Override
+	public final double[] get$rawMu() {
+		return rawMu;
+	}
+
+	// Setter for rawMu.
+	@Override
+	public final void set$rawMu(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of rawMu including if probabilities need to
+		// be updated.
+		rawMu = cv$value;
+		
+		// Unset the fixed probability flag for sample 20 as it depends on rawMu.
+		fixedProbFlag$sample20 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on rawMu.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for sigma.
+	@Override
+	public final double[] get$sigma() {
+		return sigma;
+	}
+
+	// Setter for sigma.
+	@Override
+	public final void set$sigma(double[] cv$value, boolean allocated$) {
+		// Set flags for all the side effects of sigma including if probabilities need to
+		// be updated.
+		sigma = cv$value;
+		
+		// Unset the fixed probability flag for sample 83 as it depends on sigma.
+		fixedProbFlag$sample83 = false;
+		
+		// Unset the fixed probability flag for sample 138 as it depends on sigma.
+		fixedProbFlag$sample138 = false;
+	}
+
+	// Getter for theta.
+	@Override
+	public final double get$theta() {
+		return theta;
+	}
+
+	// Setter for theta.
+	@Override
+	public final void set$theta(double cv$value, boolean allocated$) {
+		// Set flags for all the side effects of theta including if probabilities need to
+		// be updated.
+		theta = cv$value;
+		
+		// Unset the fixed probability flag for sample 88 as it depends on theta.
+		fixedProbFlag$sample88 = false;
+		
+		// Unset the fixed probability flag for sample 101 as it depends on theta.
+		fixedProbFlag$sample101 = false;
+	}
+
+	// Getter for y.
+	@Override
+	public final double[] get$y() {
+		return y;
+	}
+
+	// Getter for yObserved.
+	@Override
+	public final double[] get$yObserved() {
+		return yObserved;
+	}
+
+	// Setter for yObserved.
+	@Override
+	public final void set$yObserved(double[] cv$value, boolean allocated$) {
+		yObserved = cv$value;
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample101
+	private final void drawValueSample101(int var96) {
+		component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample20
+	private final void drawValueSample20(int var19) {
+		rawMu[var19] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 41.
+		// 
+		// Guard to check that at most one copy of the code is executed for a given set of
+		// loop iterations.
+		boolean guard$sample20put43 = false;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((var19 == 0)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put43 = true;
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(((var19 == 1) && !guard$sample20put43)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put43 = true;
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put43 = true;
+			mu[0] = rawMu[0];
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+			mu[0] = rawMu[1];
+		
+		// Guards to ensure that mu is only updated when there is a valid path.
+		// 
+		// Looking for a path between Sample 20 and consumer double[] 59.
+		// 
+		// Guard to check that at most one copy of the code is executed for a given set of
+		// loop iterations.
+		boolean guard$sample20put63 = false;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((var19 == 0)) {
+			// The body will execute, so should not be executed again
+			guard$sample20put63 = true;
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if((var19 == 1)) {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20put63) {
+				// The body will execute, so should not be executed again
+				guard$sample20put63 = true;
+				double var57;
+				if((rawMu[0] < rawMu[1]))
+					var57 = rawMu[1];
+				else
+					var57 = rawMu[0];
+				mu[1] = var57;
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+				// The body will execute, so should not be executed again
+				guard$sample20put63 = true;
+				mu[1] = rawMu[1];
+			}
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+			mu[1] = rawMu[0];
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample83
+	private final void drawValueSample83(int var78) {
+		sigma[var78] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+	}
+
+	// Pick a value from the distribution for the unconditioned variable from sample88
+	private final void drawValueSample88() {
+		theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 101 drawn from componentDistribution. Inference was performed using
+	// variable marginalization.
+	private final void inferSample101(int var96) {
+		{
+			// Guards to ensure that component is only updated when there is a valid path.
+			// 
+			// Variable declaration of cv$currentValue moved.
+			// Declaration comment was:
+			// The value currently being tested
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			component[var96] = false;
+			
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Variable declaration of cv$currentValue moved.
+			// Declaration comment was:
+			// The value currently being tested
+			// 
+			// Value of the variable at this index
+			// 
+			// Substituted "cv$valuePos" with its value "0".
+			double cv$accumulatedProbabilities = (((0.0 <= theta) && (theta <= 1.0))?Math.log((1.0 - theta)):Double.NEGATIVE_INFINITY);
+			
+			// Processing conditional point124.
+			// 
+			// Looking for a path between Sample 101 and consumer double 118.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(component[var96]) {
+				{
+					// Variable declaration of componentSigma moved.
+					double componentSigma = sigma[0];
+					
+					// Constructing a random variable input for use later.
+					double var128 = (componentSigma * componentSigma);
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 138 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Substituted "n" with its value "var96".
+					cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				}
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = false;
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1]))
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[0] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124$global[0]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124$global[1]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((rawMu[0] < rawMu[1]) && !guard$sample20if124$global[0])) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124$global[1])) {
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				double traceTempVariable$componentSigma$58_1 = sigma[0];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				// 
+				// Substituted "componentMu" with its value "mu[0]".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 83 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Looking for a path between Sample 83 and consumer double 127.
+				// 
+				// Unrolled loop
+				// 
+				// Processing sample task 83 of consumer random variable null.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((((0.0 <= sigma[0]) && (sigma[0] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[0] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			else {
+				{
+					// Variable declaration of componentSigma moved.
+					double componentSigma = sigma[1];
+					
+					// Constructing a random variable input for use later.
+					double var128 = (componentSigma * componentSigma);
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 138 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Substituted "n" with its value "var96".
+					cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				}
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = false;
+				
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1]))
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[1] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else
+					// Unrolled loop
+					// 
+					// Set the flags to false
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[0] = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124$global[0]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(!guard$sample20if124$global[1]) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((rawMu[0] < rawMu[1]) && !guard$sample20if124$global[1])) {
+					// Unrolled loop
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[1] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124$global[0])) {
+					// The body will execute, so should not be executed again
+					// 
+					// Guard to check that at most one copy of the code is executed for a given random
+					// variable instance.
+					guard$sample20if124$global[0] = true;
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// This value is not used before it is set again, so removing the value declaration.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					// 
+					// Constructing a random variable input for use later.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				double traceTempVariable$componentSigma$63_1 = sigma[1];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				// 
+				// Substituted "componentMu" with its value "mu[1]".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 83 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Processing sample task 83 of consumer random variable null.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((((0.0 <= sigma[1]) && (sigma[1] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[1] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Save the calculated index value into the array of index value probabilities
+			// 
+			// Get a local reference to the scratch space.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			cv$var97$stateProbabilityGlobal[0] = cv$accumulatedProbabilities;
+		}
+		
+		// Guards to ensure that component is only updated when there is a valid path.
+		// 
+		// Variable declaration of cv$currentValue moved.
+		// Declaration comment was:
+		// The value currently being tested
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		component[var96] = true;
+		
+		// An accumulator to allow the value for each distribution to be constructed before
+		// it is added to the index probabilities.
+		// 
+		// Variable declaration of cv$currentValue moved.
+		// Declaration comment was:
+		// The value currently being tested
+		// 
+		// Value of the variable at this index
+		// 
+		// Substituted "cv$valuePos" with its value "1".
+		double cv$accumulatedProbabilities = (((0.0 <= theta) && (theta <= 1.0))?Math.log(theta):Double.NEGATIVE_INFINITY);
+		
+		// Processing conditional point124.
+		// 
+		// Looking for a path between Sample 101 and consumer double 118.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(component[var96]) {
+			{
+				// Variable declaration of componentSigma moved.
+				double componentSigma = sigma[0];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (componentSigma * componentSigma);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			// 
+			// Guard to check that at most one copy of the code is executed for a given random
+			// variable instance.
+			guard$sample20if124$global[0] = false;
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			// 
+			// Guard to check that at most one copy of the code is executed for a given random
+			// variable instance.
+			guard$sample20if124$global[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((rawMu[0] < rawMu[1]))
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			else
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124$global[0]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124$global[1]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20if124$global[0])) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124$global[1])) {
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			double traceTempVariable$componentSigma$58_1 = sigma[0];
+			
+			// Mark that the sample has observed constrained data.
+			constrainedFlag$sample101[var96] = true;
+			
+			// Constructing a random variable input for use later.
+			double var128 = (traceTempVariable$componentSigma$58_1 * traceTempVariable$componentSigma$58_1);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 138 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Substituted "n" with its value "var96".
+			// 
+			// Substituted "componentMu" with its value "mu[0]".
+			cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 83 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Looking for a path between Sample 83 and consumer double 127.
+			// 
+			// Unrolled loop
+			// 
+			// Processing sample task 83 of consumer random variable null.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Constructing a random variable input for use later.
+			cv$accumulatedProbabilities = ((((0.0 <= sigma[0]) && (sigma[0] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[0] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		else {
+			{
+				// Variable declaration of componentSigma moved.
+				double componentSigma = sigma[1];
+				
+				// Constructing a random variable input for use later.
+				double var128 = (componentSigma * componentSigma);
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 138 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Substituted "n" with its value "var96".
+				cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			}
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			// 
+			// Guard to check that at most one copy of the code is executed for a given random
+			// variable instance.
+			guard$sample20if124$global[0] = false;
+			
+			// Unrolled loop
+			// 
+			// Set the flags to false
+			// 
+			// Guard to check that at most one copy of the code is executed for a given random
+			// variable instance.
+			guard$sample20if124$global[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((rawMu[0] < rawMu[1]))
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			else
+				// Unrolled loop
+				// 
+				// Set the flags to false
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124$global[0]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!guard$sample20if124$global[1]) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !guard$sample20if124$global[1])) {
+				// Unrolled loop
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[1] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && !guard$sample20if124$global[0])) {
+				// The body will execute, so should not be executed again
+				// 
+				// Guard to check that at most one copy of the code is executed for a given random
+				// variable instance.
+				guard$sample20if124$global[0] = true;
+				
+				// A check to ensure rounding of floating point values can never result in a negative
+				// value.
+				// 
+				// Recorded the probability of reaching sample task 20 with the current configuration.
+				// 
+				// Set an accumulator to record the consumer distributions not seen. Initially set
+				// to 1 as seen values will be deducted from this value.
+				// 
+				// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+				// Declaration comment was:
+				// This value is not used before it is set again, so removing the value declaration.
+				// 
+				// Processing sample task 20 of consumer random variable null.
+				// 
+				// Set an accumulator to sum the probabilities for each possible configuration of
+				// inputs.
+				// 
+				// Constructing a random variable input for use later.
+				cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+			}
+			double traceTempVariable$componentSigma$63_1 = sigma[1];
+			
+			// Mark that the sample has observed constrained data.
+			constrainedFlag$sample101[var96] = true;
+			
+			// Constructing a random variable input for use later.
+			double var128 = (traceTempVariable$componentSigma$63_1 * traceTempVariable$componentSigma$63_1);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 138 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Substituted "n" with its value "var96".
+			// 
+			// Substituted "componentMu" with its value "mu[1]".
+			cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[var96] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+			
+			// A check to ensure rounding of floating point values can never result in a negative
+			// value.
+			// 
+			// Recorded the probability of reaching sample task 83 with the current configuration.
+			// 
+			// Set an accumulator to record the consumer distributions not seen. Initially set
+			// to 1 as seen values will be deducted from this value.
+			// 
+			// Processing sample task 83 of consumer random variable null.
+			// 
+			// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+			// Declaration comment was:
+			// Set an accumulator to sum the probabilities for each possible configuration of
+			// inputs.
+			// 
+			// Constructing a random variable input for use later.
+			cv$accumulatedProbabilities = ((((0.0 <= sigma[1]) && (sigma[1] <= 1.0E100))?DistributionSampling.logProbabilityGaussian((sigma[1] / 2.0)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+		}
+		
+		// Save the calculated index value into the array of index value probabilities
+		// 
+		// Get a local reference to the scratch space.
+		// 
+		// Record the reached probability density.
+		// 
+		// Initialize a counter to track the reached distributions.
+		cv$var97$stateProbabilityGlobal[1] = cv$accumulatedProbabilities;
+		if(constrainedFlag$sample101[var96]) {
+			// This value is not used before it is set again, so removing the value declaration.
+			// 
+			// The sum of all the probabilities in log space
+			double cv$logSum;
+			
+			// Sum all the values
+			// 
+			// Initialize the max to the first element.
+			// 
+			// Get a local reference to the scratch space.
+			double cv$lseMax = cv$var97$stateProbabilityGlobal[0];
+			
+			// Unrolled loop
+			// 
+			// Get a local reference to the scratch space.
+			double cv$lseElementValue = cv$var97$stateProbabilityGlobal[1];
+			if((cv$lseMax < cv$lseElementValue))
+				cv$lseMax = cv$lseElementValue;
+			
+			// If the maximum value is -infinity return -infinity.
+			if((cv$lseMax == Double.NEGATIVE_INFINITY))
+				cv$logSum = Double.NEGATIVE_INFINITY;
+			
+			// Sum the values in the array.
+			else
+				// Increment the value of the target, moving the value back into log space.
+				// 
+				// The sum of all the probabilities in log space
+				// 
+				// Get a local reference to the scratch space.
+				// 
+				// Get a local reference to the scratch space.
+				// 
+				// Initialize the sum of the array elements
+				cv$logSum = (Math.log((Math.exp((cv$var97$stateProbabilityGlobal[0] - cv$lseMax)) + Math.exp((cv$var97$stateProbabilityGlobal[1] - cv$lseMax)))) + cv$lseMax);
+			
+			// If all the sum is zero, just share the probability evenly.
+			if((cv$logSum == Double.NEGATIVE_INFINITY)) {
+				// Unrolled loop
+				// Get a local reference to the scratch space.
+				cv$var97$stateProbabilityGlobal[0] = 0.5;
+				
+				// Get a local reference to the scratch space.
+				cv$var97$stateProbabilityGlobal[1] = 0.5;
+			} else {
+				// Unrolled loop
+				// Get a local reference to the scratch space.
+				cv$var97$stateProbabilityGlobal[0] = Math.exp((cv$var97$stateProbabilityGlobal[0] - cv$logSum));
+				
+				// Get a local reference to the scratch space.
+				cv$var97$stateProbabilityGlobal[1] = Math.exp((cv$var97$stateProbabilityGlobal[1] - cv$logSum));
+			}
+			
+			// Set array values that are not computed for the input to negative infinity.
+			// 
+			// Get a local reference to the scratch space.
+			for(int cv$indexName = 2; cv$indexName < cv$var97$stateProbabilityGlobal.length; cv$indexName += 1)
+				// Get a local reference to the scratch space.
+				cv$var97$stateProbabilityGlobal[cv$indexName] = Double.NEGATIVE_INFINITY;
+			
+			// Guards to ensure that component is only updated when there is a valid path.
+			// 
+			// Write out the value of the sample to a temporary variable prior to updating the
+			// intermediate variables.
+			// 
+			// cv$numStates's comment
+			// variable marginalization
+			component[var96] = (DistributionSampling.sampleCategorical(RNG$, cv$var97$stateProbabilityGlobal, 2) == 1);
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 20 drawn from Gaussian 7. Inference was performed using Metropolis-Hastings.
+	private final void inferSample20(int var19) {
+		constrainedFlag$sample20[var19] = false;
+		
+		// The original value of the sample
+		double cv$originalValue = rawMu[var19];
+		
+		// This value is not used before it is set again, so removing the value declaration.
+		// 
+		// The probability of the random variable generating the originally sampled value
+		double cv$originalProbability;
+		
+		// Calculate a proposed variance.
+		double cv$var = ((cv$originalValue * cv$originalValue) * 0.010000000000000002);
+		
+		// Ensure the variance is at least 0.01
+		if((cv$var < 0.010000000000000002))
+			cv$var = 0.010000000000000002;
+		
+		// The proposed new value for the sample
+		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+		{
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			// 
+			// Set the current value to the current state of the tree.
+			double cv$accumulatedProbabilities = (DistributionSampling.logProbabilityGaussian((cv$originalValue / 2.0)) - 0.6931471805599453);
+			
+			// Looking for a path between Sample 20 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[0];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Set the current value to the current state of the tree.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 1)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							// 
+							// Set the current value to the current state of the tree.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							// 
+							// Set the current value to the current state of the tree.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[1];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Set the current value to the current state of the tree.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$originalValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Processing conditional point41.
+			// 
+			// Looking for a path between Sample 20 and consumer double 39.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if41 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if41 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$36_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$36_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$52_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$52_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if41)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$37_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$37_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$53_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$53_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Processing conditional point61.
+			// 
+			// Looking for a path between Sample 20 and consumer double 57.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if61 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if61 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$72_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$72_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$88_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$88_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if61)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$73_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$73_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$89_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$89_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(constrainedFlag$sample20[var19]) {
+			{
+				// Guards to ensure that rawMu is only updated when there is a valid path.
+				rawMu[var19] = cv$proposedValue;
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put43 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((var19 == 1) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					mu[0] = rawMu[0];
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+					mu[0] = rawMu[1];
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put63 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put63 = true;
+					double var57;
+					if((rawMu[0] < rawMu[1]))
+						var57 = rawMu[1];
+					else
+						var57 = rawMu[0];
+					mu[1] = var57;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 1)) {
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						double var57;
+						if((rawMu[0] < rawMu[1]))
+							var57 = rawMu[1];
+						else
+							var57 = rawMu[0];
+						mu[1] = var57;
+					}
+					
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						mu[1] = rawMu[1];
+					}
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+					mu[1] = rawMu[0];
+			}
+			
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			double cv$accumulatedProbabilities = (DistributionSampling.logProbabilityGaussian((cv$proposedValue / 2.0)) - 0.6931471805599453);
+			
+			// Looking for a path between Sample 20 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[0];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 1)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((!(rawMu[0] < rawMu[1]) && (var19 == 0))) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample20[0] = true;
+						
+						// Variable declaration of componentSigma moved.
+						double componentSigma = sigma[1];
+						
+						// Constructing a random variable input for use later.
+						double var128 = (componentSigma * componentSigma);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - cv$proposedValue) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Processing conditional point41.
+			// 
+			// Looking for a path between Sample 20 and consumer double 39.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if41 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if41 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$36_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$36_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$52_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$52_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if41)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var115$37_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$37_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var115$53_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[0];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var115$53_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Processing conditional point61.
+			// 
+			// Looking for a path between Sample 20 and consumer double 57.
+			// 
+			// Guard to check that at most one copy of the code is executed for a given set of
+			// loop iterations.
+			boolean guard$sample20if61 = false;
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var19 == 0)) {
+				// The body will execute, so should not be executed again
+				guard$sample20if61 = true;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$72_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$72_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$88_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[0] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$88_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((var19 == 1) && !guard$sample20if61)) {
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					double traceTempVariable$var117$73_2 = rawMu[1];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$73_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				else {
+					double traceTempVariable$var117$89_2 = rawMu[0];
+					for(int n = 0; n < N; n += 1) {
+						if(!component[n]) {
+							// Mark that the sample has observed constrained data.
+							constrainedFlag$sample20[1] = true;
+							
+							// Variable declaration of componentSigma moved.
+							double componentSigma = sigma[1];
+							
+							// Constructing a random variable input for use later.
+							double var128 = (componentSigma * componentSigma);
+							
+							// A check to ensure rounding of floating point values can never result in a negative
+							// value.
+							// 
+							// Recorded the probability of reaching sample task 138 with the current configuration.
+							// 
+							// Set an accumulator to record the consumer distributions not seen. Initially set
+							// to 1 as seen values will be deducted from this value.
+							// 
+							// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+							// Declaration comment was:
+							// Set an accumulator to sum the probabilities for each possible configuration of
+							// inputs.
+							cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - traceTempVariable$var117$89_2) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+						}
+					}
+					
+					// A check to ensure rounding of floating point values can never result in a negative
+					// value.
+					// 
+					// Recorded the probability of reaching sample task 20 with the current configuration.
+					// 
+					// Set an accumulator to record the consumer distributions not seen. Initially set
+					// to 1 as seen values will be deducted from this value.
+					// 
+					// Processing sample task 20 of consumer random variable null.
+					// 
+					// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+					// Declaration comment was:
+					// Set an accumulator to sum the probabilities for each possible configuration of
+					// inputs.
+					cv$accumulatedProbabilities = ((DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) + cv$accumulatedProbabilities) - 0.6931471805599453);
+				}
+			}
+			
+			// The probability ration for the proposed value and the current value.
+			// 
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			double cv$ratio = (cv$accumulatedProbabilities - cv$originalProbability);
+			
+			// Test if the probability of the sample is sufficient to keep the value. This needs
+			// to be less than or equal as otherwise if the proposed value is not possible and
+			// the random value is 0 an impossible value will be accepted.
+			if(((cv$ratio <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN(cv$ratio))) {
+				// If it is not revert the changes.
+				// 
+				// Set the sample value
+				// Guards to ensure that rawMu is only updated when there is a valid path.
+				// 
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				rawMu[var19] = cv$originalValue;
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put43 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((var19 == 1) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					double var39;
+					if((rawMu[0] < rawMu[1]))
+						var39 = rawMu[0];
+					else
+						var39 = rawMu[1];
+					mu[0] = var39;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((((rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put43)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put43 = true;
+					mu[0] = rawMu[0];
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 1)) && !guard$sample20put43))
+					mu[0] = rawMu[1];
+				
+				// Guards to ensure that mu is only updated when there is a valid path.
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Guard to check that at most one copy of the code is executed for a given set of
+				// loop iterations.
+				boolean guard$sample20put63 = false;
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 0)) {
+					// The body will execute, so should not be executed again
+					guard$sample20put63 = true;
+					double var57;
+					if((rawMu[0] < rawMu[1]))
+						var57 = rawMu[1];
+					else
+						var57 = rawMu[0];
+					mu[1] = var57;
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((var19 == 1)) {
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(!guard$sample20put63) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						double var57;
+						if((rawMu[0] < rawMu[1]))
+							var57 = rawMu[1];
+						else
+							var57 = rawMu[0];
+						mu[1] = var57;
+					}
+					
+					// Constraints moved from conditionals in inner loops/scopes/etc.
+					if(((rawMu[0] < rawMu[1]) && !guard$sample20put63)) {
+						// The body will execute, so should not be executed again
+						guard$sample20put63 = true;
+						mu[1] = rawMu[1];
+					}
+				}
+				
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if(((!(rawMu[0] < rawMu[1]) && (var19 == 0)) && !guard$sample20put63))
+					mu[1] = rawMu[0];
+			}
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 83 drawn from TruncatedGaussian 66. Inference was performed using
+	// Metropolis-Hastings.
+	private final void inferSample83(int var78) {
+		constrainedFlag$sample83[var78] = false;
+		
+		// The original value of the sample
+		double cv$originalValue = sigma[var78];
+		
+		// This value is not used before it is set again, so removing the value declaration.
+		// 
+		// The probability of the random variable generating the originally sampled value
+		double cv$originalProbability;
+		
+		// Calculate a proposed variance.
+		double cv$var = ((cv$originalValue * cv$originalValue) * 0.010000000000000002);
+		
+		// Ensure the variance is at least 0.01
+		if((cv$var < 0.010000000000000002))
+			cv$var = 0.010000000000000002;
+		
+		// The proposed new value for the sample
+		double cv$proposedValue = ((Math.sqrt(cv$var) * DistributionSampling.sampleGaussian(RNG$)) + cv$originalValue);
+		{
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			// 
+			// Set the current value to the current state of the tree.
+			double cv$accumulatedProbabilities = (((0.0 <= cv$originalValue) && (cv$originalValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$originalValue / 2.0)):Double.NEGATIVE_INFINITY);
+			
+			// Looking for a path between Sample 83 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 0)) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[0] = true;
+						
+						// Constructing a random variable input for use later.
+						// 
+						// Set the current value to the current state of the tree.
+						double var128 = (cv$originalValue * cv$originalValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[0]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 1)) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[1] = true;
+						
+						// Constructing a random variable input for use later.
+						// 
+						// Set the current value to the current state of the tree.
+						double var128 = (cv$originalValue * cv$originalValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[1]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			cv$originalProbability = cv$accumulatedProbabilities;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(constrainedFlag$sample83[var78]) {
+			// Guards to ensure that sigma is only updated when there is a valid path.
+			sigma[var78] = cv$proposedValue;
+			
+			// An accumulator to allow the value for each distribution to be constructed before
+			// it is added to the index probabilities.
+			// 
+			// Constructing a random variable input for use later.
+			double cv$accumulatedProbabilities = (((0.0 <= cv$proposedValue) && (cv$proposedValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$proposedValue / 2.0)):Double.NEGATIVE_INFINITY);
+			
+			// Looking for a path between Sample 83 and consumer Gaussian 129.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 0)) {
+				for(int n = 0; n < N; n += 1) {
+					if(component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[0] = true;
+						
+						// Constructing a random variable input for use later.
+						double var128 = (cv$proposedValue * cv$proposedValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[0]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[0]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((var78 == 1)) {
+				for(int n = 0; n < N; n += 1) {
+					if(!component[n]) {
+						// Mark that the sample has observed constrained data.
+						constrainedFlag$sample83[1] = true;
+						
+						// Constructing a random variable input for use later.
+						double var128 = (cv$proposedValue * cv$proposedValue);
+						
+						// A check to ensure rounding of floating point values can never result in a negative
+						// value.
+						// 
+						// Recorded the probability of reaching sample task 138 with the current configuration.
+						// 
+						// Set an accumulator to record the consumer distributions not seen. Initially set
+						// to 1 as seen values will be deducted from this value.
+						// 
+						// Variable declaration of cv$accumulatedConsumerProbabilities moved.
+						// Declaration comment was:
+						// Set an accumulator to sum the probabilities for each possible configuration of
+						// inputs.
+						// 
+						// Substituted "componentMu" with its value "mu[1]".
+						cv$accumulatedProbabilities = (((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - mu[1]) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY) + cv$accumulatedProbabilities);
+					}
+				}
+			}
+			
+			// The probability ration for the proposed value and the current value.
+			// 
+			// Initialize a log space accumulator to take the product of all the distribution
+			// probabilities.
+			// 
+			// Record the reached probability density.
+			// 
+			// Initialize a counter to track the reached distributions.
+			double cv$ratio = (cv$accumulatedProbabilities - cv$originalProbability);
+			
+			// Test if the probability of the sample is sufficient to keep the value. This needs
+			// to be less than or equal as otherwise if the proposed value is not possible and
+			// the random value is 0 an impossible value will be accepted.
+			if(((cv$ratio <= Math.log(DistributionSampling.sampleUniform(RNG$))) || Double.isNaN(cv$ratio)))
+				// If it is not revert the changes.
+				// 
+				// Set the sample value
+				// 
+				// Guards to ensure that sigma is only updated when there is a valid path.
+				// 
+				// Write out the value of the sample to a temporary variable prior to updating the
+				// intermediate variables.
+				sigma[var78] = cv$originalValue;
+		}
+	}
+
+	// Method to perform the inference steps to calculate new values for the samples generated
+	// by sample task 88 drawn from Beta 83. Inference was performed using a Beta to Bernoulli/Binomial
+	// conjugate prior.
+	private final void inferSample88() {
+		constrainedFlag$sample88 = false;
+		
+		// Local variable to record the number of true samples.
+		int cv$sum = 0;
+		
+		// Local variable to record the number of samples.
+		int cv$count = 0;
+		
+		// Processing random variable 85.
+		// 
+		// Processing sample task 101 of consumer random variable componentDistribution.
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if((fixedFlag$sample101 || constrainedFlag$sample101[var96])) {
+				// Mark that the sample has observed constrained data.
+				constrainedFlag$sample88 = true;
+				
+				// Include the value sampled by task 101 from random variable componentDistribution.
+				// 
+				// Increment the number of samples.
+				cv$count = (cv$count + 1);
+				
+				// If the sample value was positive increase the count
+				if(component[var96])
+					cv$sum = (cv$sum + 1);
+			}
+		}
+		if(constrainedFlag$sample88)
+			// Write out the new value of the sample.
+			theta = Conjugates.sampleConjugateBetaBinomial(RNG$, 5.0, 5.0, cv$sum, cv$count);
+	}
+
+	// Calculate the probability of the samples represented by sample101 using sampled
+	// values.
+	private final void logProbabilityValue$sample101() {
+		// Determine if we need to calculate the values for sample task 101 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample101) {
+			// Generating probabilities for sample task
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int var96 = 0; var96 < N; var96 += 1) {
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= theta) && (theta <= 1.0))?Math.log((component[var96]?theta:(1.0 - theta))):Double.NEGATIVE_INFINITY));
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(cv$sampleReached) {
+				logProbability$componentDistribution = cv$sampleAccumulator;
+				
+				// Store the random variable instance probability
+				logProbability$var97 = cv$sampleAccumulator;
+			}
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$component = (logProbability$component + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample101 = (fixedFlag$sample101 && fixedFlag$sample88);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			if((0 < N))
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+			if(cv$sampleReached)
+				logProbability$componentDistribution = logProbability$var97;
+			
+			// Update the variable probability
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$component = (logProbability$component + logProbability$var97);
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$var97);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample101)
+				// Variable declaration of cv$accumulator moved.
+				logProbability$$evidence = (logProbability$$evidence + logProbability$var97);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample138 using sampled
+	// values.
+	private final void logProbabilityValue$sample138() {
+		// Determine if we need to calculate the values for sample task 138 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample138) {
+			// Generating probabilities for sample task
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator = 0.0;
+			
+			// A guard to check if the sample value is ever reached.
+			boolean cv$sampleReached = false;
+			for(int n = 0; n < N; n += 1) {
+				double componentMu;
+				if(component[n])
+					componentMu = mu[0];
+				else
+					componentMu = mu[1];
+				double componentSigma;
+				if(component[n])
+					componentSigma = sigma[0];
+				else
+					componentSigma = sigma[1];
+				double var128 = (componentSigma * componentSigma);
+				
+				// Record that the sample was reached.
+				cv$sampleReached = true;
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				cv$sampleAccumulator = (cv$sampleAccumulator + ((0.0 < var128)?(DistributionSampling.logProbabilityGaussian(((y[n] - componentMu) / Math.sqrt(var128))) - (Math.log(var128) * 0.5)):Double.NEGATIVE_INFINITY));
+			}
+			
+			// Only update the sample if it was reached, otherwise the NaN will be
+			// erroneously over written.
+			if(cv$sampleReached)
+				// Store the random variable instance probability
+				// 
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$var130 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$y = (logProbability$y + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample138 = ((fixedFlag$sample20 && fixedFlag$sample83) && fixedFlag$sample101);
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// Update the variable probability
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$y = (logProbability$y + logProbability$var130);
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$var130);
+			
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$evidence = (logProbability$$evidence + logProbability$var130);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample20 using sampled
+	// values.
+	private final void logProbabilityValue$sample20() {
+		// Determine if we need to calculate the values for sample task 20 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample20) {
+			// Generating probabilities for sample task
+			// This value is not used before it is set again, so removing the value declaration.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator;
+			{
+				// Store the value of the function call, so the function call is only made once.
+				// 
+				// The sample value to calculate the probability of generating
+				double cv$weightedProbability = (DistributionSampling.logProbabilityGaussian((rawMu[0] / 2.0)) - 0.6931471805599453);
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				cv$sampleAccumulator = cv$weightedProbability;
+				
+				// Store the sample task probability
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				logProbability$sample20[0] = cv$weightedProbability;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					// Set the guard so the update is only applied once.
+					cv$guard$mu = true;
+					
+					// Update the variable probability
+					// 
+					// Scale the probability relative to the observed distribution space.
+					// 
+					// Add the probability of this distribution configuration to the accumulator.
+					// 
+					// An accumulator for the distributed probability space covered.
+					logProbability$mu = (logProbability$mu + cv$weightedProbability);
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !cv$guard$mu))
+					// Update the variable probability
+					// 
+					// Scale the probability relative to the observed distribution space.
+					// 
+					// Add the probability of this distribution configuration to the accumulator.
+					// 
+					// An accumulator for the distributed probability space covered.
+					logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			}
+			
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$weightedProbability = (DistributionSampling.logProbabilityGaussian((rawMu[1] / 2.0)) - 0.6931471805599453);
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			cv$sampleAccumulator = (cv$sampleAccumulator + cv$weightedProbability);
+			
+			// Store the sample task probability
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			logProbability$sample20[1] = cv$weightedProbability;
+			
+			// Guard to ensure that mu is only updated once for this probability.
+			boolean cv$guard$mu = false;
+			
+			// Add probability to constructed variables that have guards, so need per sample probabilities
+			// from the combined probability
+			// 
+			// Looking for a path between Sample 20 and consumer double[] 41.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Guard to ensure that mu is only updated once for this probability.
+			if(!(rawMu[0] < rawMu[1])) {
+				// Set the guard so the update is only applied once.
+				cv$guard$mu = true;
+				
+				// Update the variable probability
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			}
+			
+			// Looking for a path between Sample 20 and consumer double[] 59.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !cv$guard$mu))
+				// Update the variable probability
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				logProbability$mu = (logProbability$mu + cv$weightedProbability);
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$rawMu = (logProbability$rawMu + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample20 = fixedFlag$sample20;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// This value is not used before it is set again, so removing the value declaration.
+			double cv$rvAccumulator;
+			{
+				double cv$sampleValue = logProbability$sample20[0];
+				cv$rvAccumulator = cv$sampleValue;
+				
+				// Guard to ensure that mu is only updated once for this probability.
+				boolean cv$guard$mu = false;
+				
+				// Add probability to constructed variables that have guards, so need per sample probabilities
+				// from the combined probability
+				// 
+				// Looking for a path between Sample 20 and consumer double[] 41.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((rawMu[0] < rawMu[1])) {
+					// Set the guard so the update is only applied once.
+					cv$guard$mu = true;
+					
+					// Update the variable probability
+					logProbability$mu = (logProbability$mu + cv$sampleValue);
+				}
+				
+				// Looking for a path between Sample 20 and consumer double[] 59.
+				// 
+				// Constraints moved from conditionals in inner loops/scopes/etc.
+				if((!(rawMu[0] < rawMu[1]) && !cv$guard$mu))
+					// Update the variable probability
+					logProbability$mu = (logProbability$mu + cv$sampleValue);
+			}
+			double cv$sampleValue = logProbability$sample20[1];
+			cv$rvAccumulator = (cv$rvAccumulator + cv$sampleValue);
+			
+			// Guard to ensure that mu is only updated once for this probability.
+			boolean cv$guard$mu = false;
+			
+			// Add probability to constructed variables that have guards, so need per sample probabilities
+			// from the combined probability
+			// 
+			// Looking for a path between Sample 20 and consumer double[] 41.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Guard to ensure that mu is only updated once for this probability.
+			if(!(rawMu[0] < rawMu[1])) {
+				// Set the guard so the update is only applied once.
+				cv$guard$mu = true;
+				
+				// Update the variable probability
+				logProbability$mu = (logProbability$mu + cv$sampleValue);
+			}
+			
+			// Looking for a path between Sample 20 and consumer double[] 59.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(((rawMu[0] < rawMu[1]) && !cv$guard$mu))
+				// Update the variable probability
+				logProbability$mu = (logProbability$mu + cv$sampleValue);
+			
+			// Update the variable probability
+			logProbability$rawMu = (logProbability$rawMu + cv$rvAccumulator);
+			
+			// Add probability to model
+			logProbability$$model = (logProbability$$model + cv$rvAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample20)
+				logProbability$$evidence = (logProbability$$evidence + cv$rvAccumulator);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample83 using sampled
+	// values.
+	private final void logProbabilityValue$sample83() {
+		// Determine if we need to calculate the values for sample task 83 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample83) {
+			// Generating probabilities for sample task
+			// This value is not used before it is set again, so removing the value declaration.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			double cv$sampleAccumulator;
+			{
+				// The sample value to calculate the probability of generating
+				double cv$sampleValue = sigma[0];
+				
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				// 
+				// Scale the probability relative to the observed distribution space.
+				// 
+				// Add the probability of this distribution configuration to the accumulator.
+				// 
+				// An accumulator for the distributed probability space covered.
+				// 
+				// Variable declaration of cv$distributionAccumulator moved.
+				// Declaration comment was:
+				// An accumulator for log probabilities.
+				// 
+				// Store the value of the function call, so the function call is only made once.
+				cv$sampleAccumulator = (((0.0 <= cv$sampleValue) && (cv$sampleValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$sampleValue / 2.0)):Double.NEGATIVE_INFINITY);
+			}
+			
+			// The sample value to calculate the probability of generating
+			double cv$sampleValue = sigma[1];
+			
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			cv$sampleAccumulator = (cv$sampleAccumulator + (((0.0 <= cv$sampleValue) && (cv$sampleValue <= 1.0E100))?DistributionSampling.logProbabilityGaussian((cv$sampleValue / 2.0)):Double.NEGATIVE_INFINITY));
+			
+			// Store the random variable instance probability
+			logProbability$var79 = cv$sampleAccumulator;
+			
+			// Update the variable probability
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$sigma = (logProbability$sigma + cv$sampleAccumulator);
+			
+			// Add probability to model
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			logProbability$$model = (logProbability$$model + cv$sampleAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				logProbability$$evidence = (logProbability$$evidence + cv$sampleAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample83 = fixedFlag$sample83;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// Update the variable probability
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$sigma = (logProbability$sigma + logProbability$var79);
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$var79);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample83)
+				// Variable declaration of cv$accumulator moved.
+				logProbability$$evidence = (logProbability$$evidence + logProbability$var79);
+		}
+	}
+
+	// Calculate the probability of the samples represented by sample88 using sampled
+	// values.
+	private final void logProbabilityValue$sample88() {
+		// Determine if we need to calculate the values for sample task 88 or if we should
+		// just use cached values.
+		if(!fixedProbFlag$sample88) {
+			// Generating probabilities for sample task
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			// 
+			// Scale the probability relative to the observed distribution space.
+			// 
+			// Add the probability of this distribution configuration to the accumulator.
+			// 
+			// An accumulator for the distributed probability space covered.
+			// 
+			// Variable declaration of cv$distributionAccumulator moved.
+			// Declaration comment was:
+			// An accumulator for log probabilities.
+			// 
+			// Store the value of the function call, so the function call is only made once.
+			// 
+			// The sample value to calculate the probability of generating
+			double cv$distributionAccumulator = DistributionSampling.logProbabilityBeta(theta, 5.0, 5.0);
+			
+			// Store the sample task probability
+			logProbability$theta = cv$distributionAccumulator;
+			
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			// Declaration comment was:
+			// Accumulator for probabilities of instances of the random variable
+			// 
+			// Add the probability of this instance of the random variable to the probability
+			// of all instances of the random variable.
+			// 
+			// Accumulator for probabilities of instances of the random variable
+			// 
+			// Add the probability of this sample task to the sample task accumulator.
+			// 
+			// Accumulator for sample probabilities for a specific instance of the random variable.
+			logProbability$$model = (logProbability$$model + cv$distributionAccumulator);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				// Variable declaration of cv$accumulator moved.
+				// Declaration comment was:
+				// Accumulator for probabilities of instances of the random variable
+				// 
+				// Add the probability of this instance of the random variable to the probability
+				// of all instances of the random variable.
+				// 
+				// Accumulator for probabilities of instances of the random variable
+				// 
+				// Add the probability of this sample task to the sample task accumulator.
+				// 
+				// Accumulator for sample probabilities for a specific instance of the random variable.
+				logProbability$$evidence = (logProbability$$evidence + cv$distributionAccumulator);
+			
+			// Now the probability is calculated store if it can be cached or if it needs to be
+			// recalculated next time.
+			fixedProbFlag$sample88 = fixedFlag$sample88;
+		} else {
+			// Using cached values.
+			// 
+			// Updating random variable and model probabilities using cached probabilities for
+			// this sample
+			// Add probability to model
+			// 
+			// Variable declaration of cv$accumulator moved.
+			logProbability$$model = (logProbability$$model + logProbability$theta);
+			
+			// If this value is fixed, add it to the probability of this model producing the fixed
+			// values
+			if(fixedFlag$sample88)
+				// Variable declaration of cv$accumulator moved.
+				logProbability$$evidence = (logProbability$$evidence + logProbability$theta);
+		}
+	}
+
+	// Method to allocate space temporary variables used by the inference methods. Allocating
+	// here prevents repeated allocation and deallocation, and makes the code more amenable
+	// to GPU execution.
+	@Override
+	public final void allocateScratch() {
+		// Allocate scratch space.
+		// Constructor for cv$var97$stateProbabilityGlobal
+		// 
+		// Allocation of cv$var97$stateProbabilityGlobal for single threaded execution
+		cv$var97$stateProbabilityGlobal = new double[2];
+		
+		// Allocation of guard$sample20if124$global for single threaded execution
+		guard$sample20if124$global = new boolean[2];
+	}
+
+	// Method to allocate space for model inputs and outputs.
+	@Override
+	public final void allocator() {
+		// If rawMu has not been set already allocate space.
+		if(!fixedFlag$sample20)
+			// Constructor for rawMu
+			rawMu = new double[2];
+		
+		// Constructor for mu
+		mu = new double[2];
+		
+		// If sigma has not been set already allocate space.
+		if(!fixedFlag$sample83)
+			// Constructor for sigma
+			sigma = new double[2];
+		
+		// If component has not been set already allocate space.
+		if(!fixedFlag$sample101)
+			// Constructor for component
+			component = new boolean[length$yObserved];
+		
+		// Constructor for y
+		y = new double[length$yObserved];
+		
+		// Constructor for constrainedFlag$sample101
+		constrainedFlag$sample101 = new boolean[length$yObserved];
+		
+		// Constructor for constrainedFlag$sample20
+		constrainedFlag$sample20 = new boolean[2];
+		
+		// Constructor for constrainedFlag$sample83
+		constrainedFlag$sample83 = new boolean[2];
+		
+		// Constructor for logProbability$sample20
+		logProbability$sample20 = new double[2];
+		
+		// Allocate scratch space
+		allocateScratch();
+	}
+
+	// Method to execute the model code conventionally.
+	@Override
+	public final void forwardGeneration() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+		for(int n = 0; n < N; n += 1) {
+			double componentMu;
+			if(component[n])
+				componentMu = mu[0];
+			else
+				componentMu = mu[1];
+			double componentSigma;
+			if(component[n])
+				componentSigma = sigma[0];
+			else
+				componentSigma = sigma[1];
+			y[n] = ((componentSigma * DistributionSampling.sampleGaussian(RNG$)) + componentMu);
+		}
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are calculated
+	// and stored.
+	@Override
+	public final void forwardGenerationDistributionsNoOutputsPrime() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	// Method to execute the model code conventionally with priming of fixed intermediate
+	// variables.
+	@Override
+	public final void forwardGenerationPrime() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+		for(int n = 0; n < N; n += 1) {
+			double componentMu;
+			if(component[n])
+				componentMu = mu[0];
+			else
+				componentMu = mu[1];
+			double componentSigma;
+			if(component[n])
+				componentSigma = sigma[0];
+			else
+				componentSigma = sigma[1];
+			y[n] = ((componentSigma * DistributionSampling.sampleGaussian(RNG$)) + componentMu);
+		}
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Distributions are collapsed to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputs() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var39;
+			if((rawMu[0] < rawMu[1]))
+				var39 = rawMu[0];
+			else
+				var39 = rawMu[1];
+			mu[0] = var39;
+			
+			// This value is not used before it is set again, so removing the value declaration.
+			double var57;
+			if((rawMu[0] < rawMu[1]))
+				var57 = rawMu[1];
+			else
+				var57 = rawMu[0];
+			mu[1] = var57;
+		}
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	// Method to execute the model code conventionally, excluding the elements that generate
+	// observed values. Fixed intermediate variables are primed. Distributions are collapsed
+	// to single values.
+	@Override
+	public final void forwardGenerationValuesNoOutputsPrime() {
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample20) {
+			rawMu[0] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+			rawMu[1] = (DistributionSampling.sampleGaussian(RNG$) * 2.0);
+		}
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		// 
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample83) {
+			sigma[0] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+			sigma[1] = (DistributionSampling.sampleTruncatedGaussian(RNG$, 0.0, 0.5, 5.0E99, 1.0) * 2.0);
+		}
+		if(!fixedFlag$sample88)
+			theta = DistributionSampling.sampleBeta(RNG$, 5.0, 5.0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!fixedFlag$sample101) {
+			for(int var96 = 0; var96 < N; var96 += 1)
+				component[var96] = DistributionSampling.sampleBernoulli(RNG$, theta);
+		}
+	}
+
+	// Method to execute one round of Gibbs sampling.
+	@Override
+	public final void gibbsRound() {
+		// Infer the samples in chronological order.
+		if(system$gibbsForward) {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample20) {
+				inferSample20(0);
+				inferSample20(1);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample83) {
+				inferSample83(0);
+				inferSample83(1);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample101) {
+				for(int var96 = 0; var96 < N; var96 += 1)
+					inferSample101(var96);
+			}
+		}
+		// Infer the samples in reverse chronological order.
+		else {
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample101) {
+				for(int var96 = (N - 1); var96 >= 0; var96 -= 1)
+					inferSample101(var96);
+			}
+			if(!fixedFlag$sample88)
+				inferSample88();
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample83) {
+				inferSample83(1);
+				inferSample83(0);
+			}
+			
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			// 
+			// Constraints moved from conditionals in inner loops/scopes/etc.
+			if(!fixedFlag$sample20) {
+				inferSample20(1);
+				inferSample20(0);
+			}
+		}
+		
+		// Reverse the direction of execution for the next iteration
+		system$gibbsForward = !system$gibbsForward;
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!constrainedFlag$sample20[0])
+			drawValueSample20(0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!constrainedFlag$sample20[1])
+			drawValueSample20(1);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!constrainedFlag$sample83[0])
+			drawValueSample83(0);
+		
+		// Constraints moved from conditionals in inner loops/scopes/etc.
+		if(!constrainedFlag$sample83[1])
+			drawValueSample83(1);
+		if(!constrainedFlag$sample88)
+			drawValueSample88();
+		for(int var96 = 0; var96 < N; var96 += 1) {
+			if(!constrainedFlag$sample101[var96])
+				drawValueSample101(var96);
+		}
+	}
+
+	// A method to initialize all the probabilities in the model to 0/Log(1) ready for
+	// the current probabilities to be calculated by calculating the probability of each
+	// sample task, and its effect on the rest of the model.
+	private final void initializeLogProbabilityFields() {
+		// Set the probabilities of the random variable, and the model as a whole to ready
+		// them to be reconstructed by the probability calls for each sample. Sample probabilities
+		// are only reset for samples that are not fixed at a value that has already been
+		// calculated.
+		logProbability$$model = 0.0;
+		logProbability$$evidence = 0.0;
+		logProbability$rawMu = 0.0;
+		logProbability$mu = 0.0;
+		if(!fixedProbFlag$sample20) {
+			// Unrolled loop
+			logProbability$sample20[0] = Double.NaN;
+			logProbability$sample20[1] = Double.NaN;
+		}
+		logProbability$sigma = 0.0;
+		if(!fixedProbFlag$sample83)
+			logProbability$var79 = Double.NaN;
+		if(!fixedProbFlag$sample88)
+			logProbability$theta = Double.NaN;
+		logProbability$componentDistribution = Double.NaN;
+		logProbability$component = 0.0;
+		if(!fixedProbFlag$sample101)
+			logProbability$var97 = Double.NaN;
+		logProbability$y = 0.0;
+		if(!fixedProbFlag$sample138)
+			logProbability$var130 = Double.NaN;
+	}
+
+	// Method for initializing the model into a valid state before commencing inference
+	// etc.
+	@Override
+	public final void initializeModel() {
+		N = length$yObserved;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample101$1 = 0; index$constrainedFlag$sample101$1 < constrainedFlag$sample101.length; index$constrainedFlag$sample101$1 += 1)
+			constrainedFlag$sample101[index$constrainedFlag$sample101$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample20$1 = 0; index$constrainedFlag$sample20$1 < constrainedFlag$sample20.length; index$constrainedFlag$sample20$1 += 1)
+			constrainedFlag$sample20[index$constrainedFlag$sample20$1] = true;
+		
+		// Set all the values in the array
+		for(int index$constrainedFlag$sample83$1 = 0; index$constrainedFlag$sample83$1 < constrainedFlag$sample83.length; index$constrainedFlag$sample83$1 += 1)
+			constrainedFlag$sample83[index$constrainedFlag$sample83$1] = true;
+	}
+
+	// Construct the evidence probabilities.
+	@Override
+	public final void logEvidenceProbabilities() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Call each method in turn to generate the new probability values.
+		if(fixedFlag$sample20)
+			logProbabilityValue$sample20();
+		if(fixedFlag$sample83)
+			logProbabilityValue$sample83();
+		if(fixedFlag$sample88)
+			logProbabilityValue$sample88();
+		if(fixedFlag$sample101)
+			logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model uses distributions
+	// when possible.
+	@Override
+	public final void logModelProbabilitiesDist() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to calculate the probabilities of all the samples in the model including
+	// those generating fixed data. In the process probabilities for all the random variables
+	// and for the model as a whole will be calculated. This model only uses values.
+	@Override
+	public final void logModelProbabilitiesVal() {
+		// Reset all the non-fixed probabilities ready to calculate the new values.
+		initializeLogProbabilityFields();
+		
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using distributions where
+		// appropriate.
+		// 
+		// Calculate the probabilities for each sample task in the model, generating probabilities
+		// for the random variables and whole model in the process using values only.
+		logProbabilityValue$sample20();
+		logProbabilityValue$sample83();
+		logProbabilityValue$sample88();
+		logProbabilityValue$sample101();
+		logProbabilityValue$sample138();
+	}
+
+	// Method to propagate observed values back into the model.
+	@Override
+	public final void propagateObservedValues() {
+		// Propagating values back from observations into the models intermediate variables.
+		// 
+		// Deep copy between arrays
+		int cv$length1 = y.length;
+		for(int cv$index1 = 0; cv$index1 < cv$length1; cv$index1 += 1)
+			y[cv$index1] = yObserved[cv$index1];
+	}
+
+	// A method to set array values that depend on the output of a sample task, but are
+	// not directly set by the sample task. This method is called to propagate set values
+	// through the model. Any non-fixed sample values may be sampled to random variables
+	// as part of this process.
+	@Override
+	public final void setIntermediates() {
+		double var39;
+		if((rawMu[0] < rawMu[1]))
+			var39 = rawMu[0];
+		else
+			var39 = rawMu[1];
+		mu[0] = var39;
+		double var57;
+		if((rawMu[0] < rawMu[1]))
+			var57 = rawMu[1];
+		else
+			var57 = rawMu[0];
+		mu[1] = var57;
+	}
+
+	@Override
+	public String modelCode() {
+		return "/*\n"
+		     + " * Sandwood\n"
+		     + " *\n"
+		     + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+		     + " * \n"
+		     + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+		     + " */\n"
+		     + "\n"
+		     + "package org.sandwood.compiler.tests.parser;\n"
+		     + "\n"
+		     + "public model LowDimMix(double[] yObserved) {\n"
+		     + "    int N = yObserved.length;\n"
+		     + "\n"
+		     + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+		     + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+		     + "    // the constant normalisation factor for the ordered constraint.\n"
+		     + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+		     + "    double[] mu = new double[2];\n"
+		     + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+		     + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+		     + "\n"
+		     + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+		     + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+		     + "\n"
+		     + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+		     + "    double theta = beta(5.0, 5.0).sample();\n"
+		     + "\n"
+		     + "    // Stan likelihood:\n"
+		     + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+		     + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+		     + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+		     + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+		     + "    boolean[] component = componentDistribution.sample(N);\n"
+		     + "    double[] y = new double[N];\n"
+		     + "\n"
+		     + "    for(int n = 0; n < N; n++) {\n"
+		     + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+		     + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+		     + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+		     + "    }\n"
+		     + "\n"
+		     + "    y.observe(yObserved);\n"
+		     + "}\n"
+		     + "";
+	}
+}

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix_model.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix_model.java
@@ -1,0 +1,632 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.runtime.model.Model;
+import org.sandwood.runtime.model.ExecutionTarget;
+import org.sandwood.runtime.model.variables.*;
+import org.sandwood.runtime.internal.model.variables.*;
+import org.sandwood.runtime.internal.model.variables.probability.ProbabilityType;
+import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
+
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+  * Class representing the Sandwood model LowDimMix This is the class that
+  * all user interactions with the model should occur through.
+  */
+public final class LowDimMix extends Model {
+
+    private LowDimMix$CoreInterface system$c = new LowDimMix$SingleThreadCPU(ExecutionTarget.singleThread);
+
+    private final ComputedBooleanArrayInternal $component = new ComputedBooleanArrayInternal(this, "component", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public boolean[] getValue() { return system$c.get$component(); }
+
+        @Override
+        protected void setValueInternal(boolean[] value) {
+            system$c.set$component(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$component(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample101(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample101())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing component of type boolean[] from the Sandwood model 
+     */
+    public final ComputedBooleanArray component = $component;
+
+    private final ComputedDoubleArrayInternal $mu = new ComputedDoubleArrayInternal(this, "mu", false, false, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$mu(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {}
+
+        @Override
+        protected void testSettable() {
+            throw new SandwoodException("Set is not available for variable mu because its value depends on variable \"rawMu\".");
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$mu(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample20(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample20())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing mu of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray mu = $mu;
+
+    private final ComputedDoubleArrayInternal $rawMu = new ComputedDoubleArrayInternal(this, "rawMu", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$rawMu(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {
+            system$c.set$rawMu(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$rawMu(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample20(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample20())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing rawMu of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray rawMu = $rawMu;
+
+    private final ComputedDoubleArrayInternal $sigma = new ComputedDoubleArrayInternal(this, "sigma", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$sigma(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {
+            system$c.set$sigma(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$sigma(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample83(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample83())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing sigma of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray sigma = $sigma;
+
+    private final ComputedDoubleInternal $theta = new ComputedDoubleInternal(this, "theta", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double getValue() { return system$c.get$theta(); }
+
+        @Override
+        protected void setValueInternal(double value) {
+            system$c.set$theta(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$theta(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample88(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample88())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing theta of type double from the Sandwood model 
+     */
+    public final ComputedDouble theta = $theta;
+
+    private final ComputedDoubleArrayInternal $y = new ComputedDoubleArrayInternal(this, "y", false, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$y(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {}
+
+        @Override
+        protected void testSettable() {
+            throw new SandwoodException("Set is not available for variable y because it is fixed by observing a variable.");
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$y(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
+        }
+
+        @Override
+        public Immutability isFixed() {
+            return Immutability.OBSERVED;
+        }
+    };
+
+    /**
+     * Computed variable representing y of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray y = $y;
+
+	private Map<String, ComputedVariableInternal> $computedVariables = new HashMap<>();
+
+    private Map<String, ObservedVariableInternal> $modelInputs = new HashMap<>();
+
+    private final ObservedDoubleArrayShapeableInternal $yObserved = new ObservedDoubleArrayShapeableInternal(this, "yObserved") {
+        @Override
+        public double[] getValue() {
+            synchronized(model) {
+                return system$c.get$yObserved();
+            }
+        }
+
+        @Override
+        public void setValueInternal(double[] value) {
+            system$c.set$yObserved(value, allocated);
+            system$c.set$length$yObserved(value.length, allocated);
+        }
+
+        @Override
+        public void setShapeInternal(int shape) {
+            system$c.set$length$yObserved(shape, allocated);
+        }
+
+        @Override
+        public int getShape() {
+            return system$c.get$length$yObserved();
+        }
+    };
+
+    /**
+     * Observed variable representing yObserved of type double[] from the Sandwood model 
+     */
+    public final ObservedDoubleArrayShapeable yObserved = $yObserved;
+
+    private Map<String, ObservedVariableInternal> $regularObservedValues = new HashMap<>();
+    private Map<String, ObservedVariableShapeableInternal<?>> $shapedObservedValues = new HashMap<>();
+    private final RandomVariableInternal $componentDistribution = new RandomVariableInternal(this, "componentDistribution", ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double getCurrentLogProbability() {
+            return system$c.get$logProbability$componentDistribution();
+        }
+    };
+
+    /**
+     * Random variable representing componentDistribution from the Sandwood model 
+     */
+    public final RandomVariable componentDistribution = $componentDistribution;
+
+    private HasProbabilityInternal[] $probabilityVariables = {$component, $mu, $rawMu, $sigma, $theta, $y, $componentDistribution};
+
+    //Constructors
+    /**
+     * A constructor for a model where no variable values are set.
+     */
+    public LowDimMix() {
+        super();
+        //ComputedVariable
+        $computedVariables.put("component", $component);
+        $computedVariables.put("mu", $mu);
+        $computedVariables.put("rawMu", $rawMu);
+        $computedVariables.put("sigma", $sigma);
+        $computedVariables.put("theta", $theta);
+        $computedVariables.put("y", $y);
+
+        //Observed array fields
+        $shapedObservedValues.put("yObserved", $yObserved);
+        init(system$c, $modelInputs, $regularObservedValues, $shapedObservedValues, $computedVariables, $probabilityVariables);
+    }
+    /**
+      * A constructor to set all the required values in the model to infer values. These
+      * will be values in an untrained model so this will only generate values from the
+      * default distributions described in the model.
+      * @param yObservedShape An integer array describing the shape of variable yObserved to use in the model when generating results.
+      */
+
+    public LowDimMix(int yObservedShape) {
+        this();
+        this.$yObserved.setShape(yObservedShape);
+    }
+    /**
+      * A constructor to set all the required values in the model to infer the model
+      * parameters, or to generate probabilities for the model.
+      * @param yObserved The value to set yObserved to.
+      */
+
+    public LowDimMix(double[] yObserved) {
+        this();
+        this.yObserved.setValue(yObserved);
+    }
+    
+    @Override
+    protected LowDimMix$CoreInterface setExecutionTargetInternal(ExecutionTarget target) {
+        LowDimMix$CoreInterface newCore;
+        switch(target.executionType) {
+            case SingleThreadCPU:
+                newCore = new LowDimMix$SingleThreadCPU(target);
+                break;
+            case MultiThreadCPU:
+                newCore = new LowDimMix$MultiThreadCPU(target);
+                break;
+            default:
+                throw new SandwoodException("Unsupported execution type: " + target);
+        }
+        transferData(system$c, newCore);
+        system$c = newCore;
+        return newCore;
+    }
+
+    private void transferData(LowDimMix$CoreInterface oldCore, LowDimMix$CoreInterface newCore) {
+
+        //Observed arrays
+        if(yObserved.isSet()) {
+            newCore.set$yObserved(oldCore.get$yObserved(), false);
+            newCore.set$length$yObserved(oldCore.get$length$yObserved(), false);
+        }
+        else if(yObserved.shapeSet())
+            newCore.set$length$yObserved(oldCore.get$length$yObserved(), false);
+
+        //ComputedVariables
+        if($component.isSet())
+            newCore.set$component(oldCore.get$component(), false);
+        if($rawMu.isSet())
+            newCore.set$rawMu(oldCore.get$rawMu(), false);
+        if($sigma.isSet())
+            newCore.set$sigma(oldCore.get$sigma(), false);
+        if($theta.isSet())
+            newCore.set$theta(oldCore.get$theta(), false);
+
+        //Set fixed flags
+        newCore.set$fixedFlag$sample101(oldCore.get$fixedFlag$sample101(), false);
+        newCore.set$fixedFlag$sample20(oldCore.get$fixedFlag$sample20(), false);
+        newCore.set$fixedFlag$sample83(oldCore.get$fixedFlag$sample83(), false);
+        newCore.set$fixedFlag$sample88(oldCore.get$fixedFlag$sample88(), false);
+    }
+
+    /**
+     * A class to hold all the values required to perform a value inference on the model.
+     */
+    public static class InferValueInputs {
+        /** Field holding the shape of model input yObserved */
+        public final int yObservedShape;
+
+        /**
+          * A constructor taking all the values required to set up the model to infer variables.
+          * @param yObservedShape An integer array describing the shape of variable yObserved to use in the model when generating results.
+          */
+        public InferValueInputs(int yObservedShape) {
+            this.yObservedShape = yObservedShape;
+        }
+    }
+
+    /**
+     * A class to hold all the inputs for the model. It can be used to parameterize inference of the model probabilities
+     * and probability calculations.
+     */
+    public static class AllInputs {
+        /** Field holding the value of model input yObserved */
+        public final double[] yObserved;
+
+        /**
+          * A constructor to take all the required values by the model to infer the model
+          * parameters, or to generate probabilities for the model.
+          * @param yObserved The value to set yObserved to.
+          */
+        public AllInputs(double[] yObserved) {
+            this.yObserved = yObserved;
+        }
+    }
+
+    /**
+     * A class to hold all the outputs from the model after an infer values step.
+     */
+    public static class InferredValueOutputs {
+        /** Field holding the value of component after a convention execution step.*/
+        public final boolean[] component;
+        /** Field holding the value of mu after a convention execution step.*/
+        public final double[] mu;
+        /** Field holding the value of rawMu after a convention execution step.*/
+        public final double[] rawMu;
+        /** Field holding the value of sigma after a convention execution step.*/
+        public final double[] sigma;
+        /** Field holding the value of theta after a convention execution step.*/
+        public final double theta;
+        /** Field holding the value of y after a convention execution step.*/
+        public final double[] y;
+
+        InferredValueOutputs(LowDimMix system$model) {
+            this.component = system$model.component.getSamples()[0];
+            this.mu = system$model.mu.getSamples()[0];
+            this.rawMu = system$model.rawMu.getSamples()[0];
+            this.sigma = system$model.sigma.getSamples()[0];
+            this.theta = system$model.theta.getSamples()[0];
+            this.y = system$model.y.getSamples()[0];
+        }
+    }
+
+    /**
+     * A class to hold all the probabilities from the model after a generate probabilities step.
+     */
+    public static class LogProbabilities {
+        private final double $logModelProbability;
+        /** Field holding the log probability of random variable componentDistribution */
+        public final double componentDistribution;
+        /** Field holding the log probability of computed variable component */
+        public final double component;
+        /** Field holding the log probability of computed variable mu */
+        public final double mu;
+        /** Field holding the log probability of computed variable rawMu */
+        public final double rawMu;
+        /** Field holding the log probability of computed variable sigma */
+        public final double sigma;
+        /** Field holding the log probability of computed variable theta */
+        public final double theta;
+        /** Field holding the log probability of computed variable y */
+        public final double y;
+
+        LogProbabilities(LowDimMix system$model) {
+            this.$logModelProbability = system$model.getLogProbability();
+            this.componentDistribution = system$model.componentDistribution.getLogProbability();
+            this.component = system$model.component.getLogProbability();
+            this.mu = system$model.mu.getLogProbability();
+            this.rawMu = system$model.rawMu.getLogProbability();
+            this.sigma = system$model.sigma.getLogProbability();
+            this.theta = system$model.theta.getLogProbability();
+            this.y = system$model.y.getLogProbability();
+        }
+
+        /** Method to return log probability of the whole model 
+         *  @return The log probability of the whole model. */
+        public double getModelProbability() { return $logModelProbability; }
+    }
+
+    /**
+     * A class to hold all the probabilities from the model after a generate probabilities step.
+     */
+    public static class Probabilities {
+        private final double $modelProbability;
+        /** Field holding the probability of random variable componentDistribution */
+        public final double componentDistribution;
+        /** Field holding the probability of computed variable component */
+        public final double component;
+        /** Field holding the probability of computed variable mu */
+        public final double mu;
+        /** Field holding the probability of computed variable rawMu */
+        public final double rawMu;
+        /** Field holding the probability of computed variable sigma */
+        public final double sigma;
+        /** Field holding the probability of computed variable theta */
+        public final double theta;
+        /** Field holding the probability of computed variable y */
+        public final double y;
+
+        Probabilities(LowDimMix system$model) {
+            this.$modelProbability = system$model.getProbability();
+            this.componentDistribution = system$model.componentDistribution.getProbability();
+            this.component = system$model.component.getProbability();
+            this.mu = system$model.mu.getProbability();
+            this.rawMu = system$model.rawMu.getProbability();
+            this.sigma = system$model.sigma.getProbability();
+            this.theta = system$model.theta.getProbability();
+            this.y = system$model.y.getProbability();
+        }
+
+        /** Method to return probability of the whole model 
+         *  @return The probability of the whole model. */
+        public double getModelProbability() { return $modelProbability; }
+    }
+
+    /**
+     * A class to hold all the outputs from the model after an infer model call.
+     */
+    public static class InferredModelOutputs {
+        /** Field holding the MAP or Sample value of component after an infer model call. */
+        public final boolean[][] component;
+        /** Field holding the MAP or Sample value of mu after an infer model call. */
+        public final double[][] mu;
+        /** Field holding the MAP or Sample value of rawMu after an infer model call. */
+        public final double[][] rawMu;
+        /** Field holding the MAP or Sample value of sigma after an infer model call. */
+        public final double[][] sigma;
+        /** Field holding the MAP or Sample value of theta after an infer model call. */
+        public final double[] theta;
+
+        InferredModelOutputs(LowDimMix system$model) {
+            this.component = system$model.getInferredValue(system$model.$component);
+            this.mu = system$model.getInferredValue(system$model.$mu);
+            this.rawMu = system$model.getInferredValue(system$model.$rawMu);
+            this.sigma = system$model.getInferredValue(system$model.$sigma);
+            this.theta = system$model.getInferredValue(system$model.$theta);
+        }
+    }
+
+    /**
+     * Perform a single pass generating values from the model.
+     * @param inputs An object containing the parameters required to run inference on the model.
+     * @return An object containing the values computed by the inference step.
+     */
+    public InferredValueOutputs execute(InferValueInputs inputs) {
+        this.$yObserved.setShape(inputs.yObservedShape);
+        execute();
+        return new InferredValueOutputs(this);
+    }
+
+    /**
+     * Infer the values of the different elements of the model.
+     * @param iterations The number of iterations to perform when inferring the values.
+     * @param inputs An object containing the parameters required to generate the model parameters.
+     * @return An object containing the computed values for the model.
+     */
+    public InferredModelOutputs inferValues(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferValues(iterations);
+        return new InferredModelOutputs(this);
+    }
+
+    /**
+     * Generate the probabilities of the different elements of the model.
+     * @param iterations How many iterations should be used to generate these values?
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(iterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Calculate the probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(double variance, int initialIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Calculate the probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param maxIterations The maximum number of iterations a that can be used to calculate the probabilities. If the model has not
+     * converged by this point the calculation will terminate anyway, and the result generated so far will be returned.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(double variance, int initialIterations, int maxIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations, maxIterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Generate the log probabilities of the different elements of the model.
+     * @param iterations How many iterations should be used to generate these values?
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(iterations);
+        return new LogProbabilities(this);
+    }
+
+    /**
+     * Calculate the log probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(double variance, int initialIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations);
+        return new LogProbabilities(this);
+    }
+
+    /**
+     * Calculate the log probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param maxIterations The maximum number of iterations a that can be used to calculate the probabilities. If the model has not
+     * converged by this point the calculation will terminate anyway, and the result generated so far will be returned.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(double variance, int initialIterations, int maxIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations, maxIterations);
+        return new LogProbabilities(this);
+    }
+}
+//END OF CODE

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix_modelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix_modelNoComments.java
@@ -1,0 +1,632 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.runtime.model.Model;
+import org.sandwood.runtime.model.ExecutionTarget;
+import org.sandwood.runtime.model.variables.*;
+import org.sandwood.runtime.internal.model.variables.*;
+import org.sandwood.runtime.internal.model.variables.probability.ProbabilityType;
+import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
+
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+  * Class representing the Sandwood model LowDimMix This is the class that
+  * all user interactions with the model should occur through.
+  */
+public final class LowDimMix extends Model {
+
+    private LowDimMix$CoreInterface system$c = new LowDimMix$SingleThreadCPU(ExecutionTarget.singleThread);
+
+    private final ComputedBooleanArrayInternal $component = new ComputedBooleanArrayInternal(this, "component", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public boolean[] getValue() { return system$c.get$component(); }
+
+        @Override
+        protected void setValueInternal(boolean[] value) {
+            system$c.set$component(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$component(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample101(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample101())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing component of type boolean[] from the Sandwood model 
+     */
+    public final ComputedBooleanArray component = $component;
+
+    private final ComputedDoubleArrayInternal $mu = new ComputedDoubleArrayInternal(this, "mu", false, false, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$mu(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {}
+
+        @Override
+        protected void testSettable() {
+            throw new SandwoodException("Set is not available for variable mu because its value depends on variable \"rawMu\".");
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$mu(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample20(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample20())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing mu of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray mu = $mu;
+
+    private final ComputedDoubleArrayInternal $rawMu = new ComputedDoubleArrayInternal(this, "rawMu", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$rawMu(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {
+            system$c.set$rawMu(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$rawMu(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample20(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample20())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing rawMu of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray rawMu = $rawMu;
+
+    private final ComputedDoubleArrayInternal $sigma = new ComputedDoubleArrayInternal(this, "sigma", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$sigma(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {
+            system$c.set$sigma(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$sigma(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample83(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample83())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing sigma of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray sigma = $sigma;
+
+    private final ComputedDoubleInternal $theta = new ComputedDoubleInternal(this, "theta", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double getValue() { return system$c.get$theta(); }
+
+        @Override
+        protected void setValueInternal(double value) {
+            system$c.set$theta(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$theta(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample88(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample88())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing theta of type double from the Sandwood model 
+     */
+    public final ComputedDouble theta = $theta;
+
+    private final ComputedDoubleArrayInternal $y = new ComputedDoubleArrayInternal(this, "y", false, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$y(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {}
+
+        @Override
+        protected void testSettable() {
+            throw new SandwoodException("Set is not available for variable y because it is fixed by observing a variable.");
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$y(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
+        }
+
+        @Override
+        public Immutability isFixed() {
+            return Immutability.OBSERVED;
+        }
+    };
+
+    /**
+     * Computed variable representing y of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray y = $y;
+
+	private Map<String, ComputedVariableInternal> $computedVariables = new HashMap<>();
+
+    private Map<String, ObservedVariableInternal> $modelInputs = new HashMap<>();
+
+    private final ObservedDoubleArrayShapeableInternal $yObserved = new ObservedDoubleArrayShapeableInternal(this, "yObserved") {
+        @Override
+        public double[] getValue() {
+            synchronized(model) {
+                return system$c.get$yObserved();
+            }
+        }
+
+        @Override
+        public void setValueInternal(double[] value) {
+            system$c.set$yObserved(value, allocated);
+            system$c.set$length$yObserved(value.length, allocated);
+        }
+
+        @Override
+        public void setShapeInternal(int shape) {
+            system$c.set$length$yObserved(shape, allocated);
+        }
+
+        @Override
+        public int getShape() {
+            return system$c.get$length$yObserved();
+        }
+    };
+
+    /**
+     * Observed variable representing yObserved of type double[] from the Sandwood model 
+     */
+    public final ObservedDoubleArrayShapeable yObserved = $yObserved;
+
+    private Map<String, ObservedVariableInternal> $regularObservedValues = new HashMap<>();
+    private Map<String, ObservedVariableShapeableInternal<?>> $shapedObservedValues = new HashMap<>();
+    private final RandomVariableInternal $componentDistribution = new RandomVariableInternal(this, "componentDistribution", ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double getCurrentLogProbability() {
+            return system$c.get$logProbability$componentDistribution();
+        }
+    };
+
+    /**
+     * Random variable representing componentDistribution from the Sandwood model 
+     */
+    public final RandomVariable componentDistribution = $componentDistribution;
+
+    private HasProbabilityInternal[] $probabilityVariables = {$component, $mu, $rawMu, $sigma, $theta, $y, $componentDistribution};
+
+    //Constructors
+    /**
+     * A constructor for a model where no variable values are set.
+     */
+    public LowDimMix() {
+        super();
+        //ComputedVariable
+        $computedVariables.put("component", $component);
+        $computedVariables.put("mu", $mu);
+        $computedVariables.put("rawMu", $rawMu);
+        $computedVariables.put("sigma", $sigma);
+        $computedVariables.put("theta", $theta);
+        $computedVariables.put("y", $y);
+
+        //Observed array fields
+        $shapedObservedValues.put("yObserved", $yObserved);
+        init(system$c, $modelInputs, $regularObservedValues, $shapedObservedValues, $computedVariables, $probabilityVariables);
+    }
+    /**
+      * A constructor to set all the required values in the model to infer values. These
+      * will be values in an untrained model so this will only generate values from the
+      * default distributions described in the model.
+      * @param yObservedShape An integer array describing the shape of variable yObserved to use in the model when generating results.
+      */
+
+    public LowDimMix(int yObservedShape) {
+        this();
+        this.$yObserved.setShape(yObservedShape);
+    }
+    /**
+      * A constructor to set all the required values in the model to infer the model
+      * parameters, or to generate probabilities for the model.
+      * @param yObserved The value to set yObserved to.
+      */
+
+    public LowDimMix(double[] yObserved) {
+        this();
+        this.yObserved.setValue(yObserved);
+    }
+    
+    @Override
+    protected LowDimMix$CoreInterface setExecutionTargetInternal(ExecutionTarget target) {
+        LowDimMix$CoreInterface newCore;
+        switch(target.executionType) {
+            case SingleThreadCPU:
+                newCore = new LowDimMix$SingleThreadCPU(target);
+                break;
+            case MultiThreadCPU:
+                newCore = new LowDimMix$MultiThreadCPU(target);
+                break;
+            default:
+                throw new SandwoodException("Unsupported execution type: " + target);
+        }
+        transferData(system$c, newCore);
+        system$c = newCore;
+        return newCore;
+    }
+
+    private void transferData(LowDimMix$CoreInterface oldCore, LowDimMix$CoreInterface newCore) {
+
+        //Observed arrays
+        if(yObserved.isSet()) {
+            newCore.set$yObserved(oldCore.get$yObserved(), false);
+            newCore.set$length$yObserved(oldCore.get$length$yObserved(), false);
+        }
+        else if(yObserved.shapeSet())
+            newCore.set$length$yObserved(oldCore.get$length$yObserved(), false);
+
+        //ComputedVariables
+        if($component.isSet())
+            newCore.set$component(oldCore.get$component(), false);
+        if($rawMu.isSet())
+            newCore.set$rawMu(oldCore.get$rawMu(), false);
+        if($sigma.isSet())
+            newCore.set$sigma(oldCore.get$sigma(), false);
+        if($theta.isSet())
+            newCore.set$theta(oldCore.get$theta(), false);
+
+        //Set fixed flags
+        newCore.set$fixedFlag$sample101(oldCore.get$fixedFlag$sample101(), false);
+        newCore.set$fixedFlag$sample20(oldCore.get$fixedFlag$sample20(), false);
+        newCore.set$fixedFlag$sample83(oldCore.get$fixedFlag$sample83(), false);
+        newCore.set$fixedFlag$sample88(oldCore.get$fixedFlag$sample88(), false);
+    }
+
+    /**
+     * A class to hold all the values required to perform a value inference on the model.
+     */
+    public static class InferValueInputs {
+        /** Field holding the shape of model input yObserved */
+        public final int yObservedShape;
+
+        /**
+          * A constructor taking all the values required to set up the model to infer variables.
+          * @param yObservedShape An integer array describing the shape of variable yObserved to use in the model when generating results.
+          */
+        public InferValueInputs(int yObservedShape) {
+            this.yObservedShape = yObservedShape;
+        }
+    }
+
+    /**
+     * A class to hold all the inputs for the model. It can be used to parameterize inference of the model probabilities
+     * and probability calculations.
+     */
+    public static class AllInputs {
+        /** Field holding the value of model input yObserved */
+        public final double[] yObserved;
+
+        /**
+          * A constructor to take all the required values by the model to infer the model
+          * parameters, or to generate probabilities for the model.
+          * @param yObserved The value to set yObserved to.
+          */
+        public AllInputs(double[] yObserved) {
+            this.yObserved = yObserved;
+        }
+    }
+
+    /**
+     * A class to hold all the outputs from the model after an infer values step.
+     */
+    public static class InferredValueOutputs {
+        /** Field holding the value of component after a convention execution step.*/
+        public final boolean[] component;
+        /** Field holding the value of mu after a convention execution step.*/
+        public final double[] mu;
+        /** Field holding the value of rawMu after a convention execution step.*/
+        public final double[] rawMu;
+        /** Field holding the value of sigma after a convention execution step.*/
+        public final double[] sigma;
+        /** Field holding the value of theta after a convention execution step.*/
+        public final double theta;
+        /** Field holding the value of y after a convention execution step.*/
+        public final double[] y;
+
+        InferredValueOutputs(LowDimMix system$model) {
+            this.component = system$model.component.getSamples()[0];
+            this.mu = system$model.mu.getSamples()[0];
+            this.rawMu = system$model.rawMu.getSamples()[0];
+            this.sigma = system$model.sigma.getSamples()[0];
+            this.theta = system$model.theta.getSamples()[0];
+            this.y = system$model.y.getSamples()[0];
+        }
+    }
+
+    /**
+     * A class to hold all the probabilities from the model after a generate probabilities step.
+     */
+    public static class LogProbabilities {
+        private final double $logModelProbability;
+        /** Field holding the log probability of random variable componentDistribution */
+        public final double componentDistribution;
+        /** Field holding the log probability of computed variable component */
+        public final double component;
+        /** Field holding the log probability of computed variable mu */
+        public final double mu;
+        /** Field holding the log probability of computed variable rawMu */
+        public final double rawMu;
+        /** Field holding the log probability of computed variable sigma */
+        public final double sigma;
+        /** Field holding the log probability of computed variable theta */
+        public final double theta;
+        /** Field holding the log probability of computed variable y */
+        public final double y;
+
+        LogProbabilities(LowDimMix system$model) {
+            this.$logModelProbability = system$model.getLogProbability();
+            this.componentDistribution = system$model.componentDistribution.getLogProbability();
+            this.component = system$model.component.getLogProbability();
+            this.mu = system$model.mu.getLogProbability();
+            this.rawMu = system$model.rawMu.getLogProbability();
+            this.sigma = system$model.sigma.getLogProbability();
+            this.theta = system$model.theta.getLogProbability();
+            this.y = system$model.y.getLogProbability();
+        }
+
+        /** Method to return log probability of the whole model 
+         *  @return The log probability of the whole model. */
+        public double getModelProbability() { return $logModelProbability; }
+    }
+
+    /**
+     * A class to hold all the probabilities from the model after a generate probabilities step.
+     */
+    public static class Probabilities {
+        private final double $modelProbability;
+        /** Field holding the probability of random variable componentDistribution */
+        public final double componentDistribution;
+        /** Field holding the probability of computed variable component */
+        public final double component;
+        /** Field holding the probability of computed variable mu */
+        public final double mu;
+        /** Field holding the probability of computed variable rawMu */
+        public final double rawMu;
+        /** Field holding the probability of computed variable sigma */
+        public final double sigma;
+        /** Field holding the probability of computed variable theta */
+        public final double theta;
+        /** Field holding the probability of computed variable y */
+        public final double y;
+
+        Probabilities(LowDimMix system$model) {
+            this.$modelProbability = system$model.getProbability();
+            this.componentDistribution = system$model.componentDistribution.getProbability();
+            this.component = system$model.component.getProbability();
+            this.mu = system$model.mu.getProbability();
+            this.rawMu = system$model.rawMu.getProbability();
+            this.sigma = system$model.sigma.getProbability();
+            this.theta = system$model.theta.getProbability();
+            this.y = system$model.y.getProbability();
+        }
+
+        /** Method to return probability of the whole model 
+         *  @return The probability of the whole model. */
+        public double getModelProbability() { return $modelProbability; }
+    }
+
+    /**
+     * A class to hold all the outputs from the model after an infer model call.
+     */
+    public static class InferredModelOutputs {
+        /** Field holding the MAP or Sample value of component after an infer model call. */
+        public final boolean[][] component;
+        /** Field holding the MAP or Sample value of mu after an infer model call. */
+        public final double[][] mu;
+        /** Field holding the MAP or Sample value of rawMu after an infer model call. */
+        public final double[][] rawMu;
+        /** Field holding the MAP or Sample value of sigma after an infer model call. */
+        public final double[][] sigma;
+        /** Field holding the MAP or Sample value of theta after an infer model call. */
+        public final double[] theta;
+
+        InferredModelOutputs(LowDimMix system$model) {
+            this.component = system$model.getInferredValue(system$model.$component);
+            this.mu = system$model.getInferredValue(system$model.$mu);
+            this.rawMu = system$model.getInferredValue(system$model.$rawMu);
+            this.sigma = system$model.getInferredValue(system$model.$sigma);
+            this.theta = system$model.getInferredValue(system$model.$theta);
+        }
+    }
+
+    /**
+     * Perform a single pass generating values from the model.
+     * @param inputs An object containing the parameters required to run inference on the model.
+     * @return An object containing the values computed by the inference step.
+     */
+    public InferredValueOutputs execute(InferValueInputs inputs) {
+        this.$yObserved.setShape(inputs.yObservedShape);
+        execute();
+        return new InferredValueOutputs(this);
+    }
+
+    /**
+     * Infer the values of the different elements of the model.
+     * @param iterations The number of iterations to perform when inferring the values.
+     * @param inputs An object containing the parameters required to generate the model parameters.
+     * @return An object containing the computed values for the model.
+     */
+    public InferredModelOutputs inferValues(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferValues(iterations);
+        return new InferredModelOutputs(this);
+    }
+
+    /**
+     * Generate the probabilities of the different elements of the model.
+     * @param iterations How many iterations should be used to generate these values?
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(iterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Calculate the probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(double variance, int initialIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Calculate the probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param maxIterations The maximum number of iterations a that can be used to calculate the probabilities. If the model has not
+     * converged by this point the calculation will terminate anyway, and the result generated so far will be returned.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(double variance, int initialIterations, int maxIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations, maxIterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Generate the log probabilities of the different elements of the model.
+     * @param iterations How many iterations should be used to generate these values?
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(iterations);
+        return new LogProbabilities(this);
+    }
+
+    /**
+     * Calculate the log probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(double variance, int initialIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations);
+        return new LogProbabilities(this);
+    }
+
+    /**
+     * Calculate the log probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param maxIterations The maximum number of iterations a that can be used to calculate the probabilities. If the model has not
+     * converged by this point the calculation will terminate anyway, and the result generated so far will be returned.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(double variance, int initialIterations, int maxIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations, maxIterations);
+        return new LogProbabilities(this);
+    }
+}
+//END OF CODE

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix_modelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix_modelSingle.java
@@ -1,0 +1,632 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.runtime.model.Model;
+import org.sandwood.runtime.model.ExecutionTarget;
+import org.sandwood.runtime.model.variables.*;
+import org.sandwood.runtime.internal.model.variables.*;
+import org.sandwood.runtime.internal.model.variables.probability.ProbabilityType;
+import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
+
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+  * Class representing the Sandwood model LowDimMix This is the class that
+  * all user interactions with the model should occur through.
+  */
+public final class LowDimMix extends Model {
+
+    private LowDimMix$CoreInterface system$c = new LowDimMix$SingleThreadCPU(ExecutionTarget.singleThread);
+
+    private final ComputedBooleanArrayInternal $component = new ComputedBooleanArrayInternal(this, "component", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public boolean[] getValue() { return system$c.get$component(); }
+
+        @Override
+        protected void setValueInternal(boolean[] value) {
+            system$c.set$component(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$component(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample101(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample101())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing component of type boolean[] from the Sandwood model 
+     */
+    public final ComputedBooleanArray component = $component;
+
+    private final ComputedDoubleArrayInternal $mu = new ComputedDoubleArrayInternal(this, "mu", false, false, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$mu(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {}
+
+        @Override
+        protected void testSettable() {
+            throw new SandwoodException("Set is not available for variable mu because its value depends on variable \"rawMu\".");
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$mu(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample20(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample20())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing mu of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray mu = $mu;
+
+    private final ComputedDoubleArrayInternal $rawMu = new ComputedDoubleArrayInternal(this, "rawMu", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$rawMu(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {
+            system$c.set$rawMu(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$rawMu(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample20(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample20())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing rawMu of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray rawMu = $rawMu;
+
+    private final ComputedDoubleArrayInternal $sigma = new ComputedDoubleArrayInternal(this, "sigma", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$sigma(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {
+            system$c.set$sigma(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$sigma(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample83(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample83())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing sigma of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray sigma = $sigma;
+
+    private final ComputedDoubleInternal $theta = new ComputedDoubleInternal(this, "theta", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double getValue() { return system$c.get$theta(); }
+
+        @Override
+        protected void setValueInternal(double value) {
+            system$c.set$theta(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$theta(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample88(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample88())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing theta of type double from the Sandwood model 
+     */
+    public final ComputedDouble theta = $theta;
+
+    private final ComputedDoubleArrayInternal $y = new ComputedDoubleArrayInternal(this, "y", false, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$y(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {}
+
+        @Override
+        protected void testSettable() {
+            throw new SandwoodException("Set is not available for variable y because it is fixed by observing a variable.");
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$y(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
+        }
+
+        @Override
+        public Immutability isFixed() {
+            return Immutability.OBSERVED;
+        }
+    };
+
+    /**
+     * Computed variable representing y of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray y = $y;
+
+	private Map<String, ComputedVariableInternal> $computedVariables = new HashMap<>();
+
+    private Map<String, ObservedVariableInternal> $modelInputs = new HashMap<>();
+
+    private final ObservedDoubleArrayShapeableInternal $yObserved = new ObservedDoubleArrayShapeableInternal(this, "yObserved") {
+        @Override
+        public double[] getValue() {
+            synchronized(model) {
+                return system$c.get$yObserved();
+            }
+        }
+
+        @Override
+        public void setValueInternal(double[] value) {
+            system$c.set$yObserved(value, allocated);
+            system$c.set$length$yObserved(value.length, allocated);
+        }
+
+        @Override
+        public void setShapeInternal(int shape) {
+            system$c.set$length$yObserved(shape, allocated);
+        }
+
+        @Override
+        public int getShape() {
+            return system$c.get$length$yObserved();
+        }
+    };
+
+    /**
+     * Observed variable representing yObserved of type double[] from the Sandwood model 
+     */
+    public final ObservedDoubleArrayShapeable yObserved = $yObserved;
+
+    private Map<String, ObservedVariableInternal> $regularObservedValues = new HashMap<>();
+    private Map<String, ObservedVariableShapeableInternal<?>> $shapedObservedValues = new HashMap<>();
+    private final RandomVariableInternal $componentDistribution = new RandomVariableInternal(this, "componentDistribution", ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double getCurrentLogProbability() {
+            return system$c.get$logProbability$componentDistribution();
+        }
+    };
+
+    /**
+     * Random variable representing componentDistribution from the Sandwood model 
+     */
+    public final RandomVariable componentDistribution = $componentDistribution;
+
+    private HasProbabilityInternal[] $probabilityVariables = {$component, $mu, $rawMu, $sigma, $theta, $y, $componentDistribution};
+
+    //Constructors
+    /**
+     * A constructor for a model where no variable values are set.
+     */
+    public LowDimMix() {
+        super();
+        //ComputedVariable
+        $computedVariables.put("component", $component);
+        $computedVariables.put("mu", $mu);
+        $computedVariables.put("rawMu", $rawMu);
+        $computedVariables.put("sigma", $sigma);
+        $computedVariables.put("theta", $theta);
+        $computedVariables.put("y", $y);
+
+        //Observed array fields
+        $shapedObservedValues.put("yObserved", $yObserved);
+        init(system$c, $modelInputs, $regularObservedValues, $shapedObservedValues, $computedVariables, $probabilityVariables);
+    }
+    /**
+      * A constructor to set all the required values in the model to infer values. These
+      * will be values in an untrained model so this will only generate values from the
+      * default distributions described in the model.
+      * @param yObservedShape An integer array describing the shape of variable yObserved to use in the model when generating results.
+      */
+
+    public LowDimMix(int yObservedShape) {
+        this();
+        this.$yObserved.setShape(yObservedShape);
+    }
+    /**
+      * A constructor to set all the required values in the model to infer the model
+      * parameters, or to generate probabilities for the model.
+      * @param yObserved The value to set yObserved to.
+      */
+
+    public LowDimMix(double[] yObserved) {
+        this();
+        this.yObserved.setValue(yObserved);
+    }
+    
+    @Override
+    protected LowDimMix$CoreInterface setExecutionTargetInternal(ExecutionTarget target) {
+        LowDimMix$CoreInterface newCore;
+        switch(target.executionType) {
+            case SingleThreadCPU:
+                newCore = new LowDimMix$SingleThreadCPU(target);
+                break;
+            case MultiThreadCPU:
+                newCore = new LowDimMix$MultiThreadCPU(target);
+                break;
+            default:
+                throw new SandwoodException("Unsupported execution type: " + target);
+        }
+        transferData(system$c, newCore);
+        system$c = newCore;
+        return newCore;
+    }
+
+    private void transferData(LowDimMix$CoreInterface oldCore, LowDimMix$CoreInterface newCore) {
+
+        //Observed arrays
+        if(yObserved.isSet()) {
+            newCore.set$yObserved(oldCore.get$yObserved(), false);
+            newCore.set$length$yObserved(oldCore.get$length$yObserved(), false);
+        }
+        else if(yObserved.shapeSet())
+            newCore.set$length$yObserved(oldCore.get$length$yObserved(), false);
+
+        //ComputedVariables
+        if($component.isSet())
+            newCore.set$component(oldCore.get$component(), false);
+        if($rawMu.isSet())
+            newCore.set$rawMu(oldCore.get$rawMu(), false);
+        if($sigma.isSet())
+            newCore.set$sigma(oldCore.get$sigma(), false);
+        if($theta.isSet())
+            newCore.set$theta(oldCore.get$theta(), false);
+
+        //Set fixed flags
+        newCore.set$fixedFlag$sample101(oldCore.get$fixedFlag$sample101(), false);
+        newCore.set$fixedFlag$sample20(oldCore.get$fixedFlag$sample20(), false);
+        newCore.set$fixedFlag$sample83(oldCore.get$fixedFlag$sample83(), false);
+        newCore.set$fixedFlag$sample88(oldCore.get$fixedFlag$sample88(), false);
+    }
+
+    /**
+     * A class to hold all the values required to perform a value inference on the model.
+     */
+    public static class InferValueInputs {
+        /** Field holding the shape of model input yObserved */
+        public final int yObservedShape;
+
+        /**
+          * A constructor taking all the values required to set up the model to infer variables.
+          * @param yObservedShape An integer array describing the shape of variable yObserved to use in the model when generating results.
+          */
+        public InferValueInputs(int yObservedShape) {
+            this.yObservedShape = yObservedShape;
+        }
+    }
+
+    /**
+     * A class to hold all the inputs for the model. It can be used to parameterize inference of the model probabilities
+     * and probability calculations.
+     */
+    public static class AllInputs {
+        /** Field holding the value of model input yObserved */
+        public final double[] yObserved;
+
+        /**
+          * A constructor to take all the required values by the model to infer the model
+          * parameters, or to generate probabilities for the model.
+          * @param yObserved The value to set yObserved to.
+          */
+        public AllInputs(double[] yObserved) {
+            this.yObserved = yObserved;
+        }
+    }
+
+    /**
+     * A class to hold all the outputs from the model after an infer values step.
+     */
+    public static class InferredValueOutputs {
+        /** Field holding the value of component after a convention execution step.*/
+        public final boolean[] component;
+        /** Field holding the value of mu after a convention execution step.*/
+        public final double[] mu;
+        /** Field holding the value of rawMu after a convention execution step.*/
+        public final double[] rawMu;
+        /** Field holding the value of sigma after a convention execution step.*/
+        public final double[] sigma;
+        /** Field holding the value of theta after a convention execution step.*/
+        public final double theta;
+        /** Field holding the value of y after a convention execution step.*/
+        public final double[] y;
+
+        InferredValueOutputs(LowDimMix system$model) {
+            this.component = system$model.component.getSamples()[0];
+            this.mu = system$model.mu.getSamples()[0];
+            this.rawMu = system$model.rawMu.getSamples()[0];
+            this.sigma = system$model.sigma.getSamples()[0];
+            this.theta = system$model.theta.getSamples()[0];
+            this.y = system$model.y.getSamples()[0];
+        }
+    }
+
+    /**
+     * A class to hold all the probabilities from the model after a generate probabilities step.
+     */
+    public static class LogProbabilities {
+        private final double $logModelProbability;
+        /** Field holding the log probability of random variable componentDistribution */
+        public final double componentDistribution;
+        /** Field holding the log probability of computed variable component */
+        public final double component;
+        /** Field holding the log probability of computed variable mu */
+        public final double mu;
+        /** Field holding the log probability of computed variable rawMu */
+        public final double rawMu;
+        /** Field holding the log probability of computed variable sigma */
+        public final double sigma;
+        /** Field holding the log probability of computed variable theta */
+        public final double theta;
+        /** Field holding the log probability of computed variable y */
+        public final double y;
+
+        LogProbabilities(LowDimMix system$model) {
+            this.$logModelProbability = system$model.getLogProbability();
+            this.componentDistribution = system$model.componentDistribution.getLogProbability();
+            this.component = system$model.component.getLogProbability();
+            this.mu = system$model.mu.getLogProbability();
+            this.rawMu = system$model.rawMu.getLogProbability();
+            this.sigma = system$model.sigma.getLogProbability();
+            this.theta = system$model.theta.getLogProbability();
+            this.y = system$model.y.getLogProbability();
+        }
+
+        /** Method to return log probability of the whole model 
+         *  @return The log probability of the whole model. */
+        public double getModelProbability() { return $logModelProbability; }
+    }
+
+    /**
+     * A class to hold all the probabilities from the model after a generate probabilities step.
+     */
+    public static class Probabilities {
+        private final double $modelProbability;
+        /** Field holding the probability of random variable componentDistribution */
+        public final double componentDistribution;
+        /** Field holding the probability of computed variable component */
+        public final double component;
+        /** Field holding the probability of computed variable mu */
+        public final double mu;
+        /** Field holding the probability of computed variable rawMu */
+        public final double rawMu;
+        /** Field holding the probability of computed variable sigma */
+        public final double sigma;
+        /** Field holding the probability of computed variable theta */
+        public final double theta;
+        /** Field holding the probability of computed variable y */
+        public final double y;
+
+        Probabilities(LowDimMix system$model) {
+            this.$modelProbability = system$model.getProbability();
+            this.componentDistribution = system$model.componentDistribution.getProbability();
+            this.component = system$model.component.getProbability();
+            this.mu = system$model.mu.getProbability();
+            this.rawMu = system$model.rawMu.getProbability();
+            this.sigma = system$model.sigma.getProbability();
+            this.theta = system$model.theta.getProbability();
+            this.y = system$model.y.getProbability();
+        }
+
+        /** Method to return probability of the whole model 
+         *  @return The probability of the whole model. */
+        public double getModelProbability() { return $modelProbability; }
+    }
+
+    /**
+     * A class to hold all the outputs from the model after an infer model call.
+     */
+    public static class InferredModelOutputs {
+        /** Field holding the MAP or Sample value of component after an infer model call. */
+        public final boolean[][] component;
+        /** Field holding the MAP or Sample value of mu after an infer model call. */
+        public final double[][] mu;
+        /** Field holding the MAP or Sample value of rawMu after an infer model call. */
+        public final double[][] rawMu;
+        /** Field holding the MAP or Sample value of sigma after an infer model call. */
+        public final double[][] sigma;
+        /** Field holding the MAP or Sample value of theta after an infer model call. */
+        public final double[] theta;
+
+        InferredModelOutputs(LowDimMix system$model) {
+            this.component = system$model.getInferredValue(system$model.$component);
+            this.mu = system$model.getInferredValue(system$model.$mu);
+            this.rawMu = system$model.getInferredValue(system$model.$rawMu);
+            this.sigma = system$model.getInferredValue(system$model.$sigma);
+            this.theta = system$model.getInferredValue(system$model.$theta);
+        }
+    }
+
+    /**
+     * Perform a single pass generating values from the model.
+     * @param inputs An object containing the parameters required to run inference on the model.
+     * @return An object containing the values computed by the inference step.
+     */
+    public InferredValueOutputs execute(InferValueInputs inputs) {
+        this.$yObserved.setShape(inputs.yObservedShape);
+        execute();
+        return new InferredValueOutputs(this);
+    }
+
+    /**
+     * Infer the values of the different elements of the model.
+     * @param iterations The number of iterations to perform when inferring the values.
+     * @param inputs An object containing the parameters required to generate the model parameters.
+     * @return An object containing the computed values for the model.
+     */
+    public InferredModelOutputs inferValues(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferValues(iterations);
+        return new InferredModelOutputs(this);
+    }
+
+    /**
+     * Generate the probabilities of the different elements of the model.
+     * @param iterations How many iterations should be used to generate these values?
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(iterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Calculate the probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(double variance, int initialIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Calculate the probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param maxIterations The maximum number of iterations a that can be used to calculate the probabilities. If the model has not
+     * converged by this point the calculation will terminate anyway, and the result generated so far will be returned.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(double variance, int initialIterations, int maxIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations, maxIterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Generate the log probabilities of the different elements of the model.
+     * @param iterations How many iterations should be used to generate these values?
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(iterations);
+        return new LogProbabilities(this);
+    }
+
+    /**
+     * Calculate the log probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(double variance, int initialIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations);
+        return new LogProbabilities(this);
+    }
+
+    /**
+     * Calculate the log probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param maxIterations The maximum number of iterations a that can be used to calculate the probabilities. If the model has not
+     * converged by this point the calculation will terminate anyway, and the result generated so far will be returned.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(double variance, int initialIterations, int maxIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations, maxIterations);
+        return new LogProbabilities(this);
+    }
+}
+//END OF CODE

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix_optimisedModel.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix_optimisedModel.java
@@ -1,0 +1,632 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.runtime.model.Model;
+import org.sandwood.runtime.model.ExecutionTarget;
+import org.sandwood.runtime.model.variables.*;
+import org.sandwood.runtime.internal.model.variables.*;
+import org.sandwood.runtime.internal.model.variables.probability.ProbabilityType;
+import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
+
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+  * Class representing the Sandwood model LowDimMix This is the class that
+  * all user interactions with the model should occur through.
+  */
+public final class LowDimMix extends Model {
+
+    private LowDimMix$CoreInterface system$c = new LowDimMix$SingleThreadCPU(ExecutionTarget.singleThread);
+
+    private final ComputedBooleanArrayInternal $component = new ComputedBooleanArrayInternal(this, "component", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public boolean[] getValue() { return system$c.get$component(); }
+
+        @Override
+        protected void setValueInternal(boolean[] value) {
+            system$c.set$component(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$component(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample101(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample101())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing component of type boolean[] from the Sandwood model 
+     */
+    public final ComputedBooleanArray component = $component;
+
+    private final ComputedDoubleArrayInternal $mu = new ComputedDoubleArrayInternal(this, "mu", false, false, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$mu(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {}
+
+        @Override
+        protected void testSettable() {
+            throw new SandwoodException("Set is not available for variable mu because its value depends on variable \"rawMu\".");
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$mu(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample20(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample20())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing mu of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray mu = $mu;
+
+    private final ComputedDoubleArrayInternal $rawMu = new ComputedDoubleArrayInternal(this, "rawMu", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$rawMu(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {
+            system$c.set$rawMu(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$rawMu(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample20(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample20())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing rawMu of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray rawMu = $rawMu;
+
+    private final ComputedDoubleArrayInternal $sigma = new ComputedDoubleArrayInternal(this, "sigma", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$sigma(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {
+            system$c.set$sigma(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$sigma(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample83(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample83())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing sigma of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray sigma = $sigma;
+
+    private final ComputedDoubleInternal $theta = new ComputedDoubleInternal(this, "theta", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double getValue() { return system$c.get$theta(); }
+
+        @Override
+        protected void setValueInternal(double value) {
+            system$c.set$theta(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$theta(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample88(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample88())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing theta of type double from the Sandwood model 
+     */
+    public final ComputedDouble theta = $theta;
+
+    private final ComputedDoubleArrayInternal $y = new ComputedDoubleArrayInternal(this, "y", false, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$y(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {}
+
+        @Override
+        protected void testSettable() {
+            throw new SandwoodException("Set is not available for variable y because it is fixed by observing a variable.");
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$y(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
+        }
+
+        @Override
+        public Immutability isFixed() {
+            return Immutability.OBSERVED;
+        }
+    };
+
+    /**
+     * Computed variable representing y of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray y = $y;
+
+	private Map<String, ComputedVariableInternal> $computedVariables = new HashMap<>();
+
+    private Map<String, ObservedVariableInternal> $modelInputs = new HashMap<>();
+
+    private final ObservedDoubleArrayShapeableInternal $yObserved = new ObservedDoubleArrayShapeableInternal(this, "yObserved") {
+        @Override
+        public double[] getValue() {
+            synchronized(model) {
+                return system$c.get$yObserved();
+            }
+        }
+
+        @Override
+        public void setValueInternal(double[] value) {
+            system$c.set$yObserved(value, allocated);
+            system$c.set$length$yObserved(value.length, allocated);
+        }
+
+        @Override
+        public void setShapeInternal(int shape) {
+            system$c.set$length$yObserved(shape, allocated);
+        }
+
+        @Override
+        public int getShape() {
+            return system$c.get$length$yObserved();
+        }
+    };
+
+    /**
+     * Observed variable representing yObserved of type double[] from the Sandwood model 
+     */
+    public final ObservedDoubleArrayShapeable yObserved = $yObserved;
+
+    private Map<String, ObservedVariableInternal> $regularObservedValues = new HashMap<>();
+    private Map<String, ObservedVariableShapeableInternal<?>> $shapedObservedValues = new HashMap<>();
+    private final RandomVariableInternal $componentDistribution = new RandomVariableInternal(this, "componentDistribution", ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double getCurrentLogProbability() {
+            return system$c.get$logProbability$componentDistribution();
+        }
+    };
+
+    /**
+     * Random variable representing componentDistribution from the Sandwood model 
+     */
+    public final RandomVariable componentDistribution = $componentDistribution;
+
+    private HasProbabilityInternal[] $probabilityVariables = {$component, $mu, $rawMu, $sigma, $theta, $y, $componentDistribution};
+
+    //Constructors
+    /**
+     * A constructor for a model where no variable values are set.
+     */
+    public LowDimMix() {
+        super();
+        //ComputedVariable
+        $computedVariables.put("component", $component);
+        $computedVariables.put("mu", $mu);
+        $computedVariables.put("rawMu", $rawMu);
+        $computedVariables.put("sigma", $sigma);
+        $computedVariables.put("theta", $theta);
+        $computedVariables.put("y", $y);
+
+        //Observed array fields
+        $shapedObservedValues.put("yObserved", $yObserved);
+        init(system$c, $modelInputs, $regularObservedValues, $shapedObservedValues, $computedVariables, $probabilityVariables);
+    }
+    /**
+      * A constructor to set all the required values in the model to infer values. These
+      * will be values in an untrained model so this will only generate values from the
+      * default distributions described in the model.
+      * @param yObservedShape An integer array describing the shape of variable yObserved to use in the model when generating results.
+      */
+
+    public LowDimMix(int yObservedShape) {
+        this();
+        this.$yObserved.setShape(yObservedShape);
+    }
+    /**
+      * A constructor to set all the required values in the model to infer the model
+      * parameters, or to generate probabilities for the model.
+      * @param yObserved The value to set yObserved to.
+      */
+
+    public LowDimMix(double[] yObserved) {
+        this();
+        this.yObserved.setValue(yObserved);
+    }
+    
+    @Override
+    protected LowDimMix$CoreInterface setExecutionTargetInternal(ExecutionTarget target) {
+        LowDimMix$CoreInterface newCore;
+        switch(target.executionType) {
+            case SingleThreadCPU:
+                newCore = new LowDimMix$SingleThreadCPU(target);
+                break;
+            case MultiThreadCPU:
+                newCore = new LowDimMix$MultiThreadCPU(target);
+                break;
+            default:
+                throw new SandwoodException("Unsupported execution type: " + target);
+        }
+        transferData(system$c, newCore);
+        system$c = newCore;
+        return newCore;
+    }
+
+    private void transferData(LowDimMix$CoreInterface oldCore, LowDimMix$CoreInterface newCore) {
+
+        //Observed arrays
+        if(yObserved.isSet()) {
+            newCore.set$yObserved(oldCore.get$yObserved(), false);
+            newCore.set$length$yObserved(oldCore.get$length$yObserved(), false);
+        }
+        else if(yObserved.shapeSet())
+            newCore.set$length$yObserved(oldCore.get$length$yObserved(), false);
+
+        //ComputedVariables
+        if($component.isSet())
+            newCore.set$component(oldCore.get$component(), false);
+        if($rawMu.isSet())
+            newCore.set$rawMu(oldCore.get$rawMu(), false);
+        if($sigma.isSet())
+            newCore.set$sigma(oldCore.get$sigma(), false);
+        if($theta.isSet())
+            newCore.set$theta(oldCore.get$theta(), false);
+
+        //Set fixed flags
+        newCore.set$fixedFlag$sample101(oldCore.get$fixedFlag$sample101(), false);
+        newCore.set$fixedFlag$sample20(oldCore.get$fixedFlag$sample20(), false);
+        newCore.set$fixedFlag$sample83(oldCore.get$fixedFlag$sample83(), false);
+        newCore.set$fixedFlag$sample88(oldCore.get$fixedFlag$sample88(), false);
+    }
+
+    /**
+     * A class to hold all the values required to perform a value inference on the model.
+     */
+    public static class InferValueInputs {
+        /** Field holding the shape of model input yObserved */
+        public final int yObservedShape;
+
+        /**
+          * A constructor taking all the values required to set up the model to infer variables.
+          * @param yObservedShape An integer array describing the shape of variable yObserved to use in the model when generating results.
+          */
+        public InferValueInputs(int yObservedShape) {
+            this.yObservedShape = yObservedShape;
+        }
+    }
+
+    /**
+     * A class to hold all the inputs for the model. It can be used to parameterize inference of the model probabilities
+     * and probability calculations.
+     */
+    public static class AllInputs {
+        /** Field holding the value of model input yObserved */
+        public final double[] yObserved;
+
+        /**
+          * A constructor to take all the required values by the model to infer the model
+          * parameters, or to generate probabilities for the model.
+          * @param yObserved The value to set yObserved to.
+          */
+        public AllInputs(double[] yObserved) {
+            this.yObserved = yObserved;
+        }
+    }
+
+    /**
+     * A class to hold all the outputs from the model after an infer values step.
+     */
+    public static class InferredValueOutputs {
+        /** Field holding the value of component after a convention execution step.*/
+        public final boolean[] component;
+        /** Field holding the value of mu after a convention execution step.*/
+        public final double[] mu;
+        /** Field holding the value of rawMu after a convention execution step.*/
+        public final double[] rawMu;
+        /** Field holding the value of sigma after a convention execution step.*/
+        public final double[] sigma;
+        /** Field holding the value of theta after a convention execution step.*/
+        public final double theta;
+        /** Field holding the value of y after a convention execution step.*/
+        public final double[] y;
+
+        InferredValueOutputs(LowDimMix system$model) {
+            this.component = system$model.component.getSamples()[0];
+            this.mu = system$model.mu.getSamples()[0];
+            this.rawMu = system$model.rawMu.getSamples()[0];
+            this.sigma = system$model.sigma.getSamples()[0];
+            this.theta = system$model.theta.getSamples()[0];
+            this.y = system$model.y.getSamples()[0];
+        }
+    }
+
+    /**
+     * A class to hold all the probabilities from the model after a generate probabilities step.
+     */
+    public static class LogProbabilities {
+        private final double $logModelProbability;
+        /** Field holding the log probability of random variable componentDistribution */
+        public final double componentDistribution;
+        /** Field holding the log probability of computed variable component */
+        public final double component;
+        /** Field holding the log probability of computed variable mu */
+        public final double mu;
+        /** Field holding the log probability of computed variable rawMu */
+        public final double rawMu;
+        /** Field holding the log probability of computed variable sigma */
+        public final double sigma;
+        /** Field holding the log probability of computed variable theta */
+        public final double theta;
+        /** Field holding the log probability of computed variable y */
+        public final double y;
+
+        LogProbabilities(LowDimMix system$model) {
+            this.$logModelProbability = system$model.getLogProbability();
+            this.componentDistribution = system$model.componentDistribution.getLogProbability();
+            this.component = system$model.component.getLogProbability();
+            this.mu = system$model.mu.getLogProbability();
+            this.rawMu = system$model.rawMu.getLogProbability();
+            this.sigma = system$model.sigma.getLogProbability();
+            this.theta = system$model.theta.getLogProbability();
+            this.y = system$model.y.getLogProbability();
+        }
+
+        /** Method to return log probability of the whole model 
+         *  @return The log probability of the whole model. */
+        public double getModelProbability() { return $logModelProbability; }
+    }
+
+    /**
+     * A class to hold all the probabilities from the model after a generate probabilities step.
+     */
+    public static class Probabilities {
+        private final double $modelProbability;
+        /** Field holding the probability of random variable componentDistribution */
+        public final double componentDistribution;
+        /** Field holding the probability of computed variable component */
+        public final double component;
+        /** Field holding the probability of computed variable mu */
+        public final double mu;
+        /** Field holding the probability of computed variable rawMu */
+        public final double rawMu;
+        /** Field holding the probability of computed variable sigma */
+        public final double sigma;
+        /** Field holding the probability of computed variable theta */
+        public final double theta;
+        /** Field holding the probability of computed variable y */
+        public final double y;
+
+        Probabilities(LowDimMix system$model) {
+            this.$modelProbability = system$model.getProbability();
+            this.componentDistribution = system$model.componentDistribution.getProbability();
+            this.component = system$model.component.getProbability();
+            this.mu = system$model.mu.getProbability();
+            this.rawMu = system$model.rawMu.getProbability();
+            this.sigma = system$model.sigma.getProbability();
+            this.theta = system$model.theta.getProbability();
+            this.y = system$model.y.getProbability();
+        }
+
+        /** Method to return probability of the whole model 
+         *  @return The probability of the whole model. */
+        public double getModelProbability() { return $modelProbability; }
+    }
+
+    /**
+     * A class to hold all the outputs from the model after an infer model call.
+     */
+    public static class InferredModelOutputs {
+        /** Field holding the MAP or Sample value of component after an infer model call. */
+        public final boolean[][] component;
+        /** Field holding the MAP or Sample value of mu after an infer model call. */
+        public final double[][] mu;
+        /** Field holding the MAP or Sample value of rawMu after an infer model call. */
+        public final double[][] rawMu;
+        /** Field holding the MAP or Sample value of sigma after an infer model call. */
+        public final double[][] sigma;
+        /** Field holding the MAP or Sample value of theta after an infer model call. */
+        public final double[] theta;
+
+        InferredModelOutputs(LowDimMix system$model) {
+            this.component = system$model.getInferredValue(system$model.$component);
+            this.mu = system$model.getInferredValue(system$model.$mu);
+            this.rawMu = system$model.getInferredValue(system$model.$rawMu);
+            this.sigma = system$model.getInferredValue(system$model.$sigma);
+            this.theta = system$model.getInferredValue(system$model.$theta);
+        }
+    }
+
+    /**
+     * Perform a single pass generating values from the model.
+     * @param inputs An object containing the parameters required to run inference on the model.
+     * @return An object containing the values computed by the inference step.
+     */
+    public InferredValueOutputs execute(InferValueInputs inputs) {
+        this.$yObserved.setShape(inputs.yObservedShape);
+        execute();
+        return new InferredValueOutputs(this);
+    }
+
+    /**
+     * Infer the values of the different elements of the model.
+     * @param iterations The number of iterations to perform when inferring the values.
+     * @param inputs An object containing the parameters required to generate the model parameters.
+     * @return An object containing the computed values for the model.
+     */
+    public InferredModelOutputs inferValues(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferValues(iterations);
+        return new InferredModelOutputs(this);
+    }
+
+    /**
+     * Generate the probabilities of the different elements of the model.
+     * @param iterations How many iterations should be used to generate these values?
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(iterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Calculate the probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(double variance, int initialIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Calculate the probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param maxIterations The maximum number of iterations a that can be used to calculate the probabilities. If the model has not
+     * converged by this point the calculation will terminate anyway, and the result generated so far will be returned.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(double variance, int initialIterations, int maxIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations, maxIterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Generate the log probabilities of the different elements of the model.
+     * @param iterations How many iterations should be used to generate these values?
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(iterations);
+        return new LogProbabilities(this);
+    }
+
+    /**
+     * Calculate the log probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(double variance, int initialIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations);
+        return new LogProbabilities(this);
+    }
+
+    /**
+     * Calculate the log probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param maxIterations The maximum number of iterations a that can be used to calculate the probabilities. If the model has not
+     * converged by this point the calculation will terminate anyway, and the result generated so far will be returned.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(double variance, int initialIterations, int maxIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations, maxIterations);
+        return new LogProbabilities(this);
+    }
+}
+//END OF CODE

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix_optimisedModelNoComments.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix_optimisedModelNoComments.java
@@ -1,0 +1,632 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.runtime.model.Model;
+import org.sandwood.runtime.model.ExecutionTarget;
+import org.sandwood.runtime.model.variables.*;
+import org.sandwood.runtime.internal.model.variables.*;
+import org.sandwood.runtime.internal.model.variables.probability.ProbabilityType;
+import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
+
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+  * Class representing the Sandwood model LowDimMix This is the class that
+  * all user interactions with the model should occur through.
+  */
+public final class LowDimMix extends Model {
+
+    private LowDimMix$CoreInterface system$c = new LowDimMix$SingleThreadCPU(ExecutionTarget.singleThread);
+
+    private final ComputedBooleanArrayInternal $component = new ComputedBooleanArrayInternal(this, "component", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public boolean[] getValue() { return system$c.get$component(); }
+
+        @Override
+        protected void setValueInternal(boolean[] value) {
+            system$c.set$component(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$component(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample101(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample101())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing component of type boolean[] from the Sandwood model 
+     */
+    public final ComputedBooleanArray component = $component;
+
+    private final ComputedDoubleArrayInternal $mu = new ComputedDoubleArrayInternal(this, "mu", false, false, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$mu(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {}
+
+        @Override
+        protected void testSettable() {
+            throw new SandwoodException("Set is not available for variable mu because its value depends on variable \"rawMu\".");
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$mu(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample20(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample20())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing mu of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray mu = $mu;
+
+    private final ComputedDoubleArrayInternal $rawMu = new ComputedDoubleArrayInternal(this, "rawMu", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$rawMu(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {
+            system$c.set$rawMu(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$rawMu(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample20(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample20())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing rawMu of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray rawMu = $rawMu;
+
+    private final ComputedDoubleArrayInternal $sigma = new ComputedDoubleArrayInternal(this, "sigma", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$sigma(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {
+            system$c.set$sigma(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$sigma(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample83(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample83())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing sigma of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray sigma = $sigma;
+
+    private final ComputedDoubleInternal $theta = new ComputedDoubleInternal(this, "theta", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double getValue() { return system$c.get$theta(); }
+
+        @Override
+        protected void setValueInternal(double value) {
+            system$c.set$theta(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$theta(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample88(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample88())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing theta of type double from the Sandwood model 
+     */
+    public final ComputedDouble theta = $theta;
+
+    private final ComputedDoubleArrayInternal $y = new ComputedDoubleArrayInternal(this, "y", false, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$y(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {}
+
+        @Override
+        protected void testSettable() {
+            throw new SandwoodException("Set is not available for variable y because it is fixed by observing a variable.");
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$y(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
+        }
+
+        @Override
+        public Immutability isFixed() {
+            return Immutability.OBSERVED;
+        }
+    };
+
+    /**
+     * Computed variable representing y of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray y = $y;
+
+	private Map<String, ComputedVariableInternal> $computedVariables = new HashMap<>();
+
+    private Map<String, ObservedVariableInternal> $modelInputs = new HashMap<>();
+
+    private final ObservedDoubleArrayShapeableInternal $yObserved = new ObservedDoubleArrayShapeableInternal(this, "yObserved") {
+        @Override
+        public double[] getValue() {
+            synchronized(model) {
+                return system$c.get$yObserved();
+            }
+        }
+
+        @Override
+        public void setValueInternal(double[] value) {
+            system$c.set$yObserved(value, allocated);
+            system$c.set$length$yObserved(value.length, allocated);
+        }
+
+        @Override
+        public void setShapeInternal(int shape) {
+            system$c.set$length$yObserved(shape, allocated);
+        }
+
+        @Override
+        public int getShape() {
+            return system$c.get$length$yObserved();
+        }
+    };
+
+    /**
+     * Observed variable representing yObserved of type double[] from the Sandwood model 
+     */
+    public final ObservedDoubleArrayShapeable yObserved = $yObserved;
+
+    private Map<String, ObservedVariableInternal> $regularObservedValues = new HashMap<>();
+    private Map<String, ObservedVariableShapeableInternal<?>> $shapedObservedValues = new HashMap<>();
+    private final RandomVariableInternal $componentDistribution = new RandomVariableInternal(this, "componentDistribution", ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double getCurrentLogProbability() {
+            return system$c.get$logProbability$componentDistribution();
+        }
+    };
+
+    /**
+     * Random variable representing componentDistribution from the Sandwood model 
+     */
+    public final RandomVariable componentDistribution = $componentDistribution;
+
+    private HasProbabilityInternal[] $probabilityVariables = {$component, $mu, $rawMu, $sigma, $theta, $y, $componentDistribution};
+
+    //Constructors
+    /**
+     * A constructor for a model where no variable values are set.
+     */
+    public LowDimMix() {
+        super();
+        //ComputedVariable
+        $computedVariables.put("component", $component);
+        $computedVariables.put("mu", $mu);
+        $computedVariables.put("rawMu", $rawMu);
+        $computedVariables.put("sigma", $sigma);
+        $computedVariables.put("theta", $theta);
+        $computedVariables.put("y", $y);
+
+        //Observed array fields
+        $shapedObservedValues.put("yObserved", $yObserved);
+        init(system$c, $modelInputs, $regularObservedValues, $shapedObservedValues, $computedVariables, $probabilityVariables);
+    }
+    /**
+      * A constructor to set all the required values in the model to infer values. These
+      * will be values in an untrained model so this will only generate values from the
+      * default distributions described in the model.
+      * @param yObservedShape An integer array describing the shape of variable yObserved to use in the model when generating results.
+      */
+
+    public LowDimMix(int yObservedShape) {
+        this();
+        this.$yObserved.setShape(yObservedShape);
+    }
+    /**
+      * A constructor to set all the required values in the model to infer the model
+      * parameters, or to generate probabilities for the model.
+      * @param yObserved The value to set yObserved to.
+      */
+
+    public LowDimMix(double[] yObserved) {
+        this();
+        this.yObserved.setValue(yObserved);
+    }
+    
+    @Override
+    protected LowDimMix$CoreInterface setExecutionTargetInternal(ExecutionTarget target) {
+        LowDimMix$CoreInterface newCore;
+        switch(target.executionType) {
+            case SingleThreadCPU:
+                newCore = new LowDimMix$SingleThreadCPU(target);
+                break;
+            case MultiThreadCPU:
+                newCore = new LowDimMix$MultiThreadCPU(target);
+                break;
+            default:
+                throw new SandwoodException("Unsupported execution type: " + target);
+        }
+        transferData(system$c, newCore);
+        system$c = newCore;
+        return newCore;
+    }
+
+    private void transferData(LowDimMix$CoreInterface oldCore, LowDimMix$CoreInterface newCore) {
+
+        //Observed arrays
+        if(yObserved.isSet()) {
+            newCore.set$yObserved(oldCore.get$yObserved(), false);
+            newCore.set$length$yObserved(oldCore.get$length$yObserved(), false);
+        }
+        else if(yObserved.shapeSet())
+            newCore.set$length$yObserved(oldCore.get$length$yObserved(), false);
+
+        //ComputedVariables
+        if($component.isSet())
+            newCore.set$component(oldCore.get$component(), false);
+        if($rawMu.isSet())
+            newCore.set$rawMu(oldCore.get$rawMu(), false);
+        if($sigma.isSet())
+            newCore.set$sigma(oldCore.get$sigma(), false);
+        if($theta.isSet())
+            newCore.set$theta(oldCore.get$theta(), false);
+
+        //Set fixed flags
+        newCore.set$fixedFlag$sample101(oldCore.get$fixedFlag$sample101(), false);
+        newCore.set$fixedFlag$sample20(oldCore.get$fixedFlag$sample20(), false);
+        newCore.set$fixedFlag$sample83(oldCore.get$fixedFlag$sample83(), false);
+        newCore.set$fixedFlag$sample88(oldCore.get$fixedFlag$sample88(), false);
+    }
+
+    /**
+     * A class to hold all the values required to perform a value inference on the model.
+     */
+    public static class InferValueInputs {
+        /** Field holding the shape of model input yObserved */
+        public final int yObservedShape;
+
+        /**
+          * A constructor taking all the values required to set up the model to infer variables.
+          * @param yObservedShape An integer array describing the shape of variable yObserved to use in the model when generating results.
+          */
+        public InferValueInputs(int yObservedShape) {
+            this.yObservedShape = yObservedShape;
+        }
+    }
+
+    /**
+     * A class to hold all the inputs for the model. It can be used to parameterize inference of the model probabilities
+     * and probability calculations.
+     */
+    public static class AllInputs {
+        /** Field holding the value of model input yObserved */
+        public final double[] yObserved;
+
+        /**
+          * A constructor to take all the required values by the model to infer the model
+          * parameters, or to generate probabilities for the model.
+          * @param yObserved The value to set yObserved to.
+          */
+        public AllInputs(double[] yObserved) {
+            this.yObserved = yObserved;
+        }
+    }
+
+    /**
+     * A class to hold all the outputs from the model after an infer values step.
+     */
+    public static class InferredValueOutputs {
+        /** Field holding the value of component after a convention execution step.*/
+        public final boolean[] component;
+        /** Field holding the value of mu after a convention execution step.*/
+        public final double[] mu;
+        /** Field holding the value of rawMu after a convention execution step.*/
+        public final double[] rawMu;
+        /** Field holding the value of sigma after a convention execution step.*/
+        public final double[] sigma;
+        /** Field holding the value of theta after a convention execution step.*/
+        public final double theta;
+        /** Field holding the value of y after a convention execution step.*/
+        public final double[] y;
+
+        InferredValueOutputs(LowDimMix system$model) {
+            this.component = system$model.component.getSamples()[0];
+            this.mu = system$model.mu.getSamples()[0];
+            this.rawMu = system$model.rawMu.getSamples()[0];
+            this.sigma = system$model.sigma.getSamples()[0];
+            this.theta = system$model.theta.getSamples()[0];
+            this.y = system$model.y.getSamples()[0];
+        }
+    }
+
+    /**
+     * A class to hold all the probabilities from the model after a generate probabilities step.
+     */
+    public static class LogProbabilities {
+        private final double $logModelProbability;
+        /** Field holding the log probability of random variable componentDistribution */
+        public final double componentDistribution;
+        /** Field holding the log probability of computed variable component */
+        public final double component;
+        /** Field holding the log probability of computed variable mu */
+        public final double mu;
+        /** Field holding the log probability of computed variable rawMu */
+        public final double rawMu;
+        /** Field holding the log probability of computed variable sigma */
+        public final double sigma;
+        /** Field holding the log probability of computed variable theta */
+        public final double theta;
+        /** Field holding the log probability of computed variable y */
+        public final double y;
+
+        LogProbabilities(LowDimMix system$model) {
+            this.$logModelProbability = system$model.getLogProbability();
+            this.componentDistribution = system$model.componentDistribution.getLogProbability();
+            this.component = system$model.component.getLogProbability();
+            this.mu = system$model.mu.getLogProbability();
+            this.rawMu = system$model.rawMu.getLogProbability();
+            this.sigma = system$model.sigma.getLogProbability();
+            this.theta = system$model.theta.getLogProbability();
+            this.y = system$model.y.getLogProbability();
+        }
+
+        /** Method to return log probability of the whole model 
+         *  @return The log probability of the whole model. */
+        public double getModelProbability() { return $logModelProbability; }
+    }
+
+    /**
+     * A class to hold all the probabilities from the model after a generate probabilities step.
+     */
+    public static class Probabilities {
+        private final double $modelProbability;
+        /** Field holding the probability of random variable componentDistribution */
+        public final double componentDistribution;
+        /** Field holding the probability of computed variable component */
+        public final double component;
+        /** Field holding the probability of computed variable mu */
+        public final double mu;
+        /** Field holding the probability of computed variable rawMu */
+        public final double rawMu;
+        /** Field holding the probability of computed variable sigma */
+        public final double sigma;
+        /** Field holding the probability of computed variable theta */
+        public final double theta;
+        /** Field holding the probability of computed variable y */
+        public final double y;
+
+        Probabilities(LowDimMix system$model) {
+            this.$modelProbability = system$model.getProbability();
+            this.componentDistribution = system$model.componentDistribution.getProbability();
+            this.component = system$model.component.getProbability();
+            this.mu = system$model.mu.getProbability();
+            this.rawMu = system$model.rawMu.getProbability();
+            this.sigma = system$model.sigma.getProbability();
+            this.theta = system$model.theta.getProbability();
+            this.y = system$model.y.getProbability();
+        }
+
+        /** Method to return probability of the whole model 
+         *  @return The probability of the whole model. */
+        public double getModelProbability() { return $modelProbability; }
+    }
+
+    /**
+     * A class to hold all the outputs from the model after an infer model call.
+     */
+    public static class InferredModelOutputs {
+        /** Field holding the MAP or Sample value of component after an infer model call. */
+        public final boolean[][] component;
+        /** Field holding the MAP or Sample value of mu after an infer model call. */
+        public final double[][] mu;
+        /** Field holding the MAP or Sample value of rawMu after an infer model call. */
+        public final double[][] rawMu;
+        /** Field holding the MAP or Sample value of sigma after an infer model call. */
+        public final double[][] sigma;
+        /** Field holding the MAP or Sample value of theta after an infer model call. */
+        public final double[] theta;
+
+        InferredModelOutputs(LowDimMix system$model) {
+            this.component = system$model.getInferredValue(system$model.$component);
+            this.mu = system$model.getInferredValue(system$model.$mu);
+            this.rawMu = system$model.getInferredValue(system$model.$rawMu);
+            this.sigma = system$model.getInferredValue(system$model.$sigma);
+            this.theta = system$model.getInferredValue(system$model.$theta);
+        }
+    }
+
+    /**
+     * Perform a single pass generating values from the model.
+     * @param inputs An object containing the parameters required to run inference on the model.
+     * @return An object containing the values computed by the inference step.
+     */
+    public InferredValueOutputs execute(InferValueInputs inputs) {
+        this.$yObserved.setShape(inputs.yObservedShape);
+        execute();
+        return new InferredValueOutputs(this);
+    }
+
+    /**
+     * Infer the values of the different elements of the model.
+     * @param iterations The number of iterations to perform when inferring the values.
+     * @param inputs An object containing the parameters required to generate the model parameters.
+     * @return An object containing the computed values for the model.
+     */
+    public InferredModelOutputs inferValues(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferValues(iterations);
+        return new InferredModelOutputs(this);
+    }
+
+    /**
+     * Generate the probabilities of the different elements of the model.
+     * @param iterations How many iterations should be used to generate these values?
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(iterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Calculate the probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(double variance, int initialIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Calculate the probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param maxIterations The maximum number of iterations a that can be used to calculate the probabilities. If the model has not
+     * converged by this point the calculation will terminate anyway, and the result generated so far will be returned.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(double variance, int initialIterations, int maxIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations, maxIterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Generate the log probabilities of the different elements of the model.
+     * @param iterations How many iterations should be used to generate these values?
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(iterations);
+        return new LogProbabilities(this);
+    }
+
+    /**
+     * Calculate the log probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(double variance, int initialIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations);
+        return new LogProbabilities(this);
+    }
+
+    /**
+     * Calculate the log probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param maxIterations The maximum number of iterations a that can be used to calculate the probabilities. If the model has not
+     * converged by this point the calculation will terminate anyway, and the result generated so far will be returned.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(double variance, int initialIterations, int maxIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations, maxIterations);
+        return new LogProbabilities(this);
+    }
+}
+//END OF CODE

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix_optimisedModelSingle.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/LowDimMix_optimisedModelSingle.java
@@ -1,0 +1,632 @@
+package org.sandwood.compiler.tests.parser;
+
+import org.sandwood.runtime.model.Model;
+import org.sandwood.runtime.model.ExecutionTarget;
+import org.sandwood.runtime.model.variables.*;
+import org.sandwood.runtime.internal.model.variables.*;
+import org.sandwood.runtime.internal.model.variables.probability.ProbabilityType;
+import org.sandwood.common.exceptions.SandwoodException;
+import org.sandwood.runtime.exceptions.SandwoodRuntimeException;
+
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+  * Class representing the Sandwood model LowDimMix This is the class that
+  * all user interactions with the model should occur through.
+  */
+public final class LowDimMix extends Model {
+
+    private LowDimMix$CoreInterface system$c = new LowDimMix$SingleThreadCPU(ExecutionTarget.singleThread);
+
+    private final ComputedBooleanArrayInternal $component = new ComputedBooleanArrayInternal(this, "component", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public boolean[] getValue() { return system$c.get$component(); }
+
+        @Override
+        protected void setValueInternal(boolean[] value) {
+            system$c.set$component(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$component(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample101(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample101())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing component of type boolean[] from the Sandwood model 
+     */
+    public final ComputedBooleanArray component = $component;
+
+    private final ComputedDoubleArrayInternal $mu = new ComputedDoubleArrayInternal(this, "mu", false, false, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$mu(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {}
+
+        @Override
+        protected void testSettable() {
+            throw new SandwoodException("Set is not available for variable mu because its value depends on variable \"rawMu\".");
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$mu(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample20(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample20())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing mu of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray mu = $mu;
+
+    private final ComputedDoubleArrayInternal $rawMu = new ComputedDoubleArrayInternal(this, "rawMu", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$rawMu(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {
+            system$c.set$rawMu(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$rawMu(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample20(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample20())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing rawMu of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray rawMu = $rawMu;
+
+    private final ComputedDoubleArrayInternal $sigma = new ComputedDoubleArrayInternal(this, "sigma", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$sigma(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {
+            system$c.set$sigma(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$sigma(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample83(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample83())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing sigma of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray sigma = $sigma;
+
+    private final ComputedDoubleInternal $theta = new ComputedDoubleInternal(this, "theta", true, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double getValue() { return system$c.get$theta(); }
+
+        @Override
+        protected void setValueInternal(double value) {
+            system$c.set$theta(value, allocated);
+            intermediatesPrimed = false;
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$theta(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            synchronized(model) {
+                system$c.set$fixedFlag$sample88(fixed, allocated);
+            }
+        }
+
+        @Override
+        public Immutability isFixed() {
+            if(system$c.get$fixedFlag$sample88())
+                return Immutability.FIXED;
+            else
+                return Immutability.FREE;
+        }
+    };
+
+    /**
+     * Computed variable representing theta of type double from the Sandwood model 
+     */
+    public final ComputedDouble theta = $theta;
+
+    private final ComputedDoubleArrayInternal $y = new ComputedDoubleArrayInternal(this, "y", false, true, false, ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double[] getValue() { return system$c.get$y(); }
+
+        @Override
+        protected void setValueInternal(double[] value) {}
+
+        @Override
+        protected void testSettable() {
+            throw new SandwoodException("Set is not available for variable y because it is fixed by observing a variable.");
+        }
+
+        @Override
+        public double getCurrentLogProbability() { return system$c.get$logProbability$y(); }
+
+        @Override
+        public void setFixed(boolean fixed) {
+            throw new SandwoodException("An observed variable can only have the value fixed to the observed value if the value is consumed by another random variable.");
+        }
+
+        @Override
+        public Immutability isFixed() {
+            return Immutability.OBSERVED;
+        }
+    };
+
+    /**
+     * Computed variable representing y of type double[] from the Sandwood model 
+     */
+    public final ComputedDoubleArray y = $y;
+
+	private Map<String, ComputedVariableInternal> $computedVariables = new HashMap<>();
+
+    private Map<String, ObservedVariableInternal> $modelInputs = new HashMap<>();
+
+    private final ObservedDoubleArrayShapeableInternal $yObserved = new ObservedDoubleArrayShapeableInternal(this, "yObserved") {
+        @Override
+        public double[] getValue() {
+            synchronized(model) {
+                return system$c.get$yObserved();
+            }
+        }
+
+        @Override
+        public void setValueInternal(double[] value) {
+            system$c.set$yObserved(value, allocated);
+            system$c.set$length$yObserved(value.length, allocated);
+        }
+
+        @Override
+        public void setShapeInternal(int shape) {
+            system$c.set$length$yObserved(shape, allocated);
+        }
+
+        @Override
+        public int getShape() {
+            return system$c.get$length$yObserved();
+        }
+    };
+
+    /**
+     * Observed variable representing yObserved of type double[] from the Sandwood model 
+     */
+    public final ObservedDoubleArrayShapeable yObserved = $yObserved;
+
+    private Map<String, ObservedVariableInternal> $regularObservedValues = new HashMap<>();
+    private Map<String, ObservedVariableShapeableInternal<?>> $shapedObservedValues = new HashMap<>();
+    private final RandomVariableInternal $componentDistribution = new RandomVariableInternal(this, "componentDistribution", ProbabilityType.UNSKIPPABLE) {
+        @Override
+        public double getCurrentLogProbability() {
+            return system$c.get$logProbability$componentDistribution();
+        }
+    };
+
+    /**
+     * Random variable representing componentDistribution from the Sandwood model 
+     */
+    public final RandomVariable componentDistribution = $componentDistribution;
+
+    private HasProbabilityInternal[] $probabilityVariables = {$component, $mu, $rawMu, $sigma, $theta, $y, $componentDistribution};
+
+    //Constructors
+    /**
+     * A constructor for a model where no variable values are set.
+     */
+    public LowDimMix() {
+        super();
+        //ComputedVariable
+        $computedVariables.put("component", $component);
+        $computedVariables.put("mu", $mu);
+        $computedVariables.put("rawMu", $rawMu);
+        $computedVariables.put("sigma", $sigma);
+        $computedVariables.put("theta", $theta);
+        $computedVariables.put("y", $y);
+
+        //Observed array fields
+        $shapedObservedValues.put("yObserved", $yObserved);
+        init(system$c, $modelInputs, $regularObservedValues, $shapedObservedValues, $computedVariables, $probabilityVariables);
+    }
+    /**
+      * A constructor to set all the required values in the model to infer values. These
+      * will be values in an untrained model so this will only generate values from the
+      * default distributions described in the model.
+      * @param yObservedShape An integer array describing the shape of variable yObserved to use in the model when generating results.
+      */
+
+    public LowDimMix(int yObservedShape) {
+        this();
+        this.$yObserved.setShape(yObservedShape);
+    }
+    /**
+      * A constructor to set all the required values in the model to infer the model
+      * parameters, or to generate probabilities for the model.
+      * @param yObserved The value to set yObserved to.
+      */
+
+    public LowDimMix(double[] yObserved) {
+        this();
+        this.yObserved.setValue(yObserved);
+    }
+    
+    @Override
+    protected LowDimMix$CoreInterface setExecutionTargetInternal(ExecutionTarget target) {
+        LowDimMix$CoreInterface newCore;
+        switch(target.executionType) {
+            case SingleThreadCPU:
+                newCore = new LowDimMix$SingleThreadCPU(target);
+                break;
+            case MultiThreadCPU:
+                newCore = new LowDimMix$MultiThreadCPU(target);
+                break;
+            default:
+                throw new SandwoodException("Unsupported execution type: " + target);
+        }
+        transferData(system$c, newCore);
+        system$c = newCore;
+        return newCore;
+    }
+
+    private void transferData(LowDimMix$CoreInterface oldCore, LowDimMix$CoreInterface newCore) {
+
+        //Observed arrays
+        if(yObserved.isSet()) {
+            newCore.set$yObserved(oldCore.get$yObserved(), false);
+            newCore.set$length$yObserved(oldCore.get$length$yObserved(), false);
+        }
+        else if(yObserved.shapeSet())
+            newCore.set$length$yObserved(oldCore.get$length$yObserved(), false);
+
+        //ComputedVariables
+        if($component.isSet())
+            newCore.set$component(oldCore.get$component(), false);
+        if($rawMu.isSet())
+            newCore.set$rawMu(oldCore.get$rawMu(), false);
+        if($sigma.isSet())
+            newCore.set$sigma(oldCore.get$sigma(), false);
+        if($theta.isSet())
+            newCore.set$theta(oldCore.get$theta(), false);
+
+        //Set fixed flags
+        newCore.set$fixedFlag$sample101(oldCore.get$fixedFlag$sample101(), false);
+        newCore.set$fixedFlag$sample20(oldCore.get$fixedFlag$sample20(), false);
+        newCore.set$fixedFlag$sample83(oldCore.get$fixedFlag$sample83(), false);
+        newCore.set$fixedFlag$sample88(oldCore.get$fixedFlag$sample88(), false);
+    }
+
+    /**
+     * A class to hold all the values required to perform a value inference on the model.
+     */
+    public static class InferValueInputs {
+        /** Field holding the shape of model input yObserved */
+        public final int yObservedShape;
+
+        /**
+          * A constructor taking all the values required to set up the model to infer variables.
+          * @param yObservedShape An integer array describing the shape of variable yObserved to use in the model when generating results.
+          */
+        public InferValueInputs(int yObservedShape) {
+            this.yObservedShape = yObservedShape;
+        }
+    }
+
+    /**
+     * A class to hold all the inputs for the model. It can be used to parameterize inference of the model probabilities
+     * and probability calculations.
+     */
+    public static class AllInputs {
+        /** Field holding the value of model input yObserved */
+        public final double[] yObserved;
+
+        /**
+          * A constructor to take all the required values by the model to infer the model
+          * parameters, or to generate probabilities for the model.
+          * @param yObserved The value to set yObserved to.
+          */
+        public AllInputs(double[] yObserved) {
+            this.yObserved = yObserved;
+        }
+    }
+
+    /**
+     * A class to hold all the outputs from the model after an infer values step.
+     */
+    public static class InferredValueOutputs {
+        /** Field holding the value of component after a convention execution step.*/
+        public final boolean[] component;
+        /** Field holding the value of mu after a convention execution step.*/
+        public final double[] mu;
+        /** Field holding the value of rawMu after a convention execution step.*/
+        public final double[] rawMu;
+        /** Field holding the value of sigma after a convention execution step.*/
+        public final double[] sigma;
+        /** Field holding the value of theta after a convention execution step.*/
+        public final double theta;
+        /** Field holding the value of y after a convention execution step.*/
+        public final double[] y;
+
+        InferredValueOutputs(LowDimMix system$model) {
+            this.component = system$model.component.getSamples()[0];
+            this.mu = system$model.mu.getSamples()[0];
+            this.rawMu = system$model.rawMu.getSamples()[0];
+            this.sigma = system$model.sigma.getSamples()[0];
+            this.theta = system$model.theta.getSamples()[0];
+            this.y = system$model.y.getSamples()[0];
+        }
+    }
+
+    /**
+     * A class to hold all the probabilities from the model after a generate probabilities step.
+     */
+    public static class LogProbabilities {
+        private final double $logModelProbability;
+        /** Field holding the log probability of random variable componentDistribution */
+        public final double componentDistribution;
+        /** Field holding the log probability of computed variable component */
+        public final double component;
+        /** Field holding the log probability of computed variable mu */
+        public final double mu;
+        /** Field holding the log probability of computed variable rawMu */
+        public final double rawMu;
+        /** Field holding the log probability of computed variable sigma */
+        public final double sigma;
+        /** Field holding the log probability of computed variable theta */
+        public final double theta;
+        /** Field holding the log probability of computed variable y */
+        public final double y;
+
+        LogProbabilities(LowDimMix system$model) {
+            this.$logModelProbability = system$model.getLogProbability();
+            this.componentDistribution = system$model.componentDistribution.getLogProbability();
+            this.component = system$model.component.getLogProbability();
+            this.mu = system$model.mu.getLogProbability();
+            this.rawMu = system$model.rawMu.getLogProbability();
+            this.sigma = system$model.sigma.getLogProbability();
+            this.theta = system$model.theta.getLogProbability();
+            this.y = system$model.y.getLogProbability();
+        }
+
+        /** Method to return log probability of the whole model 
+         *  @return The log probability of the whole model. */
+        public double getModelProbability() { return $logModelProbability; }
+    }
+
+    /**
+     * A class to hold all the probabilities from the model after a generate probabilities step.
+     */
+    public static class Probabilities {
+        private final double $modelProbability;
+        /** Field holding the probability of random variable componentDistribution */
+        public final double componentDistribution;
+        /** Field holding the probability of computed variable component */
+        public final double component;
+        /** Field holding the probability of computed variable mu */
+        public final double mu;
+        /** Field holding the probability of computed variable rawMu */
+        public final double rawMu;
+        /** Field holding the probability of computed variable sigma */
+        public final double sigma;
+        /** Field holding the probability of computed variable theta */
+        public final double theta;
+        /** Field holding the probability of computed variable y */
+        public final double y;
+
+        Probabilities(LowDimMix system$model) {
+            this.$modelProbability = system$model.getProbability();
+            this.componentDistribution = system$model.componentDistribution.getProbability();
+            this.component = system$model.component.getProbability();
+            this.mu = system$model.mu.getProbability();
+            this.rawMu = system$model.rawMu.getProbability();
+            this.sigma = system$model.sigma.getProbability();
+            this.theta = system$model.theta.getProbability();
+            this.y = system$model.y.getProbability();
+        }
+
+        /** Method to return probability of the whole model 
+         *  @return The probability of the whole model. */
+        public double getModelProbability() { return $modelProbability; }
+    }
+
+    /**
+     * A class to hold all the outputs from the model after an infer model call.
+     */
+    public static class InferredModelOutputs {
+        /** Field holding the MAP or Sample value of component after an infer model call. */
+        public final boolean[][] component;
+        /** Field holding the MAP or Sample value of mu after an infer model call. */
+        public final double[][] mu;
+        /** Field holding the MAP or Sample value of rawMu after an infer model call. */
+        public final double[][] rawMu;
+        /** Field holding the MAP or Sample value of sigma after an infer model call. */
+        public final double[][] sigma;
+        /** Field holding the MAP or Sample value of theta after an infer model call. */
+        public final double[] theta;
+
+        InferredModelOutputs(LowDimMix system$model) {
+            this.component = system$model.getInferredValue(system$model.$component);
+            this.mu = system$model.getInferredValue(system$model.$mu);
+            this.rawMu = system$model.getInferredValue(system$model.$rawMu);
+            this.sigma = system$model.getInferredValue(system$model.$sigma);
+            this.theta = system$model.getInferredValue(system$model.$theta);
+        }
+    }
+
+    /**
+     * Perform a single pass generating values from the model.
+     * @param inputs An object containing the parameters required to run inference on the model.
+     * @return An object containing the values computed by the inference step.
+     */
+    public InferredValueOutputs execute(InferValueInputs inputs) {
+        this.$yObserved.setShape(inputs.yObservedShape);
+        execute();
+        return new InferredValueOutputs(this);
+    }
+
+    /**
+     * Infer the values of the different elements of the model.
+     * @param iterations The number of iterations to perform when inferring the values.
+     * @param inputs An object containing the parameters required to generate the model parameters.
+     * @return An object containing the computed values for the model.
+     */
+    public InferredModelOutputs inferValues(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferValues(iterations);
+        return new InferredModelOutputs(this);
+    }
+
+    /**
+     * Generate the probabilities of the different elements of the model.
+     * @param iterations How many iterations should be used to generate these values?
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(iterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Calculate the probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(double variance, int initialIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Calculate the probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param maxIterations The maximum number of iterations a that can be used to calculate the probabilities. If the model has not
+     * converged by this point the calculation will terminate anyway, and the result generated so far will be returned.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public Probabilities inferProbabilities(double variance, int initialIterations, int maxIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations, maxIterations);
+        return new Probabilities(this);
+    }
+
+    /**
+     * Generate the log probabilities of the different elements of the model.
+     * @param iterations How many iterations should be used to generate these values?
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(int iterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(iterations);
+        return new LogProbabilities(this);
+    }
+
+    /**
+     * Calculate the log probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(double variance, int initialIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations);
+        return new LogProbabilities(this);
+    }
+
+    /**
+     * Calculate the log probability of each variable and the overall model. This method
+     * will iterate until the variance of the overall model drops below the value provide 
+     * for variance, or the maximum number of iterations is reached.
+     * @param variance The maximum variance in the models overall probability.
+     * @param initialIterations The number of iterations to use to start with. Having too low a value here can result in
+     * premature termination as the model may not have enough runs to estimate the variance accurately.
+     * @param maxIterations The maximum number of iterations a that can be used to calculate the probabilities. If the model has not
+     * converged by this point the calculation will terminate anyway, and the result generated so far will be returned.
+     * @param inputs An object containing the parameters required to generate the probabilities of the model.
+     * @return An object containing the computed probabilities for the model.
+     */
+    public LogProbabilities inferLogProbabilities(double variance, int initialIterations, int maxIterations, AllInputs inputs) {
+        this.$yObserved.setValue(inputs.yObserved);
+        inferProbabilities(variance, initialIterations, maxIterations);
+        return new LogProbabilities(this);
+    }
+}
+//END OF CODE

--- a/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/api.java
+++ b/Sandwood/compiler/src/test/resources/expectedOutputs/parser/ParserTest/LowDimMix/api.java
@@ -1,0 +1,134 @@
+package org.sandwood.compiler.tests.parser;
+
+import static org.sandwood.compiler.dataflowGraph.Sandwood.*;
+import static org.sandwood.compiler.dataflowGraph.Math.*;
+import static org.sandwood.compiler.dataflowGraph.Number.*;
+import static org.sandwood.compiler.dataflowGraph.variables.Variable.*;
+
+import org.sandwood.compiler.dataflowGraph.scopes.IfScope;
+import org.sandwood.compiler.dataflowGraph.variables.randomVariables.*;
+import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.*;
+import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.*;
+import org.sandwood.compiler.dataflowGraph.variables.VariableType;
+import org.sandwood.compiler.dataflowGraph.variables.Variable;
+import org.sandwood.compiler.srcTools.sourceToSource.Location;
+
+import org.sandwood.compiler.CompilationOptions;
+import org.sandwood.compiler.compilation.GeneratedAPIBuilder;
+import org.sandwood.compiler.compilation.util.CompilationDesc;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+
+public class LowDimMix extends GeneratedAPIBuilder {
+    @Override
+    public CompilationDesc buildClass(CompilationOptions opts) {
+        //Allocating initial observed parameters
+        ArrayVariable<DoubleVariable> yObserved = observeArray("yObserved", VariableType.arrayType(VariableType.DoubleVariable), location(11, 24, 11, 41));
+
+        IntVariable N = yObserved.length(location(12, 23, 12, 28));
+        N.setAlias("N");
+        N.setLocation(location(12, 9, 12, 9));
+
+        ArrayVariable<DoubleVariable> rawMu = gaussian(doubleVariable(0.0, location(17, 31, 17, 33)), doubleVariable(2.0, location(17, 36, 17, 38)).times(doubleVariable(2.0, location(17, 42, 17, 44)), location(17, 40, 17, 40)), location(17, 22, 17, 45)).sample(intVariable(2, location(17, 54, 17, 54)), location(17, 47, 17, 55));
+        rawMu.setAlias("rawMu");
+        rawMu.setLocation(location(17, 14, 17, 18));
+
+        ArrayVariable<DoubleVariable> mu = Variable.arrayVariable(location(18, 29, 18, 31), VariableType.DoubleVariable, intVariable(2, location(18, 30, 18, 30)));
+        mu.setAlias("mu");
+        mu.setLocation(location(18, 14, 18, 15));
+
+        mu.put(intVariable(0, location(19, 8, 19, 8)), ifElseLambdaAssignment(rawMu.get(intVariable(0, location(19, 19, 19, 19)), location(19, 18, 19, 20)).lessThan(rawMu.get(intVariable(1, location(19, 30, 19, 30)), location(19, 29, 19, 31)), location(19, 22, 19, 22)), () -> { return rawMu.get(intVariable(0, location(19, 41, 19, 41)), location(19, 40, 19, 42)); }, () -> { return rawMu.get(intVariable(1, location(19, 52, 19, 52)), location(19, 51, 19, 53)); }, location(19, 13, 19, 53)), location(19, 7, 19, 53));
+        mu.put(intVariable(1, location(20, 8, 20, 8)), ifElseLambdaAssignment(rawMu.get(intVariable(0, location(20, 19, 20, 19)), location(20, 18, 20, 20)).lessThan(rawMu.get(intVariable(1, location(20, 30, 20, 30)), location(20, 29, 20, 31)), location(20, 22, 20, 22)), () -> { return rawMu.get(intVariable(1, location(20, 41, 20, 41)), location(20, 40, 20, 42)); }, () -> { return rawMu.get(intVariable(0, location(20, 52, 20, 52)), location(20, 51, 20, 53)); }, location(20, 13, 20, 53)), location(20, 7, 20, 53));
+        ArrayVariable<DoubleVariable> sigma = truncatedGaussian(doubleVariable(0.0, location(23, 40, 23, 42)), doubleVariable(2.0, location(23, 45, 23, 47)).times(doubleVariable(2.0, location(23, 51, 23, 53)), location(23, 49, 23, 49)), doubleVariable(0.0, location(23, 56, 23, 58)), doubleVariable(1.0e100, location(23, 61, 23, 67)), location(23, 22, 23, 68)).sample(intVariable(2, location(23, 77, 23, 77)), location(23, 70, 23, 78));
+        sigma.setAlias("sigma");
+        sigma.setLocation(location(23, 14, 23, 18));
+
+        DoubleVariable theta = beta(doubleVariable(5.0, location(26, 25, 26, 27)), doubleVariable(5.0, location(26, 30, 26, 32)), location(26, 20, 26, 33)).sample(location(26, 35, 26, 42));
+        theta.setAlias("theta");
+        theta.setLocation(location(26, 12, 26, 16));
+
+        Bernoulli componentDistribution = bernoulli(theta, location(32, 39, 32, 54));
+        componentDistribution.setAlias("componentDistribution");
+        componentDistribution.setLocation(location(32, 15, 32, 35));
+
+        ArrayVariable<BooleanVariable> component = componentDistribution.sample(N, location(33, 49, 33, 57));
+        component.setAlias("component");
+        component.setLocation(location(33, 15, 33, 23));
+
+        ArrayVariable<DoubleVariable> y = Variable.arrayVariable(location(34, 28, 34, 30), VariableType.DoubleVariable, N);
+        y.setAlias("y");
+        y.setLocation(location(34, 14, 34, 14));
+
+        parFor(intVariable(0, location(36, 17, 36, 17)), N, intVariable(1, location(36, 27, 36, 29)), true, location(36, 5, 36, 30), (n) -> {
+            n.setAlias("n");
+            n.setLocation(location(36, 13, 36, 13));
+            DoubleVariable componentMu = ifElseLambdaAssignment(component.get(n, location(37, 39, 37, 41)), () -> { return mu.get(intVariable(0, location(37, 48, 37, 48)), location(37, 47, 37, 49)); }, () -> { return mu.get(intVariable(1, location(37, 56, 37, 56)), location(37, 55, 37, 57)); }, location(37, 30, 37, 57));
+            componentMu.setAlias("componentMu");
+            componentMu.setLocation(location(37, 16, 37, 26));
+
+            DoubleVariable componentSigma = ifElseLambdaAssignment(component.get(n, location(38, 42, 38, 44)), () -> { return sigma.get(intVariable(0, location(38, 54, 38, 54)), location(38, 53, 38, 55)); }, () -> { return sigma.get(intVariable(1, location(38, 65, 38, 65)), location(38, 64, 38, 66)); }, location(38, 33, 38, 66));
+            componentSigma.setAlias("componentSigma");
+            componentSigma.setLocation(location(38, 16, 38, 29));
+
+            y.put(n, gaussian(componentMu, componentSigma.times(componentSigma, location(39, 53, 39, 53)), location(39, 16, 39, 69)).sample(location(39, 71, 39, 78)), location(39, 10, 39, 78));
+
+        });
+
+        y.observe(yObserved, location(42, 7, 42, 24));
+
+        Variable<?>[] $variableNames = {yObserved, N, rawMu, mu, sigma, theta, componentDistribution, component, y};
+        String[] $constructorArgs = {"yObserved"};
+        Set<String> $helperClasses = new HashSet<>();
+        return compileAPI(opts, $variableNames, "LowDimMix", $helperClasses, "org.sandwood.compiler.tests.parser", $constructorArgs, getOriginalModel(), null);
+    }
+
+    private static String getOriginalModel() {
+        return "/*\n"
+             + " * Sandwood\n"
+             + " *\n"
+             + " * Copyright (c) 2019-2026, Oracle and/or its affiliates\n"
+             + " * \n"
+             + " * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/\n"
+             + " */\n"
+             + "\n"
+             + "package org.sandwood.compiler.tests.parser;\n"
+             + "\n"
+             + "public model LowDimMix(double[] yObserved) {\n"
+             + "    int N = yObserved.length;\n"
+             + "\n"
+             + "    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)\n"
+             + "    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to\n"
+             + "    // the constant normalisation factor for the ordered constraint.\n"
+             + "    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);\n"
+             + "    double[] mu = new double[2];\n"
+             + "    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];\n"
+             + "    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];\n"
+             + "\n"
+             + "    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)\n"
+             + "    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);\n"
+             + "\n"
+             + "    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)\n"
+             + "    double theta = beta(5.0, 5.0).sample();\n"
+             + "\n"
+             + "    // Stan likelihood:\n"
+             + "    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),\n"
+             + "    //                   normal_lpdf(y[n] | mu[2], sigma[2]));\n"
+             + "    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.\n"
+             + "    Bernoulli componentDistribution = bernoulli(theta);\n"
+             + "    boolean[] component = componentDistribution.sample(N);\n"
+             + "    double[] y = new double[N];\n"
+             + "\n"
+             + "    for(int n = 0; n < N; n++) {\n"
+             + "        double componentMu = component[n] ? mu[0] : mu[1];\n"
+             + "        double componentSigma = component[n] ? sigma[0] : sigma[1];\n"
+             + "        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();\n"
+             + "    }\n"
+             + "\n"
+             + "    y.observe(yObserved);\n"
+             + "}\n"
+             + "";
+    }
+}

--- a/Sandwood/compiler/src/test/resources/testInputs/org/sandwood/compiler/tests/parser/LowDimMix.sandwood
+++ b/Sandwood/compiler/src/test/resources/testInputs/org/sandwood/compiler/tests/parser/LowDimMix.sandwood
@@ -1,0 +1,43 @@
+/*
+ * Sandwood
+ *
+ * Copyright (c) 2019-2026, Oracle and/or its affiliates
+ * 
+ * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package org.sandwood.compiler.tests.parser;
+
+public model LowDimMix(double[] yObserved) {
+    int N = yObserved.length;
+
+    // Stan parameter: ordered[2] mu; prior: mu ~ normal(0, 2)
+    // Sampling two unconstrained normal values and sorting them gives the same ordered support up to
+    // the constant normalisation factor for the ordered constraint.
+    double[] rawMu = gaussian(0.0, 2.0 * 2.0).sample(2);
+    double[] mu = new double[2];
+    mu[0] = rawMu[0] < rawMu[1] ? rawMu[0] : rawMu[1];
+    mu[1] = rawMu[0] < rawMu[1] ? rawMu[1] : rawMu[0];
+
+    // Stan parameter: array[2] real<lower=0> sigma; prior: sigma ~ normal(0, 2)
+    double[] sigma = truncatedGaussian(0.0, 2.0 * 2.0, 0.0, 1.0e100).sample(2);
+
+    // Stan parameter: real<lower=0, upper=1> theta; prior: theta ~ beta(5, 5)
+    double theta = beta(5.0, 5.0).sample();
+
+    // Stan likelihood:
+    // target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),
+    //                   normal_lpdf(y[n] | mu[2], sigma[2]));
+    // In Sandwood, represent the same two-component mixture with explicit latent component indicators.
+    Bernoulli componentDistribution = bernoulli(theta);
+    boolean[] component = componentDistribution.sample(N);
+    double[] y = new double[N];
+
+    for(int n = 0; n < N; n++) {
+        double componentMu = component[n] ? mu[0] : mu[1];
+        double componentSigma = component[n] ? sigma[0] : sigma[1];
+        y[n] = gaussian(componentMu, componentSigma * componentSigma).sample();
+    }
+
+    y.observe(yObserved);
+}


### PR DESCRIPTION
### Description
The was a bug in ScopeConstructor where when getting a threadID variable name, the scope that the name was based on was being selected incorrectly. Changing which task was being looked at from the most recent one to the first one resolves this issue.

At the same time a test was added to exercise the bug, and a field in one of the tests had its permissions tightened.