### PR TITLE
Adding types to variables descriptions so that global local and scratch accesses can be separated

### DIFF
--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/APICompile.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/APICompile.java
@@ -64,6 +64,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.arrayTasks.PutTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ForTask;
+import org.sandwood.compiler.dataflowGraph.variables.GlobalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableName;
@@ -191,7 +192,7 @@ public class APICompile {
                 ObservedValuePropagationBuilder.constructPropagateObservedValues(compilationCtx);
 
                 IRSandwoodClassGenerated irCls = new IRSandwoodClassGenerated(className.backendName(target),
-                        targetPackageName, ClassName.coreBase(target), interfaces, compilationCtx.getClassFields(),
+                        targetPackageName, ClassName.coreBase(target), interfaces, compilationCtx.getClassFields(), compilationCtx.getScratchFields(),
                         compilationCtx.getFunctions(), modelCode);
                 irClasses.put(target, irCls);
             }
@@ -297,34 +298,33 @@ public class APICompile {
 
         // Fixed sample flags
         for(SampleTask<?, ?> s:compilationCtx.traces.getFixableTasks()) {
-            VariableDescription<BooleanVariable> flagName = VariableNames.fixedFlagName(s);
+            GlobalVariableDescription<BooleanVariable> flagName = VariableNames.fixedFlagName(s);
             compilationCtx.addFlagClassField(flagName, constant(false));
         }
 
         // Constrained sample flags
         compilationCtx.pushIsSerial(true);
         for(SampleTask<?, ?> s:compilationCtx.traces.getAllIntermediateSamples()) {
-            VariableDescription<BooleanVariable> flagName = VariableNames.constrainedFlagName(s);
+            GlobalVariableDescription<BooleanVariable> flagName = VariableNames.constrainedFlagName(s);
             List<ScopeDesc> scopeDescs = TreeUtils.getScopeDescs(s);
             if(scopeDescs.size() == 1) {
-                compilationCtx.addConstructedClassField(flagName, constant(true));
+                compilationCtx.addInternalFlagClassField(flagName, constant(true));
 
                 if(compilationCtx.traces.isFixableTask(s)) {
-                    VariableDescription<BooleanVariable> fixedFlag = VariableNames.fixedFlagName(s);
+                    GlobalVariableDescription<BooleanVariable> fixedFlag = VariableNames.fixedFlagName(s);
                     compilationCtx.addSetSideEffect(fixedFlag,
                             store(flagName, or(load(fixedFlag), load(flagName)), Tree.NoComment));
                 }
             } else {
                 ArrayDesc<A> arrayDescs = TreeUtils.getArrayDescription(scopeDescs, flagName.type);
-                VariableDescription<ArrayVariable<A>> altFlagName = VariableNames.altTypeName(flagName,
-                        arrayDescs.type);
+                GlobalVariableDescription<ArrayVariable<A>> altFlagName = flagName.alternativeType(arrayDescs.type);
                 IRTreeVoid allocator = TreeUtils.allocate(altFlagName, arrayDescs, compilationCtx);
-                compilationCtx.addConstructedClassField(altFlagName, allocator);
+                compilationCtx.addInternalFlagClassField(altFlagName, allocator);
                 IRTreeVoid setter = TreeUtils.setArray(altFlagName, constant(true));
                 compilationCtx.addArrayInitilisation(setter);
 
                 if(compilationCtx.traces.isFixableTask(s)) {
-                    VariableDescription<BooleanVariable> fixedFlag = VariableNames.fixedFlagName(s);
+                    GlobalVariableDescription<BooleanVariable> fixedFlag = VariableNames.fixedFlagName(s);
                     setter = TreeUtils.setArray(altFlagName, and(load(fixedFlag), constant(true)));
                     IRTreeReturn<BooleanVariable> guard = load(VariableNames.allocatedFlag());
                     setter = ifElse(guard, setter, "If the model has been allocated update the constraints flags");
@@ -336,15 +336,15 @@ public class APICompile {
 
         // Inputs
         for(Variable<?> v:compilationCtx.traces.modelInputs())
-            compilationCtx.addClassInputField(v.getUniqueVarDesc(), v.getComment());
+            compilationCtx.addClassInputField((GlobalVariableDescription<?>)v.getUniqueVarDesc(), v.getComment());
 
         for(Variable<?> v:compilationCtx.traces.observedOnlyInputs())
-            compilationCtx.addClassInputField(v.getUniqueVarDesc(), v.getComment());
+            compilationCtx.addClassInputField((GlobalVariableDescription<?>)v.getUniqueVarDesc(), v.getComment());
 
         for(Variable<?> v:compilationCtx.traces.observedShapeableValues()) {
-            compilationCtx.addClassInputField(v.getUniqueVarDesc(), v.getComment());
+            compilationCtx.addClassInputField((GlobalVariableDescription<?>)v.getUniqueVarDesc(), v.getComment());
             Variable<?> shape = compilationCtx.traces.observedShapeVariable(v);
-            compilationCtx.addClassInputField(shape.getUniqueVarDesc(), shape.getComment());
+            compilationCtx.addClassInputField((GlobalVariableDescription<?>)shape.getUniqueVarDesc(), shape.getComment());
         }
     }
 
@@ -519,7 +519,7 @@ public class APICompile {
         FunctionName functionName = FunctionName.createFunctionName(SampleFunctionClass.SAMPLE, sample);
 
         String comment = "Pick a value from the distribution for the unconditioned variable from "
-                + sample.getUniqueVarDesc();
+                + sample.getSampleName();
 
         IRVoidFunction f = voidFunction(Visibility.PRIVATE, functionName, functionArgs, result, comment, knownValues);
         compilationCtx.addFunction(SampleFunctionClass.SAMPLE, sample, f);
@@ -761,9 +761,9 @@ public class APICompile {
         if(v.containsState)
             tree = forwardTree;
         else {
-            VariableDescription<BooleanVariable> flagName = new VariableDescription<>(
+            GlobalVariableDescription<BooleanVariable> flagName = new GlobalVariableDescription<>(
                     VariableNames.internalSystemName("gibbsForward"), VariableType.BooleanVariable);
-            compilationCtx.addConstructedClassField(flagName, constant(true));
+            compilationCtx.addInternalFlagClassField(flagName, constant(true));
             IRTreeVoid reverseTree = new ReverseTreeTransformation().transform(forwardTree);
 
             IRTreeVoid conditional = ifElse(load(flagName), forwardTree, "Infer the samples in chronological order.",
@@ -808,7 +808,7 @@ public class APICompile {
 
         if(threadID != null) {
             args.add(threadID);
-            args.add(load(VariableNames.rngName(0)));
+            args.add(load(VariableNames.rngName()));
         }
 
         IRTreeReturn<?>[] argsArray = args.toArray(new IRTreeReturn<?>[args.size()]);

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/CompilationContext.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/CompilationContext.java
@@ -39,15 +39,15 @@ import org.sandwood.compiler.dataflowGraph.tasks.arrayTasks.PutTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ForTask;
+import org.sandwood.compiler.dataflowGraph.variables.GlobalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.ScratchVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.Variable.Observed;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableName;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.BooleanVariable;
 import org.sandwood.compiler.exceptions.CompilerException;
 import org.sandwood.compiler.names.FunctionName;
-import org.sandwood.compiler.names.VariableNames;
 import org.sandwood.compiler.traces.Traces;
 import org.sandwood.compiler.traces.guards.DistSampleDesc;
 import org.sandwood.compiler.traces.guards.ScopeConstructor;
@@ -155,10 +155,11 @@ public class CompilationContext {
     }
 
     public enum FieldType {
-        INTERNAL(Getter.NONE, Setter.NONE, false, Visibility.PRIVATE, Observed.FREE),
         PRIVATE_PROBABILITY(Getter.NONE, Setter.NONE, false, Visibility.PRIVATE, Observed.FREE),
         PUBLIC_PROBABILITY(Getter.REQUIRED, Setter.NONE, false, Visibility.PUBLIC, Observed.FREE),
         USER_FLAG(Getter.REQUIRED, Setter.REQUIRED, false, Visibility.PUBLIC, Observed.FREE),
+        INTERNAL_FLAG(Getter.NONE, Setter.NONE, false, Visibility.PRIVATE, Observed.FREE),
+
         INPUT(Getter.REQUIRED, Setter.REQUIRED, false, Visibility.PUBLIC, Observed.FREE),
 
         PRIVATE_FREE_INTERMEDIATE(Getter.NONE, Setter.NONE, false, Visibility.PRIVATE, Observed.FREE),
@@ -290,13 +291,13 @@ public class CompilationContext {
 
     public static class FieldDesc<A extends Variable<A>> {
 
-        public final VariableDescription<A> varDesc;
+        public final GlobalVariableDescription<A> varDesc;
         public final String comment;
         public final IRTreeReturn<A> initialValue;
-        private final static Map<VariableDescription<?>, Set<WrappedTree<IRTree, IRTreeVoid>>> setSideEffects = new HashMap<>();
+        private final static Map<GlobalVariableDescription<?>, Set<WrappedTree<IRTree, IRTreeVoid>>> setSideEffects = new HashMap<>();
         public final FieldType fieldType;
 
-        public FieldDesc(VariableDescription<A> varDesc, FieldType fieldType, IRTreeReturn<A> initialValue,
+        public FieldDesc(GlobalVariableDescription<A> varDesc, FieldType fieldType, IRTreeReturn<A> initialValue,
                 String comment) {
             this.varDesc = varDesc;
             this.comment = comment;
@@ -312,7 +313,7 @@ public class CompilationContext {
                 return s;
         }
 
-        public static void addSetSideEffects(VariableDescription<?> varDesc, IRTreeVoid sideEffect) {
+        public static void addSetSideEffects(GlobalVariableDescription<?> varDesc, IRTreeVoid sideEffect) {
             Set<WrappedTree<IRTree, IRTreeVoid>> s = setSideEffects.computeIfAbsent(varDesc,
                     k -> new LinkedHashSet<>());
 
@@ -346,15 +347,16 @@ public class CompilationContext {
         private final List<IRTreeVoid> scratchConstructors = new ArrayList<>();
         private final List<VarConstructor> orderedConstructors = new ArrayList<>();
 
-        public void addConstructor(VariableDescription<?> fieldName, Variable<?> v, IRTreeVoid constructor) {
-            if(v == null) {
-                if(VariableNames.isCalcVar(fieldName) || VariableNames.isGuardVar(fieldName))
-                    scratchConstructors.add(IRTree.treeScope(constructor, "Constructor for " + fieldName));
-                else
-                    unorderedConstructors.add(IRTree.treeScope(constructor, "Constructor for " + fieldName));
-            } else
+        public void addClassConstructor(GlobalVariableDescription<?> fieldName, Variable<?> v, IRTreeVoid constructor) {
+            if(v == null)
+                unorderedConstructors.add(IRTree.treeScope(constructor, "Constructor for " + fieldName));
+            else
                 orderedConstructors
-                        .add(new VarConstructor(v, IRTree.treeScope(constructor, "Constructor for " + fieldName)));
+                .add(new VarConstructor(v, IRTree.treeScope(constructor, "Constructor for " + fieldName)));
+        }
+
+        public void addScratchConstructor(ScratchVariableDescription<?> fieldName, IRTreeVoid constructor) {
+            scratchConstructors.add(IRTree.treeScope(constructor, "Constructor for " + fieldName));
         }
 
         public IRTreeVoid getVarTree(Map<VariableName, FieldDesc<?>> fieldDescs) {
@@ -574,6 +576,9 @@ public class CompilationContext {
     // Java class field name, class field type.
     private final Map<VariableName, FieldDesc<?>> classFields = new HashMap<>();
 
+    // Java scratch space field names.
+    private final Set<ScratchVariableDescription<?>> scratchFields = new HashSet<>();
+
     // Store the functions constructed by the compilation process.
     private final Functions functions = new Functions();
 
@@ -706,10 +711,12 @@ public class CompilationContext {
         initialize();
         classFields.clear();
         FieldDesc.setSideEffects.clear();
+        scratchFields.clear();
         allocators.clear();
     }
 
-    public <A extends Variable<A>> void addClassInputField(VariableDescription<A> varDesc, String comment) {
+    // Declare class fields for the model and its metadata
+    public <A extends Variable<A>> void addClassInputField(GlobalVariableDescription<A> varDesc, String comment) {
         if(!classFields.containsKey(varDesc.name)) {
             classFields.put(varDesc.name, new FieldDesc<>(varDesc, FieldType.INPUT, null, comment));
 
@@ -722,96 +729,85 @@ public class CompilationContext {
         }
     }
 
-    public <A extends Variable<A>> void addConstructedClassField(VariableDescription<A> fieldname,
-            IRTreeReturn<A> initialValue) {
-        addConstructedClassField(fieldname, null, null, FieldType.INTERNAL, initialValue, null);
-    }
-
-    public <A extends Variable<A>> void addConstructedClassField(VariableDescription<A> fieldname,
-            IRTreeVoid constructor) {
-        addConstructedClassField(fieldname, constructor, null, FieldType.INTERNAL, null, null);
-    }
-
-    public <A extends Variable<A>> void addConstructedClassField(VariableDescription<A> fieldname,
-            IRTreeVoid constructor, IRTreeReturn<A> initialValue) {
-        addConstructedClassField(fieldname, constructor, null, FieldType.INTERNAL, initialValue, null);
-    }
-
-    public <A extends Variable<A>> void addConstructedClassField(VariableDescription<A> fieldname,
+    public <A extends Variable<A>> void addConstructedClassField(GlobalVariableDescription<A> fieldname,
             IRTreeVoid constructor, FieldType fieldType, String comment) {
         addConstructedClassField(fieldname, constructor, null, fieldType, null, comment);
     }
 
-    public <A extends Variable<A>> void addFlagClassField(VariableDescription<A> fieldname,
+    public <A extends Variable<A>> void addFlagClassField(GlobalVariableDescription<A> fieldname,
             IRTreeReturn<A> initialValue) {
         addConstructedClassField(fieldname, null, null, FieldType.USER_FLAG, initialValue, null);
     }
 
-    public <A extends Variable<A>> void addConstructedClassField(VariableDescription<A> fieldname,
+    public <A extends Variable<A>> void addInternalFlagClassField(GlobalVariableDescription<A> fieldname,
+            IRTreeReturn<A> initialValue) {
+        addConstructedClassField(fieldname, null, null, FieldType.INTERNAL_FLAG, initialValue, null);
+    }
+
+    public <A extends Variable<A>> void addInternalFlagClassField(GlobalVariableDescription<A> fieldname,
+            IRTreeVoid constructor) {
+        addConstructedClassField(fieldname, constructor, null, FieldType.INTERNAL_FLAG, null, null);
+    }
+
+    public <A extends Variable<A>> void addConstructedClassField(GlobalVariableDescription<A> fieldname,
             FieldType fieldType) {
         addConstructedClassField(fieldname, null, null, fieldType, null, null);
     }
 
     public <A extends Variable<A>> void addConstructedClassField(Variable<A> v, CompilationContext compilationCtx) {
-        VariableDescription<A> fieldDesc = v.getUniqueVarDesc();
-        if(classFields.containsKey(fieldDesc.name)) {
-            // If the field has already been declared just pass this through to update date the getter and setter flags
-            // if required. They are a collective OR of all the passed flags.
-            addConstructedClassField(fieldDesc, null, v);
-        } else {
+        GlobalVariableDescription<A> fieldDesc = (GlobalVariableDescription<A>) v.getUniqueVarDesc();
+        if(!classFields.containsKey(fieldDesc.name)) {
             ArrayDesc<?> arrayDesc = TreeUtils.getArrayDescription(v);
-            if(arrayDesc == null) {
+            if(arrayDesc == null)
                 addConstructedClassField(fieldDesc, null, v);
-            } else {
+            else
                 addConstructedClassFieldArray(v, fieldDesc, arrayDesc, compilationCtx);
-            }
         }
     }
 
     private <A extends Variable<A>, B extends Variable<B>> void addConstructedClassFieldArray(Variable<A> v,
-            VariableDescription<A> fieldDesc, ArrayDesc<B> arrayDesc, CompilationContext compilationCtx) {
-        VariableDescription<ArrayVariable<B>> arrayName = VariableNames.altTypeName(fieldDesc, arrayDesc.type);
+            GlobalVariableDescription<A> fieldDesc, ArrayDesc<B> arrayDesc, CompilationContext compilationCtx) {
+        GlobalVariableDescription<ArrayVariable<B>> arrayName = fieldDesc.alternativeType(arrayDesc.type);
         pushIsSerial(true);
         IRTreeVoid allocator = allocate(arrayName, arrayDesc, compilationCtx);
         popIsSerial();
         addConstructedClassField(arrayName, allocator, v);
     }
 
-    private <A extends Variable<A>> void addConstructedClassField(VariableDescription<A> fieldname,
+    private <A extends Variable<A>> void addConstructedClassField(GlobalVariableDescription<A> fieldname,
             IRTreeVoid constructor, Variable<?> v) {
         addConstructedClassField(fieldname, constructor, v, FieldType.getFieldType(v), null, v.getComment());
     }
 
-    public <A extends Variable<A>> void addConstructedClassField(VariableDescription<A> varDesc,
+    private <A extends Variable<A>> void addConstructedClassField(GlobalVariableDescription<A> varDesc,
             IRTreeVoid constructorTree, Variable<?> v, FieldType fieldType, IRTreeReturn<A> initialValue,
             String comment) {
-        // Ensure variables that did not appear in the model, and variables that have
-        // been marked private don't have getters and setters constructed.
         if(!classFields.containsKey(varDesc.name)) {
             classFields.put(varDesc.name, new FieldDesc<>(varDesc, fieldType, initialValue, comment));
             if(constructorTree != null)
-                allocators.addConstructor(varDesc, v, constructorTree);
-        } else {
-            @SuppressWarnings("unchecked")
-            FieldDesc<A> f = (FieldDesc<A>) classFields.get(varDesc.name);
-            if(initialValue == null)
-                initialValue = f.initialValue;
-            else
-                assert f.initialValue == null || (f.initialValue.equivalent(initialValue));
-            // It is important that f.varDesc is used here as only the first variable description is checked to see if
-            // it need to be converted to an array type.
-            assert fieldType == f.fieldType;
-            f = new FieldDesc<>(f.varDesc, fieldType, initialValue, f.comment);
-            classFields.put(varDesc.name, f);
+                allocators.addClassConstructor(varDesc, v, constructorTree);
         }
     }
 
-    public void addSetSideEffect(VariableDescription<?> fieldName, IRTreeVoid sideEffect) {
+    public void addSetSideEffect(GlobalVariableDescription<?> fieldName, IRTreeVoid sideEffect) {
         FieldDesc.addSetSideEffects(fieldName, sideEffect);
     }
 
     public Map<VariableName, FieldDesc<?>> getClassFields() {
         return classFields;
+    }
+
+    // Add in class fields for scratch data
+    public <A extends Variable<A>> void addScratchClassField(ScratchVariableDescription<A> field,
+            IRTreeVoid constructor) {
+        if(!scratchFields.contains(field)) {
+            scratchFields.add(field);
+            allocators.addScratchConstructor(field, constructor);
+        }
+    }
+
+    public Set<ScratchVariableDescription<?>> getScratchFields() {
+        return scratchFields;
     }
 
     // Calls initialization tracking.

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/CompilationContext.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/CompilationContext.java
@@ -352,7 +352,7 @@ public class CompilationContext {
                 unorderedConstructors.add(IRTree.treeScope(constructor, "Constructor for " + fieldName));
             else
                 orderedConstructors
-                .add(new VarConstructor(v, IRTree.treeScope(constructor, "Constructor for " + fieldName)));
+                        .add(new VarConstructor(v, IRTree.treeScope(constructor, "Constructor for " + fieldName)));
         }
 
         public void addScratchConstructor(ScratchVariableDescription<?> fieldName, IRTreeVoid constructor) {

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ForwardExecutionBuilder.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ForwardExecutionBuilder.java
@@ -42,6 +42,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleT
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ForTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.IfElseAssignmentTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -251,7 +252,7 @@ public class ForwardExecutionBuilder {
         if(guard != null)
             sc = sc.addCondition(guard).ifScopeConstructor();
 
-        VariableDescription<BooleanVariable> guardName = VariableNames.observedGuard(v);
+        LocalVariableDescription<BooleanVariable> guardName = VariableNames.observedGuard(v);
         sc.addTree((TreeBuilderInfo info) -> {
             info.compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(guardName,
                     IRTree.constant(false), "Track if it is possible to reach an observed variable"));
@@ -302,7 +303,7 @@ public class ForwardExecutionBuilder {
         for(ArrayVariable<DoubleVariable> probabilities:probabilitiesArrays) {
             VariableDescription<ArrayVariable<DoubleVariable>> probName = probabilities.getUniqueVarDesc();
             // Get local instance of the variable.
-            VariableDescription<ArrayVariable<DoubleVariable>> localName = VariableNames.calcVarName(probName,
+            LocalVariableDescription<ArrayVariable<DoubleVariable>> localName = VariableNames.localCalcVarName(probName,
                     probName.type);
             List<IRTreeReturn<IntVariable>> indexes = TreeUtils.toArgTrees(TreeUtils.getScopeArgs(probabilities),
                     compilationCtx);
@@ -383,7 +384,7 @@ public class ForwardExecutionBuilder {
 
                 // Init sum value
                 // Sum all the values in the array.
-                VariableDescription<DoubleVariable> sum = VariableNames.calcVarName(rv.getVarDesc(), "sum",
+                LocalVariableDescription<DoubleVariable> sum = VariableNames.localCalcVarName(rv.getVarDesc(), "sum",
                         VariableType.DoubleVariable);
                 compilationCtx.addTreeToScope(rvScope,
                         initializeVariable(sum, constant(0.0), "Sum the values in the array"));
@@ -453,7 +454,7 @@ public class ForwardExecutionBuilder {
                     });
             ScopeStack.popScope(rvScope);
 
-            VariableDescription<DoubleVariable> valueName = VariableNames.calcVarName("value",
+            LocalVariableDescription<DoubleVariable> valueName = VariableNames.localCalcVarName("value",
                     VariableType.DoubleVariable, true);
             IRTreeReturn<DoubleVariable> value = getProbability(rv, newScope, compilationCtx);
             IRTreeVoid valueInit = IRTree.initializeVariable(valueName, value, "Probability for this value");

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ObservedValuePropagationBuilder.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ObservedValuePropagationBuilder.java
@@ -34,6 +34,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.nonReturnTasks.ObserveVariableT
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.rvConstructor.RandomVariableConstructorTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.IfElseAssignmentTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
@@ -507,7 +508,7 @@ public class ObservedValuePropagationBuilder {
                                 if(!compilationCtx.initializedInScope(value)) {
                                     Variable<B> v = compilationCtx.addInitialized(value);
                                     compilationCtx.addTreeToScope(value.scope(),
-                                            IRTree.initializeUnsetVariable(v.getUniqueVarDesc(), Tree.NoComment));
+                                            IRTree.initializeUnsetVariable((LocalVariableDescription<B>) v.getUniqueVarDesc(), Tree.NoComment));
                                     compilationCtx.addTreeToScope(pt.scope(), IRTree.store(value.getUniqueVarDesc(),
                                             IRTree.arrayGet(arrayTree, indexTree), Tree.NoComment));
 

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ProbabilityFunction.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/ProbabilityFunction.java
@@ -52,6 +52,8 @@ import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.ProducingDataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.arrayTasks.PutTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.GlobalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -366,7 +368,7 @@ public class ProbabilityFunction {
         final Scope sampleTaskScope;
         final Variable<?> sampleVariable;
         final TraceHandle traceToSampleVariable;
-        final VariableDescription<A> sampleVariableName;
+        final LocalVariableDescription<A> sampleVariableName;
         final boolean sampleSkippable;
 
         // Store the code for initializing intermediate variable probabilities.
@@ -388,12 +390,12 @@ public class ProbabilityFunction {
         final List<ScopeDesc> randomScopes;
         final Scope randomStoreScope;
         final List<IRTreeReturn<IntVariable>> randomArgTrees;
-        final VariableDescription<DoubleVariable> randomProbName;
+        final GlobalVariableDescription<DoubleVariable> randomProbName;
         final Set<DataflowTask<?>> consumers;
         final boolean randomSkippable;
 
         // Get the scopes we will use to store probabilities for samples.
-        final VariableDescription<DoubleVariable> storedName;
+        final GlobalVariableDescription<DoubleVariable> storedName;
         final List<ScopeDesc> storeScopes;
         final List<IRTreeReturn<IntVariable>> storeArgTrees;
         final boolean isPrivate;
@@ -405,8 +407,8 @@ public class ProbabilityFunction {
 
         final Set<SampleTask<?, ?>> fixable;
         final boolean fixableProb;
-        final VariableDescription<BooleanVariable> fixedFlagName;
-        final VariableDescription<BooleanVariable> fixedProbFlagName;
+        final GlobalVariableDescription<BooleanVariable> fixedFlagName;
+        final GlobalVariableDescription<BooleanVariable> fixedProbFlagName;
 
         FunctionData(SampleTask<A, ?> sampleTask, Set<WrappedTree<IRTree, IRTreeVoid>> toInitialize,
                 boolean useDistributions, CompilationContext compilationCtx) {
@@ -416,7 +418,7 @@ public class ProbabilityFunction {
             SampleTraceDesc sampleVarDesc = compilationCtx.traces.getSampleTrace(sampleTask);
             sampleVariable = sampleVarDesc.sampleVariable;
             traceToSampleVariable = sampleVarDesc.traceToSampleVariable;
-            sampleVariableName = VariableNames.calcVarName("sampleValue", sampleTask.getOutputType(), true);
+            sampleVariableName = VariableNames.localCalcVarName("sampleValue", sampleTask.getOutputType(), true);
             conditionalTraces = compilationCtx.traces.getTracesToConditionals(sampleTask);
             sampleSkippable = DAGUtils.skippableTask(sampleTask);
             consumers = randomVariable.getConsumers();
@@ -485,14 +487,14 @@ public class ProbabilityFunction {
 
             // Get the scopes we will use to store probabilities for samples.
             if(!dependentVariables.perSampleVariables.isEmpty()) {
-                storedName = VariableNames.logProbabilityName(sampleTask.getUniqueVarDesc());
+                storedName = VariableNames.logProbabilityName(sampleTask.getSampleName());
                 storeScopes = TreeUtils.getScopeDescs(sampleTask.getOutput());
                 isPrivate = true;
                 sampleStoreScope = sampleTaskScope;
                 storeArgTrees = toArgTrees(getScopeArgs(storeScopes), compilationCtx);
                 // Test if we need random variables to be stored.
             } else if(randomStoreScope != GlobalScope.scope) {
-                storedName = VariableNames.logProbabilityName(sampleTask.getUniqueVarDesc());
+                storedName = VariableNames.logProbabilityName(sampleTask.getSampleName());
                 storeScopes = randomScopes;
                 isPrivate = true;
                 sampleStoreScope = randomStoreScope;
@@ -510,35 +512,35 @@ public class ProbabilityFunction {
         }
     }
 
-    private static final VariableDescription<DoubleVariable> evidenceProbName = VariableNames
+    private static final GlobalVariableDescription<DoubleVariable> evidenceProbName = VariableNames
             .logProbabilityName(VariableNames.internalName("evidence"));
-    private static final VariableDescription<DoubleVariable> logModelProbName = VariableNames
+    private static final GlobalVariableDescription<DoubleVariable> logModelProbName = VariableNames
             .logProbabilityName(VariableNames.internalName("model"));
-    private static final VariableDescription<DoubleVariable> sampleProbName = VariableNames
-            .calcVarName("sampleProbability", VariableType.DoubleVariable, true);
-    private static final VariableDescription<DoubleVariable> accumulatorName = VariableNames.calcVarName("accumulator",
-            VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> sampleProbName = VariableNames
+            .localCalcVarName("sampleProbability", VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> accumulatorName = VariableNames
+            .localCalcVarName("accumulator", VariableType.DoubleVariable, true);
     // Accumulator for the probabilities seen in the different distribution
     // configurations.
-    private static final VariableDescription<DoubleVariable> disAccumulator = VariableNames
-            .calcVarName("distributionAccumulator", VariableType.DoubleVariable, true);
-    private static final VariableDescription<DoubleVariable> rvProbabilityName = VariableNames
-            .calcVarName("rvAccumulator", VariableType.DoubleVariable, true);
-    private static final VariableDescription<DoubleVariable> sampleValueName = VariableNames.calcVarName("sampleValue",
-            VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> disAccumulator = VariableNames
+            .localCalcVarName("distributionAccumulator", VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> rvProbabilityName = VariableNames
+            .localCalcVarName("rvAccumulator", VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> sampleValueName = VariableNames
+            .localCalcVarName("sampleValue", VariableType.DoubleVariable, true);
     // Name for a second accumulator in the case that the same task is inside
     // another for loop relative to the random variable
-    private static final VariableDescription<DoubleVariable> sampleAccumulatorName = VariableNames
-            .calcVarName("sampleAccumulator", VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> sampleAccumulatorName = VariableNames
+            .localCalcVarName("sampleAccumulator", VariableType.DoubleVariable, true);
     // Accumulator for the probability spaces reached through the distributions.
-    private static final VariableDescription<DoubleVariable> probabilityReached = VariableNames
-            .calcVarName("probabilityReached", VariableType.DoubleVariable, true);
-    private static final VariableDescription<DoubleVariable> weightedProbability = VariableNames
-            .calcVarName("weightedProbability", VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> probabilityReached = VariableNames
+            .localCalcVarName("probabilityReached", VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> weightedProbability = VariableNames
+            .localCalcVarName("weightedProbability", VariableType.DoubleVariable, true);
 
     // Guard to check if the value has been reached.
-    private static final VariableDescription<BooleanVariable> guardName = VariableNames.calcVarName("sampleReached",
-            VariableType.BooleanVariable, true);
+    private static final LocalVariableDescription<BooleanVariable> guardName = VariableNames
+            .localCalcVarName("sampleReached", VariableType.BooleanVariable, true);
 
     public static void probabilityFunctions(CompilationContext compilationCtx) {
         // Store the code for initializing intermediate variable probabilities.
@@ -608,7 +610,7 @@ public class ProbabilityFunction {
         // random is allocated inside these scopes, so can only exist in this number of
         // dimensions.
         if(!funcData.randomVariable.isPrivate()) {
-            funcData.toInitialize.add(new WrappedTree<>(TreeUtils.constructVariable(funcData.randomProbName,
+            funcData.toInitialize.add(new WrappedTree<>(TreeUtils.constructGlobalVariable(funcData.randomProbName,
                     constant(funcData.randomSkippable ? Double.NaN : 0.0), funcData.randomScopes,
                     FieldType.PUBLIC_PROBABILITY, funcData.compilationCtx)));
         }
@@ -630,19 +632,19 @@ public class ProbabilityFunction {
         // public, or required to set probabilities if the probability is fixed
         Variable<?> sampleVar = funcData.dependentVariables.sampleVariable;
         if(sampleVar != null && (!sampleVar.isPrivate() || funcData.fixableProb)) {
-            VariableDescription<DoubleVariable> outputName = VariableNames
+            GlobalVariableDescription<DoubleVariable> outputName = VariableNames
                     .logProbabilityName(sampleVar.getUniqueVarDesc());
-            IRTreeVoid initializeIntermediate = TreeUtils.constructVariable(outputName, constant(0.0), outputScopes,
-                    sampleVar.isPrivate() ? FieldType.PRIVATE_PROBABILITY : FieldType.PUBLIC_PROBABILITY,
+            IRTreeVoid initializeIntermediate = TreeUtils.constructGlobalVariable(outputName, constant(0.0),
+                    outputScopes, sampleVar.isPrivate() ? FieldType.PRIVATE_PROBABILITY : FieldType.PUBLIC_PROBABILITY,
                     sampleVar.getComment(), funcData.compilationCtx);
             funcData.toInitialize.add(new WrappedTree<>(initializeIntermediate));
         }
         for(Variable<?> intermediate:funcData.dependentVariables) {
             if(!intermediate.isPrivate()) {
-                VariableDescription<DoubleVariable> outputName = VariableNames
+                GlobalVariableDescription<DoubleVariable> outputName = VariableNames
                         .logProbabilityName(intermediate.getUniqueVarDesc());
-                IRTreeVoid initializeIntermediate = TreeUtils.constructVariable(outputName, constant(0.0), outputScopes,
-                        FieldType.PUBLIC_PROBABILITY, intermediate.getComment(), funcData.compilationCtx);
+                IRTreeVoid initializeIntermediate = TreeUtils.constructGlobalVariable(outputName, constant(0.0),
+                        outputScopes, FieldType.PUBLIC_PROBABILITY, intermediate.getComment(), funcData.compilationCtx);
                 funcData.toInitialize.add(new WrappedTree<>(initializeIntermediate));
             }
         }
@@ -653,13 +655,13 @@ public class ProbabilityFunction {
          */
 
         // Construct a space to store the probability.
-        IRTreeVoid sampleAllocation = TreeUtils.constructVariable(funcData.storedName, constant(Double.NaN),
+        IRTreeVoid sampleAllocation = TreeUtils.constructGlobalVariable(funcData.storedName, constant(Double.NaN),
                 funcData.storeScopes, funcData.isPrivate ? FieldType.PRIVATE_PROBABILITY : FieldType.PUBLIC_PROBABILITY,
                 funcData.compilationCtx);
 
         // Construct a flag to determine if this probability is already calculated.
         if(funcData.fixableProb) {
-            funcData.compilationCtx.addConstructedClassField(funcData.fixedProbFlagName, constant(false));
+            funcData.compilationCtx.addInternalFlagClassField(funcData.fixedProbFlagName, constant(false));
 
             // Set the initialization
             IRTreeReturn<BooleanVariable> guard = negateBoolean(load(funcData.fixedProbFlagName));
@@ -706,7 +708,8 @@ public class ProbabilityFunction {
                     info.compilationCtx.addSetSideEffect(funcData.fixedFlagName, restFixed);
 
                     // Add side effect to clear the flag if a dependency is changed.
-                    VariableDescription<?> sampleName = funcData.sampleVariable.getUniqueVarDesc();
+                    GlobalVariableDescription<?> sampleName = (GlobalVariableDescription<?>) funcData.sampleVariable
+                            .getUniqueVarDesc();
                     restFixed = store(funcData.fixedProbFlagName, constant(false),
                             "Unset the fixed probability flag for sample " + funcData.sampleTask.id()
                                     + " as it depends on " + sampleName.name + ".");
@@ -721,7 +724,7 @@ public class ProbabilityFunction {
                     while(!p.isEmpty()) {
                         SampleTask<?, ?> s = p.poll();
                         if(funcData.fixable.contains(s)) {
-                            VariableDescription<BooleanVariable> sampleFixedName = VariableNames.fixedFlagName(s);
+                            GlobalVariableDescription<BooleanVariable> sampleFixedName = VariableNames.fixedFlagName(s);
                             fixed = IRTree.and(fixed, load(sampleFixedName));
 
                             // Add side effect to clear the flag if a dependency given the ability to changed
@@ -733,7 +736,8 @@ public class ProbabilityFunction {
 
                             // Add side effect to clear the flag if a dependency is changed.
                             SampleTraceDesc sampleDesc = info.compilationCtx.traces.getSampleTrace(s);
-                            VariableDescription<?> sampleName = sampleDesc.sampleVariable.getUniqueVarDesc();
+                            GlobalVariableDescription<?> sampleName = (GlobalVariableDescription<?>) sampleDesc.sampleVariable
+                                    .getUniqueVarDesc();
                             restFixed = store(funcData.fixedProbFlagName, constant(false),
                                     "Unset the fixed probability flag for sample " + funcData.sampleTask.id()
                                             + " as it depends on " + sampleName.name + ".");
@@ -816,7 +820,7 @@ public class ProbabilityFunction {
                 : SampleFunctionClass.LOG_PROBABILITY_VALUE;
         FunctionName functionName = FunctionName.createFunctionName(functionClass, funcData.sampleTask);
         String comment = "Calculate the probability of the samples represented by "
-                + funcData.sampleTask.getUniqueVarDesc()
+                + funcData.sampleTask.getSampleName()
                 + (funcData.useDistributions ? " using probability distributions." : " using sampled values.");
         funcData.compilationCtx.addFunction(functionClass, funcData.sampleTask, voidFunction(Visibility.PRIVATE,
                 functionName, new ArgDesc<?>[0], funcData.compilationCtx.getOutermostScopeTree(), comment));
@@ -1056,7 +1060,7 @@ public class ProbabilityFunction {
     private static void updateVarProbabilities(FunctionData<?> funcData,
             IRTreeReturn<DoubleVariable> accumulatedProbability, IRTreeReturn<DoubleVariable> sampleProbability) {
         {
-            Map<Variable<?>, VariableDescription<BooleanVariable>> guards = new HashMap<>();
+            Map<Variable<?>, LocalVariableDescription<BooleanVariable>> guards = new HashMap<>();
 
             // Initialize guards
             PriorityQueue<Variable<?>> p = new PriorityQueue<>();
@@ -1067,10 +1071,10 @@ public class ProbabilityFunction {
             while(!p.isEmpty()) {
                 Variable<?> v = p.poll();
                 Variable<?> instance = v.instanceHandle();
-                VariableDescription<BooleanVariable> multisetGuardName = guards.get(instance);
+                LocalVariableDescription<BooleanVariable> multisetGuardName = guards.get(instance);
                 if(multisetGuardName == null) {
-                    multisetGuardName = VariableNames.calcVarName("guard", instance.getUniqueVarDesc().name.getName(),
-                            VariableType.BooleanVariable, true);
+                    multisetGuardName = VariableNames.localCalcVarName("guard",
+                            instance.getUniqueVarDesc().name.getName(), VariableType.BooleanVariable, true);
                     guards.put(instance, multisetGuardName);
                     funcData.compilationCtx.addTreeToScope(funcData.sampleTaskScope,
                             initializeVariable(multisetGuardName, constant(false), "Guard to ensure that "
@@ -1085,9 +1089,9 @@ public class ProbabilityFunction {
             while(!p.isEmpty()) {
                 Variable<?> v = p.poll();
                 Variable<?> instance = v.instanceHandle();
-                VariableDescription<BooleanVariable> guardName = guards.get(instance);
+                LocalVariableDescription<BooleanVariable> guardName = guards.get(instance);
                 if(guardName == null) {
-                    guardName = VariableNames.calcVarName("guard", instance.getUniqueVarDesc().name.getName(),
+                    guardName = VariableNames.localCalcVarName("guard", instance.getUniqueVarDesc().name.getName(),
                             VariableType.BooleanVariable, true);
                     guards.put(instance, guardName);
                     funcData.compilationCtx.addTreeToScope(GlobalScope.scope,
@@ -1272,8 +1276,10 @@ public class ProbabilityFunction {
             IRTreeReturn<A> pTree = p.getForwardIR(compilationCtx);
             if(!compilationCtx.initializedInScope(p)) {
                 Variable<A> pInit = compilationCtx.addInitialized(p);
-                VariableDescription<A> pName = pInit.getUniqueVarDesc();
-                compilationCtx.addTreeToScope(parent.scope(), initializeVariable(pName, pTree, Tree.NoComment));
+                if(!pInit.isIntermediate() && !(pInit.getParent().getType() == DFType.CONSTRUCT_INPUT)) {
+                    LocalVariableDescription<A> pName = (LocalVariableDescription<A>) pInit.getUniqueVarDesc();
+                    compilationCtx.addTreeToScope(parent.scope(), initializeVariable(pName, pTree, Tree.NoComment));
+                }
             }
         }
     }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorArray.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorArray.java
@@ -20,6 +20,7 @@ import org.sandwood.compiler.compilation.util.SampleDescArray;
 import org.sandwood.compiler.compilation.util.TreeUtils;
 import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
@@ -35,13 +36,13 @@ public abstract class InferenceGeneratorArray<A extends Variable<A>, B extends R
 
     public abstract static class ArrayFunctionData<A extends Variable<A>, B extends RandomVariable<ArrayVariable<A>, B>>
             extends FunctionData<ArrayVariable<A>, B, SampleDescArray<A, B>> {
-        public final VariableDescription<ArrayVariable<A>> targetLocal;
+        public final LocalVariableDescription<ArrayVariable<A>> targetLocal;
 
         protected ArrayFunctionData(SampleTask<ArrayVariable<A>, B> sample, boolean sampleUpdated,
                 CompilationContext compilationCtx) {
             super(new SampleDescArray<>(sample, compilationCtx.traces), sampleUpdated, compilationCtx);
 
-            targetLocal = VariableNames.calcVarName("targetLocal", sample.getOutputType(), true);
+            targetLocal = VariableNames.localCalcVarName("targetLocal", sample.getOutputType(), true);
         }
 
         public IRTreeReturn<ArrayVariable<A>> getTarget() {
@@ -70,8 +71,8 @@ public abstract class InferenceGeneratorArray<A extends Variable<A>, B extends R
             // Dirty hack to keep getIndirect happy. TODO come up with a cleaner solutions.
             // Recasting the variable type so that the get indirect method can be used in
             // the same way it would be used for variables declared inside a loop.
-            VariableDescription<ArrayVariable<A>> targetName = VariableNames.altTypeName(
-                    funcData.sampleDesc.targetIntermediate().getUniqueVarDesc(), funcData.sampleDesc.output.getType());
+            VariableDescription<ArrayVariable<A>> targetName = funcData.sampleDesc.targetIntermediate()
+                    .getUniqueVarDesc().alternativeType(funcData.sampleDesc.output.getType());
             globalState = TreeUtils.getIndirectValue(targetName, indexes);
         } else {
             List<IRTreeReturn<IntVariable>> indexes = TreeUtils

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorArrayProb.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorArrayProb.java
@@ -44,6 +44,8 @@ import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.ScratchVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -126,53 +128,53 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
         }
     }
 
-    private final static VariableDescription<IntVariable> valuePosName = VariableNames.calcVarName("valuePos",
+    private final static VariableDescription<IntVariable> valuePosName = VariableNames.localCalcVarName("valuePos",
             VariableType.IntVariable, false);
 
     // Flags for the different variables that we will need to construct for this
     // function.
     private final static VariableDescription<ArrayVariable<DoubleVariable>> statesProbabilityNameLocal = VariableNames
-            .calcVarName("stateProbabilityLocal", VariableType.arrayType(VariableType.DoubleVariable), true);
+            .localCalcVarName("stateProbabilityLocal", VariableType.arrayType(VariableType.DoubleVariable), true);
 
     // Flags for the different variables that we will need to construct for this
     // function.
-    private final static VariableDescription<DoubleVariable> statesProbabilityValue = VariableNames
-            .calcVarName("stateProbabilityValue", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> statesProbabilityValue = VariableNames
+            .localCalcVarName("stateProbabilityValue", VariableType.DoubleVariable, true);
 
     // Log space accumulator for all the consumer sample probabilities calculated
     // so far.
-    private final static VariableDescription<DoubleVariable> consumerSampleProbabilitiesAccumulator = VariableNames
-            .calcVarName("accumulatedConsumerProbabilities", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> consumerSampleProbabilitiesAccumulator = VariableNames
+            .localCalcVarName("accumulatedConsumerProbabilities", VariableType.DoubleVariable, true);
 
     // Normal space accumulator for the probability of reaching each consumer.
-    private final static VariableDescription<DoubleVariable> consumerSampleDistributionProbabilityAccumulator = VariableNames
-            .calcVarName("consumerDistributionProbabilityAccumulator", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> consumerSampleDistributionProbabilityAccumulator = VariableNames
+            .localCalcVarName("consumerDistributionProbabilityAccumulator", VariableType.DoubleVariable, true);
 
     // Accumulator for all the consumer sample distributions calculated so far.
-    private final static VariableDescription<ArrayVariable<DoubleVariable>> consumerSampleDistributionAccumulator = VariableNames
-            .calcVarName("accumulatedConsumerDistributions", VariableType.arrayType(VariableType.DoubleVariable), true);
+    private final static LocalVariableDescription<ArrayVariable<DoubleVariable>> consumerSampleDistributionAccumulator = VariableNames
+            .localCalcVarName("accumulatedConsumerDistributions", VariableType.arrayType(VariableType.DoubleVariable), true);
 
     // An accumulator for the combined distribution probabilities calculated so far.
-    private final static VariableDescription<DoubleVariable> distributionProbabilityAccumulator = VariableNames
-            .calcVarName("accumulatedDistributionProbabilities", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> distributionProbabilityAccumulator = VariableNames
+            .localCalcVarName("accumulatedDistributionProbabilities", VariableType.DoubleVariable, true);
 
     // An accumulator for the overall probabilities for a source sample paring to be
     // summed in before they are multiplied into the overall result.
-    private final static VariableDescription<DoubleVariable> probabilitiesAccumulator = VariableNames
-            .calcVarName("accumulatedProbabilities", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> probabilitiesAccumulator = VariableNames
+            .localCalcVarName("accumulatedProbabilities", VariableType.DoubleVariable, true);
 
     // The value of the probabilities not reached when exploring the distributions
     // for the random variable.
-    private final static VariableDescription<DoubleVariable> reachedDistributionsSource = VariableNames
-            .calcVarName("reachedDistributionSourceRV", VariableType.DoubleVariable, true);
-    private final static VariableDescription<DoubleVariable> reachedDistributions = VariableNames
-            .calcVarName("reachedDistributionProbability", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> reachedDistributionsSource = VariableNames
+            .localCalcVarName("reachedDistributionSourceRV", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> reachedDistributions = VariableNames
+            .localCalcVarName("reachedDistributionProbability", VariableType.DoubleVariable, true);
 
     private final Map<DistributableRandomVariable<?, ?>, VariableDescription<ArrayVariable<DoubleVariable>>> globalDistributionScratchSpace = new HashMap<>();
 
-    private VariableDescription<ArrayVariable<DoubleVariable>> getDistributionAccumulatorName(
+    private ScratchVariableDescription<ArrayVariable<DoubleVariable>> getDistributionAccumulatorName(
             DistributableRandomVariable<?, ?> rv) {
-        return VariableNames.calcVarName("distributionAccumulator", rv.getUniqueVarDesc().name.getName(),
+        return VariableNames.globalScratchVarName("distributionAccumulator", rv.getUniqueVarDesc().name.getName(),
                 VariableType.arrayType(VariableType.DoubleVariable), true);
     }
 
@@ -193,7 +195,7 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
                         "A local array to hold the accumulated distributions of "
                                 + "the sample tasks for each configuration of distributions."));
 
-        VariableDescription<IntVariable> indexName = VariableNames.calcVarName("i", VariableType.IntVariable, true);
+        LocalVariableDescription<IntVariable> indexName = VariableNames.localCalcVarName("i", VariableType.IntVariable, true);
         IRTreeVoid body = arrayPut(load(consumerSampleDistributionAccumulator), load(indexName), constant(0.0),
                 Tree.NoComment);
         IRTreeVoid loop = IRTree.forStmt(body, constant(0), disRV.getNumStates().getForwardIR(info.compilationCtx),
@@ -210,22 +212,22 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
         // Get a local copy of the sample distribution
         IRTreeReturn<ArrayVariable<DoubleVariable>> sampleDistribution = s.getProbabilitiesArray()
                 .getForwardIR(info.compilationCtx);
-        VariableDescription<ArrayVariable<DoubleVariable>> sampleDescriptionName = VariableNames
-                .calcVarName("sampleDistribution", sampleDistribution.getOutputType(), true);
+        LocalVariableDescription<ArrayVariable<DoubleVariable>> sampleDescriptionName = VariableNames
+                .localCalcVarName("sampleDistribution", sampleDistribution.getOutputType(), true);
         info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(sampleDescriptionName,
                 sampleDistribution, "A local copy of the samples' distribution."));
 
-        VariableDescription<DoubleVariable> overlapName = VariableNames.calcVarName("overlap",
+        LocalVariableDescription<DoubleVariable> overlapName = VariableNames.localCalcVarName("overlap",
                 VariableType.DoubleVariable, true);
         info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(overlapName, constant(0.0), "The overlap of the distributions so far."));
 
         // Start constructing the body of the for loop
         IRTreeVoid[] bodyStmts = new IRTreeVoid[3];
-        VariableDescription<IntVariable> indexName = VariableNames.calcVarName("i", VariableType.IntVariable, true);
+        LocalVariableDescription<IntVariable> indexName = VariableNames.localCalcVarName("i", VariableType.IntVariable, true);
 
         // Normalise the calculated distribution value.
-        VariableDescription<DoubleVariable> normalisedName = VariableNames.calcVarName("normalisedDistValue",
+        LocalVariableDescription<DoubleVariable> normalisedName = VariableNames.localCalcVarName("normalisedDistValue",
                 VariableType.DoubleVariable, true);
         bodyStmts[0] = initializeVariable(normalisedName,
                 divideDD(arrayGet(load(consumerSampleDistributionAccumulator), load(indexName)),
@@ -233,7 +235,7 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
                 "Normalise the values in the calculated distribution");
 
         // Recover the sample distribution value for this position.
-        VariableDescription<DoubleVariable> sampleValueName = VariableNames.calcVarName("sampleDistValue",
+        LocalVariableDescription<DoubleVariable> sampleValueName = VariableNames.localCalcVarName("sampleDistValue",
                 VariableType.DoubleVariable, true);
         bodyStmts[1] = initializeVariable(sampleValueName, arrayGet(load(sampleDescriptionName), load(indexName)),
                 "Corresponding value from the sample distribution");
@@ -326,26 +328,26 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
             IRTreeReturn<ArrayVariable<DoubleVariable>> arrayValue = load(statesProbabilityNameLocal);
 
             // Bound for loops.
-            VariableDescription<IntVariable> endBound = VariableNames.calcVarName("endOfLoop", VariableType.IntVariable,
+            LocalVariableDescription<IntVariable> endBound = VariableNames.localCalcVarName("endOfLoop", VariableType.IntVariable,
                     true);
             info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     initializeVariable(endBound,
                             ((ArrayVariable<?>) funcData.sampleDesc.output).getMaxLength(info.compilationCtx),
                             "End bound for loops."));
 
-            VariableDescription<IntVariable> indexName = VariableNames.calcVarName("index", VariableType.IntVariable,
+            LocalVariableDescription<IntVariable> indexName = VariableNames.localCalcVarName("index", VariableType.IntVariable,
                     true);
 
             // Get the probability array
-            VariableDescription<ArrayVariable<DoubleVariable>> localProbability = VariableNames
-                    .calcVarName("localProbability", VariableType.arrayType(VariableType.DoubleVariable), true);
+            LocalVariableDescription<ArrayVariable<DoubleVariable>> localProbability = VariableNames
+                    .localCalcVarName("localProbability", VariableType.arrayType(VariableType.DoubleVariable), true);
             IRTreeReturn<ArrayVariable<DoubleVariable>> probabilityArray = ((DistributionSampleTask<?, ?>) funcData.sampleDesc.sample)
                     .getProbabilitiesArray().getForwardIR(info.compilationCtx);
             info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     initializeVariable(localProbability, probabilityArray, "Local copy of the probability array"));
-            VariableDescription<DoubleVariable> sumName = VariableNames.calcVarName("probabilitySum",
+            LocalVariableDescription<DoubleVariable> sumName = VariableNames.localCalcVarName("probabilitySum",
                     VariableType.DoubleVariable, true);
-            VariableDescription<DoubleVariable> valueName = VariableNames.calcVarName("probability",
+            LocalVariableDescription<DoubleVariable> valueName = VariableNames.localCalcVarName("probability",
                     VariableType.DoubleVariable, true);
 
             info.compilationCtx.addTreeToScope(GlobalScope.scope,
@@ -382,8 +384,8 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
     @Override
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> s,
             IRTreeReturn<DoubleVariable> sourceProbability, FuncData funcData, TreeBuilderInfo info) {
-        VariableDescription<DoubleVariable> distributionProbability = VariableNames
-                .calcVarName("distributionProbability", VariableType.DoubleVariable, true);
+        LocalVariableDescription<DoubleVariable> distributionProbability = VariableNames
+                .localCalcVarName("distributionProbability", VariableType.DoubleVariable, true);
         info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(distributionProbability, multiplyDD(sourceProbability, info.probability),
                         "The probability of reaching the consumer with this set of consumer arguments"));
@@ -464,7 +466,7 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
             return pTree;
 
         Variable<C> pInit = compilationCtx.addInitialized(p);
-        VariableDescription<C> pName = pInit.getUniqueVarDesc();
+        LocalVariableDescription<C> pName = (LocalVariableDescription<C>)pInit.getUniqueVarDesc();
         compilationCtx.addTreeToScope(p.scope(),
                 initializeVariable(pName, pTree, "Constructing a random variable input for use later."));
         return IRTree.load(pName);
@@ -495,7 +497,7 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
                     // TODO shrink the size of this by constructing a set of sizes, not an array for
                     // each random variable.
                     DistributableRandomVariable<?, ?> disRV = (DistributableRandomVariable<?, ?>) rv;
-                    VariableDescription<ArrayVariable<DoubleVariable>> disAccumulatorName = getDistributionAccumulatorName(
+                    ScratchVariableDescription<ArrayVariable<DoubleVariable>> disAccumulatorName = getDistributionAccumulatorName(
                             disRV);
                     globalDistributionScratchSpace.put(disRV, disAccumulatorName);
                     allocateGlobalArray(funcData, disRV, disAccumulatorName);
@@ -510,7 +512,7 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
     protected abstract void allocateGlobalStateProb(FuncData funcData);
 
     protected <C extends Variable<C>> void allocateGlobalArray(FuncData funcData, DistributableRandomVariable<?, ?> rv,
-            VariableDescription<ArrayVariable<C>> variableDescription) {
+            ScratchVariableDescription<ArrayVariable<C>> variableDescription) {
         // Allocate space for storing the results.
         funcData.compilationCtx.pushScopeState();
         // Because of the reuse of max this needs to be serial. We could overcome this by taking a copy of the value of
@@ -533,7 +535,7 @@ public abstract class InferenceGeneratorArrayProb<A extends Variable<A>, B exten
         funcData.compilationCtx.popIsSerial();
         funcData.compilationCtx.popScopeState();
 
-        createGlobalField(variableDescription, allocator, funcData);
+        createScratchClassField(variableDescription, allocator, funcData);
     }
 
     /**

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorBase.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorBase.java
@@ -40,6 +40,9 @@ import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.ProducingDataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.GlobalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.ScratchVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -201,7 +204,7 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
             }
 
             // Otherwise create a flag to record if the observed variables are reachable
-            VariableDescription<BooleanVariable> observationGuard = VariableNames.calcVarName("varObserved",
+            LocalVariableDescription<BooleanVariable> observationGuard = VariableNames.localCalcVarName("varObserved",
                     VariableType.BooleanVariable, true);
             targetScope.addTree((TreeBuilderInfo info) -> {
                 initializeVariable(observationGuard, constant(false), "A guard to record if the variable is observed");
@@ -261,8 +264,8 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
 
     protected abstract FuncData getFunctionData(SampleTask<A, B> sample, CompilationContext compilationCtx);
 
-    private static final VariableDescription<BooleanVariable> constrained = VariableNames
-            .calcVarName("sampleConstrained", VariableType.BooleanVariable, true);
+    private static final LocalVariableDescription<BooleanVariable> constrained = VariableNames
+            .localCalcVarName("sampleConstrained", VariableType.BooleanVariable, true);
 
     /**
      * Method to generate a function calculate the result of a conjugate pairing.
@@ -679,7 +682,7 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
 
         ScopeConstructor dConsumerAllArgs = c.applyDistributedArguments(1).applyDistributedArguments(2);
 
-        VariableDescription<DoubleVariable> reachedSourceName = VariableNames.scopeVarName("reachedSourceProbability",
+        LocalVariableDescription<DoubleVariable> reachedSourceName = VariableNames.scopeVarName("reachedSourceProbability",
                 VariableType.DoubleVariable);
         dConsumerAllArgs.addTree((TreeBuilderInfo info) -> info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(reachedSourceName, constant(0.0),
@@ -832,10 +835,10 @@ public abstract class InferenceGeneratorBase<A extends Variable<A>, B extends Ra
                 scopes.get(scopes.size() - 1), funcData.compilationCtx);
     }
 
-    protected <V extends Variable<V>> void createGlobalField(VariableDescription<V> fieldName, IRTreeVoid allocator,
+    protected <V extends Variable<V>> void createScratchClassField(ScratchVariableDescription<V> fieldName, IRTreeVoid allocator,
             FunctionData<A, B, S> funcData) {
         List<Scope> scopes = funcData.sampleDesc.scopes;
-        FunctionUtils.createGlobalField(fieldName, allocator, funcData.isSerial, scopes.get(scopes.size() - 1),
+        FunctionUtils.createScratchClassField(fieldName, allocator, funcData.isSerial, scopes.get(scopes.size() - 1),
                 funcData.compilationCtx);
     }
 

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorScalarProb.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/InferenceGeneratorScalarProb.java
@@ -42,6 +42,10 @@ import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.ClassVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.GlobalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.ScratchVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -127,56 +131,56 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
         }
     }
 
-    private final static VariableDescription<IntVariable> valuePosName = VariableNames.calcVarName("valuePos",
+    private final static VariableDescription<IntVariable> valuePosName = VariableNames.localCalcVarName("valuePos",
             VariableType.IntVariable, false);
 
-    protected final static VariableDescription<IntVariable> numStatesName = VariableNames.calcVarName("numStates",
+    protected final static LocalVariableDescription<IntVariable> numStatesName = VariableNames.localCalcVarName("numStates",
             VariableType.IntVariable, false);
 
     // Flags for the different variables that we will need to construct for this
     // function.
-    private final static VariableDescription<DoubleVariable> statesProbabilityValue = VariableNames
-            .calcVarName("stateProbabilityValue", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> statesProbabilityValue = VariableNames
+            .localCalcVarName("stateProbabilityValue", VariableType.DoubleVariable, true);
 
     // Log space accumulator for all the consumer sample probabilities calculated
     // so far.
-    private final static VariableDescription<DoubleVariable> consumerSampleProbabilitiesAccumulator = VariableNames
-            .calcVarName("accumulatedConsumerProbabilities", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> consumerSampleProbabilitiesAccumulator = VariableNames
+            .localCalcVarName("accumulatedConsumerProbabilities", VariableType.DoubleVariable, true);
 
     // Normal space accumulator for the probability of reaching each consumer.
-    private final static VariableDescription<DoubleVariable> consumerSampleDistributionProbabilityAccumulator = VariableNames
-            .calcVarName("consumerDistributionProbabilityAccumulator", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> consumerSampleDistributionProbabilityAccumulator = VariableNames
+            .localCalcVarName("consumerDistributionProbabilityAccumulator", VariableType.DoubleVariable, true);
 
     // Accumulator for all the consumer sample distributions calculated so far.
-    private final static VariableDescription<ArrayVariable<DoubleVariable>> consumerSampleDistributionAccumulator = VariableNames
-            .calcVarName("accumulatedConsumerDistributions", VariableType.arrayType(VariableType.DoubleVariable), true);
+    private final static LocalVariableDescription<ArrayVariable<DoubleVariable>> consumerSampleDistributionAccumulator = VariableNames
+            .localCalcVarName("accumulatedConsumerDistributions", VariableType.arrayType(VariableType.DoubleVariable), true);
 
     // An accumulator for the combined distribution probabilities calculated so far.
-    private final static VariableDescription<DoubleVariable> distributionProbabilityAccumulator = VariableNames
-            .calcVarName("accumulatedDistributionProbabilities", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> distributionProbabilityAccumulator = VariableNames
+            .localCalcVarName("accumulatedDistributionProbabilities", VariableType.DoubleVariable, true);
 
     // An accumulator for the overall probabilities for a source sample paring to be
     // summed in before they are multiplied into the overall result.
-    private final static VariableDescription<DoubleVariable> probabilitiesAccumulator = VariableNames
-            .calcVarName("accumulatedProbabilities", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> probabilitiesAccumulator = VariableNames
+            .localCalcVarName("accumulatedProbabilities", VariableType.DoubleVariable, true);
 
     // The value of the probabilities not reached when exploring the distributions
     // for the random variable.
-    private final static VariableDescription<DoubleVariable> reachedDistributionsSource = VariableNames
-            .calcVarName("reachedDistributionSourceRV", VariableType.DoubleVariable, true);
-    private final static VariableDescription<DoubleVariable> reachedDistributions = VariableNames
-            .calcVarName("reachedDistributionProbability", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> reachedDistributionsSource = VariableNames
+            .localCalcVarName("reachedDistributionSourceRV", VariableType.DoubleVariable, true);
+    private final static LocalVariableDescription<DoubleVariable> reachedDistributions = VariableNames
+            .localCalcVarName("reachedDistributionProbability", VariableType.DoubleVariable, true);
 
     private final Map<DistributableRandomVariable<?, ?>, VariableDescription<ArrayVariable<DoubleVariable>>> globalDistributionScratchSpace = new HashMap<>();
 
-    private VariableDescription<ArrayVariable<DoubleVariable>> getDistributionAccumulatorName(
+    private ScratchVariableDescription<ArrayVariable<DoubleVariable>> getDistributionAccumulatorName(
             DistributableRandomVariable<?, ?> rv) {
-        return VariableNames.calcVarName("distributionAccumulator", rv.getUniqueVarDesc().name.getName(),
+        return VariableNames.globalScratchVarName("distributionAccumulator", rv.getUniqueVarDesc().name.getName(),
                 VariableType.arrayType(VariableType.DoubleVariable), true);
     }
 
     // The current value being considered
-    private VariableDescription<A> currentValueName;
+    private LocalVariableDescription<A> currentValueName;
     private Variable<A> currentValue;
 
     private boolean canSetCurrent = false;
@@ -207,7 +211,7 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
             constructFunctionVariablesProb(funcData);
         });
 
-        currentValueName = VariableNames.calcVarName("currentValue", funcData.sampleDesc.output.getType(), true);
+        currentValueName = VariableNames.localCalcVarName("currentValue", funcData.sampleDesc.output.getType(), true);
         currentValue = Variable.namedVariable(currentValueName);
         funcData.compilationCtx.addSubstitute(funcData.sampleDesc.output, currentValue);
     }
@@ -234,7 +238,7 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
                         "A local array to hold the accumulated distributions of "
                                 + "the sample tasks for each configuration of distributions."));
 
-        VariableDescription<IntVariable> indexName = VariableNames.calcVarName("i", VariableType.IntVariable, true);
+        LocalVariableDescription<IntVariable> indexName = VariableNames.localCalcVarName("i", VariableType.IntVariable, true);
         IRTreeVoid body = arrayPut(load(consumerSampleDistributionAccumulator), load(indexName), constant(0.0),
                 Tree.NoComment);
         IRTreeVoid loop = IRTree.forStmt(body, constant(0), disRV.getNumStates().getForwardIR(funcData.compilationCtx),
@@ -251,22 +255,22 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
         // Get a local copy of the sample distribution
         IRTreeReturn<ArrayVariable<DoubleVariable>> sampleDistribution = s.getProbabilitiesArray()
                 .getForwardIR(info.compilationCtx);
-        VariableDescription<ArrayVariable<DoubleVariable>> sampleDescriptionName = VariableNames
-                .calcVarName("sampleDistribution", sampleDistribution.getOutputType(), true);
+        LocalVariableDescription<ArrayVariable<DoubleVariable>> sampleDescriptionName = VariableNames
+                .localCalcVarName("sampleDistribution", sampleDistribution.getOutputType(), true);
         info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(sampleDescriptionName,
                 sampleDistribution, "A local copy of the samples' distribution."));
 
-        VariableDescription<DoubleVariable> overlapName = VariableNames.calcVarName("overlap",
+        LocalVariableDescription<DoubleVariable> overlapName = VariableNames.localCalcVarName("overlap",
                 VariableType.DoubleVariable, true);
         info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(overlapName, constant(0.0), "The overlap of the distributions so far."));
 
         // Start constructing the body of the for loop
         IRTreeVoid[] bodyStmts = new IRTreeVoid[3];
-        VariableDescription<IntVariable> indexName = VariableNames.calcVarName("i", VariableType.IntVariable, true);
+        LocalVariableDescription<IntVariable> indexName = VariableNames.localCalcVarName("i", VariableType.IntVariable, true);
 
         // Normalise the calculated distribution value.
-        VariableDescription<DoubleVariable> normalisedName = VariableNames.calcVarName("normalisedDistValue",
+        LocalVariableDescription<DoubleVariable> normalisedName = VariableNames.localCalcVarName("normalisedDistValue",
                 VariableType.DoubleVariable, true);
         bodyStmts[0] = initializeVariable(normalisedName,
                 divideDD(arrayGet(load(consumerSampleDistributionAccumulator), load(indexName)),
@@ -274,7 +278,7 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
                 "Normalise the values in the calculated distribution");
 
         // Recover the sample distribution value for this position.
-        VariableDescription<DoubleVariable> sampleValueName = VariableNames.calcVarName("sampleDistValue",
+        LocalVariableDescription<DoubleVariable> sampleValueName = VariableNames.localCalcVarName("sampleDistValue",
                 VariableType.DoubleVariable, true);
         bodyStmts[1] = initializeVariable(sampleValueName, arrayGet(load(sampleDescriptionName), load(indexName)),
                 "Corresponding value from the sample distribution");
@@ -365,8 +369,8 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
     @Override
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> s,
             IRTreeReturn<DoubleVariable> sourceProbability, FuncData funcData, TreeBuilderInfo info) {
-        VariableDescription<DoubleVariable> distributionProbability = VariableNames
-                .calcVarName("distributionProbability", VariableType.DoubleVariable, true);
+        LocalVariableDescription<DoubleVariable> distributionProbability = VariableNames
+                .localCalcVarName("distributionProbability", VariableType.DoubleVariable, true);
         info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(distributionProbability, multiplyDD(sourceProbability, info.probability),
                         "The probability of reaching the consumer with this set of consumer arguments"));
@@ -447,7 +451,7 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
             return pTree;
 
         Variable<C> pInit = compilationCtx.addInitialized(p);
-        VariableDescription<C> pName = pInit.getUniqueVarDesc();
+        LocalVariableDescription<C> pName = (LocalVariableDescription<C>)pInit.getUniqueVarDesc();
         compilationCtx.addTreeToScope(p.scope(),
                 initializeVariable(pName, pTree, "Constructing a random variable input for use later."));
         return IRTree.load(pName);
@@ -486,10 +490,10 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
                     // TODO shrink the size of this by constructing a set of sizes, not an array for
                     // each random variable.
                     DistributableRandomVariable<?, ?> disRV = (DistributableRandomVariable<?, ?>) rv;
-                    VariableDescription<ArrayVariable<DoubleVariable>> disAccumulatorName = getDistributionAccumulatorName(
+                    ScratchVariableDescription<ArrayVariable<DoubleVariable>> disAccumulatorName = getDistributionAccumulatorName(
                             disRV);
                     globalDistributionScratchSpace.put(disRV, disAccumulatorName);
-                    allocateGlobalArray(funcData, disRV, disAccumulatorName);
+                    allocateScratchArray(funcData, disRV, disAccumulatorName);
                     break;
                 }
             }
@@ -500,8 +504,8 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
 
     protected abstract void allocateGlobalStateProb(FuncData funcData);
 
-    protected <C extends Variable<C>> void allocateGlobalArray(FuncData funcData, DistributableRandomVariable<?, ?> rv,
-            VariableDescription<ArrayVariable<C>> variableDescription) {
+    protected <C extends Variable<C>> void allocateScratchArray(FuncData funcData, DistributableRandomVariable<?, ?> rv,
+            ScratchVariableDescription<ArrayVariable<C>> variableDescription) {
         // Allocate space for storing the results.
         funcData.compilationCtx.pushScopeState();
         /*
@@ -526,7 +530,7 @@ public abstract class InferenceGeneratorScalarProb<A extends ScalarVariable<A>, 
         funcData.compilationCtx.popIsSerial();
         funcData.compilationCtx.popScopeState();
 
-        createGlobalField(variableDescription, allocator, funcData);
+        createScratchClassField(variableDescription, allocator, funcData);
     }
 
     /**

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/BetaToBernoulliBinomial.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/BetaToBernoulliBinomial.java
@@ -33,7 +33,7 @@ import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.DFType;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.RandomVariableType;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
@@ -61,11 +61,11 @@ public class BetaToBernoulliBinomial
             extends InferenceGeneratorScalar.ScalarFunctionData<DoubleVariable, Beta> {
         // Names for the different variables that will be needed to construct for this
         // function.s
-        final VariableDescription<IntVariable> noTrueName;
-        final VariableDescription<IntVariable> noTrialsName;
+        final LocalVariableDescription<IntVariable> noTrueName;
+        final LocalVariableDescription<IntVariable> noTrialsName;
 
-        final VariableDescription<DoubleVariable> noTrueNameDis;
-        final VariableDescription<DoubleVariable> noTrialsNameDis;
+        final LocalVariableDescription<DoubleVariable> noTrueNameDis;
+        final LocalVariableDescription<DoubleVariable> noTrialsNameDis;
 
         final boolean distributedConsumers;
 
@@ -73,11 +73,11 @@ public class BetaToBernoulliBinomial
                 CompilationContext compilationCtx) {
             super(sample, false, compilationCtx);
 
-            noTrueName = VariableNames.calcVarName("sum", VariableType.IntVariable, true);
-            noTrialsName = VariableNames.calcVarName("count", VariableType.IntVariable, true);
+            noTrueName = VariableNames.localCalcVarName("sum", VariableType.IntVariable, true);
+            noTrialsName = VariableNames.localCalcVarName("count", VariableType.IntVariable, true);
 
-            noTrueNameDis = VariableNames.calcVarName("sum", VariableType.DoubleVariable, true);
-            noTrialsNameDis = VariableNames.calcVarName("count", VariableType.DoubleVariable, true);
+            noTrueNameDis = VariableNames.localCalcVarName("sum", VariableType.DoubleVariable, true);
+            noTrialsNameDis = VariableNames.localCalcVarName("count", VariableType.DoubleVariable, true);
 
             boolean distributed = false;
             for(RandomVariable<?, ?> consumingRV:consumingRVs)
@@ -253,8 +253,8 @@ public class BetaToBernoulliBinomial
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> task,
             IRTreeReturn<DoubleVariable> sourceProbability, BetaToBernoulliBinomialData funcData,
             TreeBuilderInfo info) {
-        VariableDescription<DoubleVariable> distributionProbability = VariableNames
-                .calcVarName("distributionProbability", VariableType.DoubleVariable, true);
+        LocalVariableDescription<DoubleVariable> distributionProbability = VariableNames
+                .localCalcVarName("distributionProbability", VariableType.DoubleVariable, true);
         info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(distributionProbability, multiplyDD(sourceProbability, info.probability),
                         "The probability of reaching the consumer with this set of consumer arguments"));
@@ -274,9 +274,9 @@ public class BetaToBernoulliBinomial
                     addDD(load(funcData.noTrialsNameDis),
                             multiplyDI(load(distributionProbability), load(binomial.length))),
                     "Increment the number of booleans sampled.");
-            VariableDescription<DoubleVariable> accumulator = VariableNames.calcVarName("accumulator",
+            LocalVariableDescription<DoubleVariable> accumulator = VariableNames.localCalcVarName("accumulator",
                     VariableType.DoubleVariable, true);
-            VariableDescription<IntVariable> indexName = VariableNames.indexName(distribution.getUniqueVarDesc());
+            LocalVariableDescription<IntVariable> indexName = VariableNames.indexName(distribution.getUniqueVarDesc());
             List<IRTreeVoid> scopedTrees = new ArrayList<>();
             scopedTrees.add(initializeVariable(accumulator, constant(0.0),
                     "An accumulator to calculate the probable number of true booleans"));

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/DirichletToCategoricalMultinomial.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/DirichletToCategoricalMultinomial.java
@@ -23,15 +23,17 @@ import java.util.List;
 import java.util.Set;
 
 import org.sandwood.compiler.compilation.CompilationContext;
-import org.sandwood.compiler.compilation.FunctionType;
 import org.sandwood.compiler.compilation.CompilationContext.CompilationPhase;
+import org.sandwood.compiler.compilation.FunctionType;
 import org.sandwood.compiler.compilation.inference.InferenceGenerator;
 import org.sandwood.compiler.compilation.inference.InferenceGeneratorArray;
 import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.DFType;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.GlobalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.ScratchVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.RandomVariableType;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
@@ -58,21 +60,21 @@ public class DirichletToCategoricalMultinomial extends
             extends InferenceGeneratorArray.ArrayFunctionData<DoubleVariable, Dirichlet> {
         // Names for the different variables that will be needed to construct for this
         // function.
-        final VariableDescription<ArrayVariable<DoubleVariable>> countNameGlobal;
+        final ScratchVariableDescription<ArrayVariable<DoubleVariable>> countNameGlobal;
 
         protected DirichletToCategoricalData(SampleTask<ArrayVariable<DoubleVariable>, Dirichlet> sample,
                 CompilationContext compilationCtx) {
             super(sample, false, compilationCtx);
-            countNameGlobal = VariableNames.calcVarName(sampleDesc.output, "countGlobal",
+            countNameGlobal = VariableNames.globalScratchVarName(sampleDesc.output, "countGlobal",
                     VariableType.arrayType(VariableType.DoubleVariable));
         }
     }
 
-    private static final VariableDescription<ArrayVariable<DoubleVariable>> countNameLocal = VariableNames
-            .calcVarName("countLocal", VariableType.arrayType(VariableType.DoubleVariable), true);
-    private static final VariableDescription<IntVariable> arrayLength = VariableNames.calcVarName("arrayLength",
+    private static final LocalVariableDescription<ArrayVariable<DoubleVariable>> countNameLocal = VariableNames
+            .localCalcVarName("countLocal", VariableType.arrayType(VariableType.DoubleVariable), true);
+    private static final LocalVariableDescription<IntVariable> arrayLength = VariableNames.localCalcVarName("arrayLength",
             VariableType.IntVariable, true);
-    private static final VariableDescription<IntVariable> loopIndex = VariableNames.calcVarName("loopIndex",
+    private static final LocalVariableDescription<IntVariable> loopIndex = VariableNames.localCalcVarName("loopIndex",
             VariableType.IntVariable, true);
 
     private DirichletToCategoricalMultinomial() {}
@@ -152,7 +154,7 @@ public class DirichletToCategoricalMultinomial extends
         } else if(type == VariableType.Multinomial) {
             // Save the reference to the sample value for efficient access.
             IRTreeReturn<ArrayVariable<IntVariable>> sampleValue = (IRTreeReturn<ArrayVariable<IntVariable>>) current;
-            VariableDescription<ArrayVariable<IntVariable>> sampleValueName = VariableNames.calcVarName("sampleValue",
+            LocalVariableDescription<ArrayVariable<IntVariable>> sampleValueName = VariableNames.localCalcVarName("sampleValue",
                     sampleValue.getOutputType(), true);
             info.compilationCtx.addTreeToScope(GlobalScope.scope,
                     initializeVariable(sampleValueName, sampleValue, Tree.NoComment));
@@ -243,15 +245,15 @@ public class DirichletToCategoricalMultinomial extends
         funcData.compilationCtx.popIsSerial();
         funcData.compilationCtx.popScopeState();
 
-        createGlobalField(funcData.countNameGlobal, allocator, funcData);
+        createScratchClassField(funcData.countNameGlobal, allocator, funcData);
     }
 
     @Override
     protected void getDistributionSampleIR(DistributionSampleTask<?, ?> s,
             IRTreeReturn<DoubleVariable> sourceProbability, DirichletToCategoricalData funcData, TreeBuilderInfo info) {
 
-        VariableDescription<DoubleVariable> distributionProbability = VariableNames
-                .calcVarName("distributionProbability", VariableType.DoubleVariable, true);
+        LocalVariableDescription<DoubleVariable> distributionProbability = VariableNames
+                .localCalcVarName("distributionProbability", VariableType.DoubleVariable, true);
         info.compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(distributionProbability, multiplyDD(sourceProbability, info.probability),
                         "The probability of reaching the consumer with this set of consumer arguments"));

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GammaToExponential.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GammaToExponential.java
@@ -28,6 +28,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.DFType;
 import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.auxillary.DataflowTaskArgDesc;
@@ -56,9 +57,9 @@ public class GammaToExponential
 
     // Names for the different variables that will be needed to construct for this
     // function.
-    private final VariableDescription<DoubleVariable> sumName = VariableNames.calcVarName("sum",
+    private final LocalVariableDescription<DoubleVariable> sumName = VariableNames.localCalcVarName("sum",
             VariableType.DoubleVariable, true);
-    private final VariableDescription<IntVariable> countName = VariableNames.calcVarName("count",
+    private final LocalVariableDescription<IntVariable> countName = VariableNames.localCalcVarName("count",
             VariableType.IntVariable, true);
 
     private GammaToExponential() {}

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GammaToGaussian.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GammaToGaussian.java
@@ -35,7 +35,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.Divide;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.constant.ConstantDoubleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.constant.ConstantIntTask;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.auxillary.DataflowTaskArgDesc;
 import org.sandwood.compiler.dataflowGraph.variables.randomVariables.Gamma;
@@ -59,13 +59,13 @@ public class GammaToGaussian
             extends InferenceGeneratorScalar.ScalarFunctionData<DoubleVariable, Gamma> {
         // Names for the different variables that will be needed to construct for this
         // function.
-        final VariableDescription<DoubleVariable> sumName;
-        final VariableDescription<IntVariable> countName;
+        final LocalVariableDescription<DoubleVariable> sumName;
+        final LocalVariableDescription<IntVariable> countName;
 
         protected GammaToGaussianData(SampleTask<DoubleVariable, Gamma> sample, CompilationContext compilationCtx) {
             super(sample, false, compilationCtx);
-            sumName = VariableNames.calcVarName("sum", VariableType.DoubleVariable, true);
-            countName = VariableNames.calcVarName("count", VariableType.IntVariable, true);
+            sumName = VariableNames.localCalcVarName("sum", VariableType.DoubleVariable, true);
+            countName = VariableNames.localCalcVarName("count", VariableType.IntVariable, true);
         }
     }
 
@@ -122,7 +122,7 @@ public class GammaToGaussian
     @Override
     protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer,
             GammaToGaussianData funcData) {
-        VariableDescription<DoubleVariable> muName = VariableNames.calcVarName(consumer, "mu",
+        LocalVariableDescription<DoubleVariable> muName = VariableNames.localCalcVarName(consumer, "mu",
                 VariableType.DoubleVariable);
         info.compilationCtx.addTreeToScope(consumer.getParent().scope(),
                 initializeVariable(muName, ((Gaussian) consumer).mean.getForwardIR(info.compilationCtx),
@@ -133,9 +133,9 @@ public class GammaToGaussian
     @Override
     protected void getObservationToSampleIR(SampleTask<?, ?> task, IRTreeReturn<?> current,
             GammaToGaussianData funcData, TreeBuilderInfo info) {
-        VariableDescription<DoubleVariable> muName = VariableNames.calcVarName(task.randomVariable, "mu",
+        LocalVariableDescription<DoubleVariable> muName = VariableNames.localCalcVarName(task.randomVariable, "mu",
                 VariableType.DoubleVariable);
-        VariableDescription<DoubleVariable> diffName = VariableNames.calcVarName(task.randomVariable, "diff",
+        LocalVariableDescription<DoubleVariable> diffName = VariableNames.localCalcVarName(task.randomVariable, "diff",
                 VariableType.DoubleVariable);
 
         List<IRTreeVoid> trees = new ArrayList<>();

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GammaToPoisson.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GammaToPoisson.java
@@ -28,7 +28,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.DFType;
 import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.auxillary.DataflowTaskArgDesc;
 import org.sandwood.compiler.dataflowGraph.variables.randomVariables.Gamma;
@@ -51,16 +51,16 @@ public class GammaToPoisson extends InferenceGeneratorScalar<DoubleVariable, Gam
             extends InferenceGeneratorScalar.ScalarFunctionData<DoubleVariable, Gamma> {
         // Names for the different variables that need to be construct for this
         // function.
-        final VariableDescription<DoubleVariable> sumName;
-        final VariableDescription<IntVariable> countName;
-        final VariableDescription<DoubleVariable> countNameDis;
+        final LocalVariableDescription<DoubleVariable> sumName;
+        final LocalVariableDescription<IntVariable> countName;
+        final LocalVariableDescription<DoubleVariable> countNameDis;
         final boolean distributedConsumers;
 
         protected GammaToPoissonData(SampleTask<DoubleVariable, Gamma> sample, CompilationContext compilationCtx) {
             super(sample, false, compilationCtx);
-            sumName = VariableNames.calcVarName("sum", VariableType.DoubleVariable, true);
-            countName = VariableNames.calcVarName("count", VariableType.IntVariable, true);
-            countNameDis = VariableNames.calcVarName("count", VariableType.DoubleVariable, true);
+            sumName = VariableNames.localCalcVarName("sum", VariableType.DoubleVariable, true);
+            countName = VariableNames.localCalcVarName("count", VariableType.IntVariable, true);
+            countNameDis = VariableNames.localCalcVarName("count", VariableType.DoubleVariable, true);
 
             boolean distributed = false;
             for(RandomVariable<?, ?> consumingRV:consumingRVs)

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GaussianToGaussian.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/GaussianToGaussian.java
@@ -54,8 +54,8 @@ import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.Subtract;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ReductionInput;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ReductionReturnTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.auxillary.DataflowTaskArgDesc;
 import org.sandwood.compiler.dataflowGraph.variables.randomVariables.Gaussian;
@@ -80,25 +80,25 @@ public class GaussianToGaussian
             extends InferenceGeneratorScalar.ScalarFunctionData<DoubleVariable, Gaussian> {
         // Names for the different variables that need to be constructed for this
         // function.
-        final VariableDescription<DoubleVariable> sumName;
-        final VariableDescription<DoubleVariable> denominatorSquareSumName;
-        final VariableDescription<DoubleVariable> sigmaValueName;
-        final VariableDescription<BooleanVariable> sigmaNotFoundName;
+        final LocalVariableDescription<DoubleVariable> sumName;
+        final LocalVariableDescription<DoubleVariable> denominatorSquareSumName;
+        final LocalVariableDescription<DoubleVariable> sigmaValueName;
+        final LocalVariableDescription<BooleanVariable> sigmaNotFoundName;
 
-        final VariableDescription<DoubleVariable> denominatorName;
-        final VariableDescription<DoubleVariable> numeratorName;
+        final LocalVariableDescription<DoubleVariable> denominatorName;
+        final LocalVariableDescription<DoubleVariable> numeratorName;
 
         protected GaussianToGaussianData(SampleTask<DoubleVariable, Gaussian> sample,
                 CompilationContext compilationCtx) {
             super(sample, false, compilationCtx);
-            sumName = VariableNames.calcVarName("sum", VariableType.DoubleVariable, true);
-            denominatorSquareSumName = VariableNames.calcVarName("denominatorSquareSum", VariableType.DoubleVariable,
+            sumName = VariableNames.localCalcVarName("sum", VariableType.DoubleVariable, true);
+            denominatorSquareSumName = VariableNames.localCalcVarName("denominatorSquareSum", VariableType.DoubleVariable,
                     true);
-            sigmaValueName = VariableNames.calcVarName("sigmaValue", VariableType.DoubleVariable, true);
-            sigmaNotFoundName = VariableNames.calcVarName("sigmaNotFound", VariableType.BooleanVariable, true);
+            sigmaValueName = VariableNames.localCalcVarName("sigmaValue", VariableType.DoubleVariable, true);
+            sigmaNotFoundName = VariableNames.localCalcVarName("sigmaNotFound", VariableType.BooleanVariable, true);
 
-            denominatorName = VariableNames.calcVarName("denominator", VariableType.DoubleVariable, false);
-            numeratorName = VariableNames.calcVarName("numerator", VariableType.DoubleVariable, false);
+            denominatorName = VariableNames.localCalcVarName("denominator", VariableType.DoubleVariable, false);
+            numeratorName = VariableNames.localCalcVarName("numerator", VariableType.DoubleVariable, false);
         }
     }
 

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/InverseGammaToGaussian.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/conjugatePrior/InverseGammaToGaussian.java
@@ -35,7 +35,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.Divide;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.constant.ConstantDoubleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.constant.ConstantIntTask;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.auxillary.DataflowTaskArgDesc;
 import org.sandwood.compiler.dataflowGraph.variables.randomVariables.Gaussian;
@@ -59,17 +59,17 @@ public class InverseGammaToGaussian extends
             extends InferenceGeneratorScalar.ScalarFunctionData<DoubleVariable, InverseGamma> {
         // Names for the different variables that we will need to construct for this
         // function.
-        final VariableDescription<DoubleVariable> sumName;
-        final VariableDescription<IntVariable> countName;
-        final VariableDescription<DoubleVariable> countNameDis;
+        final LocalVariableDescription<DoubleVariable> sumName;
+        final LocalVariableDescription<IntVariable> countName;
+        final LocalVariableDescription<DoubleVariable> countNameDis;
         final boolean distributedConsumers;
 
         protected InverseGammaToGaussianData(SampleTask<DoubleVariable, InverseGamma> sample,
                 CompilationContext compilationCtx) {
             super(sample, false, compilationCtx);
-            sumName = VariableNames.calcVarName("sum", VariableType.DoubleVariable, true);
-            countName = VariableNames.calcVarName("count", VariableType.IntVariable, true);
-            countNameDis = VariableNames.calcVarName("count", VariableType.DoubleVariable, true);
+            sumName = VariableNames.localCalcVarName("sum", VariableType.DoubleVariable, true);
+            countName = VariableNames.localCalcVarName("count", VariableType.IntVariable, true);
+            countNameDis = VariableNames.localCalcVarName("count", VariableType.DoubleVariable, true);
 
             boolean distributed = false;
             for(RandomVariable<?, ?> consumingRV:consumingRVs)
@@ -137,7 +137,7 @@ public class InverseGammaToGaussian extends
     @Override
     protected void getConsumerRVInputIR(TreeBuilderInfo info, RandomVariable<?, ?> consumer,
             InverseGammaToGaussianData funcData) {
-        VariableDescription<DoubleVariable> muName = VariableNames.calcVarName(consumer, "mu",
+        LocalVariableDescription<DoubleVariable> muName = VariableNames.localCalcVarName(consumer, "mu",
                 VariableType.DoubleVariable);
 
         info.compilationCtx.addTreeToScope(consumer.getParent().scope(),
@@ -147,12 +147,12 @@ public class InverseGammaToGaussian extends
 
     @SuppressWarnings("unchecked")
     @Override
-    protected void getObservationToSampleIR(SampleTask<?, ?> task, IRTreeReturn<?> current,
+    protected void getObservationToSampleIR(SampleTask<?, ?> consumer, IRTreeReturn<?> current,
             InverseGammaToGaussianData funcData, TreeBuilderInfo info) {
 
-        VariableDescription<DoubleVariable> muName = VariableNames.calcVarName(task.randomVariable, "mu",
+        LocalVariableDescription<DoubleVariable> muName = VariableNames.localCalcVarName(consumer.randomVariable, "mu",
                 VariableType.DoubleVariable);
-        VariableDescription<DoubleVariable> diffName = VariableNames.calcVarName(task.randomVariable, "diff",
+        LocalVariableDescription<DoubleVariable> diffName = VariableNames.localCalcVarName(consumer.randomVariable, "diff",
                 VariableType.DoubleVariable);
 
         List<IRTreeVoid> trees = new ArrayList<>();
@@ -171,8 +171,8 @@ public class InverseGammaToGaussian extends
                     "Increment the number of samples in the calculation."));
         }
 
-        info.compilationCtx.addTreeToScope(task.scope(), sequential(trees, "Consume sample task " + task.id()
-                + " from random variable " + task.randomVariable.getVarDesc() + "."));
+        info.compilationCtx.addTreeToScope(consumer.scope(), sequential(trees, "Consume sample task " + consumer.id()
+                + " from random variable " + consumer.randomVariable.getVarDesc() + "."));
     }
 
     @Override

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/marginalization/MarginalizationFunctions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/marginalization/MarginalizationFunctions.java
@@ -31,7 +31,9 @@ import org.sandwood.compiler.compilation.util.TreeUtils;
 import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.GlobalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.ScratchVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
 import org.sandwood.compiler.dataflowGraph.variables.randomVariables.DistributableRandomVariable;
@@ -96,20 +98,20 @@ public class MarginalizationFunctions<A extends ScalarVariable<A>, B extends Dis
 
         // Names for the different variables that we will need to construct for this
         // function.
-        final VariableDescription<ArrayVariable<DoubleVariable>> statesProbabilityNameGlobal;
+        final ScratchVariableDescription<ArrayVariable<DoubleVariable>> statesProbabilityNameGlobal;
 
         protected MarginalizationData(SampleTask<A, B> sample, CompilationContext compilationCtx) {
             super(sample, sample.randomVariable.getNumStates(), compilationCtx);
 
-            statesProbabilityNameGlobal = VariableNames.calcVarName(sampleDesc.output, "stateProbabilityGlobal",
+            statesProbabilityNameGlobal = VariableNames.globalScratchVarName(sampleDesc.output, "stateProbabilityGlobal",
                     VariableType.arrayType(VariableType.DoubleVariable));
         }
     }
 
     // Names for the different variables that we will need to construct for this
     // function.
-    private final static VariableDescription<ArrayVariable<DoubleVariable>> statesProbabilityNameLocal = VariableNames
-            .calcVarName("stateProbabilityLocal", VariableType.arrayType(VariableType.DoubleVariable), true);
+    private final static LocalVariableDescription<ArrayVariable<DoubleVariable>> statesProbabilityNameLocal = VariableNames
+            .localCalcVarName("stateProbabilityLocal", VariableType.arrayType(VariableType.DoubleVariable), true);
 
     @Override
     protected String getInferenceType() {
@@ -139,7 +141,7 @@ public class MarginalizationFunctions<A extends ScalarVariable<A>, B extends Dis
 
     @Override
     protected void allocateGlobalStateProb(MarginalizationData<A, B> funcData) {
-        allocateGlobalArray(funcData, funcData.sourceRandom, funcData.statesProbabilityNameGlobal);
+        allocateScratchArray(funcData, funcData.sourceRandom, funcData.statesProbabilityNameGlobal);
     }
 
     @Override
@@ -153,9 +155,9 @@ public class MarginalizationFunctions<A extends ScalarVariable<A>, B extends Dis
 
     private void normalizeArray(IRTreeReturn<ArrayVariable<DoubleVariable>> sourceArray,
             IRTreeReturn<ArrayVariable<DoubleVariable>> targetArray, CompilationContext compilationCtx) {
-        VariableDescription<DoubleVariable> sumName = VariableNames.calcVarName("logSum", VariableType.DoubleVariable,
+        LocalVariableDescription<DoubleVariable> sumName = VariableNames.localCalcVarName("logSum", VariableType.DoubleVariable,
                 true);
-        VariableDescription<IntVariable> indexName = VariableNames.calcVarName("indexName", VariableType.IntVariable,
+        LocalVariableDescription<IntVariable> indexName = VariableNames.localCalcVarName("indexName", VariableType.IntVariable,
                 true);
         compilationCtx.addTreeToScope(GlobalScope.scope,
                 initializeVariable(sumName, constant(0.0), "The sum of all the probabilities in log space"));
@@ -211,8 +213,8 @@ public class MarginalizationFunctions<A extends ScalarVariable<A>, B extends Dis
             IRTreeReturn<ArrayVariable<DoubleVariable>> arrayValue = load(statesProbabilityNameLocal);
 
             // Get the probability array
-            VariableDescription<ArrayVariable<DoubleVariable>> localProbability = VariableNames
-                    .calcVarName("localProbability", VariableType.arrayType(VariableType.DoubleVariable), true);
+            LocalVariableDescription<ArrayVariable<DoubleVariable>> localProbability = VariableNames
+                    .localCalcVarName("localProbability", VariableType.arrayType(VariableType.DoubleVariable), true);
             IRTreeReturn<ArrayVariable<DoubleVariable>> probabilityArray = ((DistributionSampleTask<?, ?>) funcData.sampleDesc.sample)
                     .getProbabilitiesArray().getForwardIR(funcData.compilationCtx);
             funcData.compilationCtx.addTreeToScope(GlobalScope.scope,

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsArrayFunctions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsArrayFunctions.java
@@ -27,6 +27,7 @@ import org.sandwood.compiler.compilation.inference.InferenceGeneratorArrayProb;
 import org.sandwood.compiler.compilation.util.TreeUtils;
 import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -59,10 +60,10 @@ public abstract class MetropolisHastingsArrayFunctions<A extends Variable<A>, B 
         }
     }
 
-    private static final VariableDescription<DoubleVariable> originalProbabilityName = VariableNames
-            .calcVarName("originalProbability", VariableType.DoubleVariable, true);
-    private static final VariableDescription<DoubleVariable> proposedProbabilityName = VariableNames
-            .calcVarName("proposedProbability", VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> originalProbabilityName = VariableNames
+            .localCalcVarName("originalProbability", VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> proposedProbabilityName = VariableNames
+            .localCalcVarName("proposedProbability", VariableType.DoubleVariable, true);
 
     @Override
     protected String getInferenceType() {
@@ -137,7 +138,7 @@ public abstract class MetropolisHastingsArrayFunctions<A extends Variable<A>, B 
     @Override
     protected void addSampleValueTree(MetropolisHastingsArrayData<A, B> funcData) {
 
-        VariableDescription<DoubleVariable> ratioName = VariableNames.calcVarName("ratio", VariableType.DoubleVariable,
+        LocalVariableDescription<DoubleVariable> ratioName = VariableNames.localCalcVarName("ratio", VariableType.DoubleVariable,
                 true);
         IRTreeReturn<DoubleVariable> ratio = subtractDD(load(proposedProbabilityName), load(originalProbabilityName));
         funcData.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(ratioName, ratio,

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsDirichletFunctions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsDirichletFunctions.java
@@ -37,6 +37,7 @@ import org.sandwood.compiler.compilation.CompilationContext;
 import org.sandwood.compiler.compilation.FunctionType;
 import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
@@ -54,19 +55,19 @@ import org.sandwood.compiler.trees.irTree.IRTreeVoid;
  * going to zero the probabilities are generated and stored in log space.
  */
 public class MetropolisHastingsDirichletFunctions extends MetropolisHastingsArrayFunctions<DoubleVariable, Dirichlet> {
-    private static final VariableDescription<DoubleVariable> proposedDifference = VariableNames
-            .calcVarName("proposedDifference", VariableType.DoubleVariable, true);
-    private static final VariableDescription<DoubleVariable> rebalanceValue = VariableNames
-            .calcVarName("rebalanceValue", VariableType.DoubleVariable, true);
-    private static final VariableDescription<IntVariable> indexToChange = VariableNames.calcVarName("indexToChange",
+    private static final LocalVariableDescription<DoubleVariable> proposedDifference = VariableNames
+            .localCalcVarName("proposedDifference", VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> rebalanceValue = VariableNames
+            .localCalcVarName("rebalanceValue", VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<IntVariable> indexToChange = VariableNames.localCalcVarName("indexToChange",
             VariableType.IntVariable, true);
-    private static final VariableDescription<DoubleVariable> movementRatio = VariableNames.calcVarName("movementRatio",
+    private static final LocalVariableDescription<DoubleVariable> movementRatio = VariableNames.localCalcVarName("movementRatio",
             VariableType.DoubleVariable, true);
-    private static final VariableDescription<IntVariable> loopIndex = VariableNames.calcVarName("loopIndex",
+    private static final LocalVariableDescription<IntVariable> loopIndex = VariableNames.localCalcVarName("loopIndex",
             VariableType.IntVariable, true);
-    private static final VariableDescription<IntVariable> arrayLength = VariableNames.calcVarName("arrayLength",
+    private static final LocalVariableDescription<IntVariable> arrayLength = VariableNames.localCalcVarName("arrayLength",
             VariableType.IntVariable, true);
-    private static final VariableDescription<DoubleVariable> tempValue = VariableNames.calcVarName("temp",
+    private static final LocalVariableDescription<DoubleVariable> tempValue = VariableNames.localCalcVarName("temp",
             VariableType.DoubleVariable, true);
 
     /**

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsDoubleFunctions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsDoubleFunctions.java
@@ -22,7 +22,7 @@ import org.sandwood.compiler.compilation.CompilationContext;
 import org.sandwood.compiler.compilation.FunctionType;
 import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.randomVariables.RandomVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.BooleanVariable;
@@ -51,7 +51,7 @@ public class MetropolisHastingsDoubleFunctions<B extends RandomVariable<DoubleVa
 
     @Override
     protected void getProposedValue(MetropolisHastingsData<DoubleVariable, B> funcData) {
-        VariableDescription<DoubleVariable> varName = VariableNames.calcVarName("var", VariableType.DoubleVariable,
+        LocalVariableDescription<DoubleVariable> varName = VariableNames.localCalcVarName("var", VariableType.DoubleVariable,
                 true);
 
         // Calculate the variance based on the current value.

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsIntFunctions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsIntFunctions.java
@@ -30,6 +30,7 @@ import org.sandwood.compiler.compilation.CompilationContext;
 import org.sandwood.compiler.compilation.FunctionType;
 import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.randomVariables.RandomVariable;
@@ -63,9 +64,9 @@ public class MetropolisHastingsIntFunctions<B extends RandomVariable<IntVariable
      */
     @Override
     protected void getProposedValue(MetropolisHastingsData<IntVariable, B> funcData) {
-        VariableDescription<DoubleVariable> varName = VariableNames.calcVarName("var", VariableType.DoubleVariable,
+        LocalVariableDescription<DoubleVariable> varName = VariableNames.localCalcVarName("var", VariableType.DoubleVariable,
                 true);
-        VariableDescription<DoubleVariable> offsetName = VariableNames.calcVarName("offset",
+        LocalVariableDescription<DoubleVariable> offsetName = VariableNames.localCalcVarName("offset",
                 VariableType.DoubleVariable, true);
 
         // Calculate the variance based on the current value.

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsMultinomialFunctions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsMultinomialFunctions.java
@@ -32,6 +32,7 @@ import org.sandwood.compiler.compilation.CompilationContext;
 import org.sandwood.compiler.compilation.FunctionType;
 import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
@@ -64,17 +65,17 @@ public class MetropolisHastingsMultinomialFunctions extends MetropolisHastingsAr
         }
     }
 
-    private static final VariableDescription<IntVariable> nonZeroCount = VariableNames.calcVarName("nonZeroCount",
+    private static final LocalVariableDescription<IntVariable> nonZeroCount = VariableNames.localCalcVarName("nonZeroCount",
             VariableType.IntVariable, true);
-    private static final VariableDescription<IntVariable> source = VariableNames.calcVarName("sourceIndex",
+    private static final LocalVariableDescription<IntVariable> source = VariableNames.localCalcVarName("sourceIndex",
             VariableType.IntVariable, true);
-    private static final VariableDescription<IntVariable> destination = VariableNames.calcVarName("destinationIndex",
+    private static final LocalVariableDescription<IntVariable> destination = VariableNames.localCalcVarName("destinationIndex",
             VariableType.IntVariable, true);
-    private static final VariableDescription<IntVariable> change = VariableNames.calcVarName("changeValue",
+    private static final LocalVariableDescription<IntVariable> change = VariableNames.localCalcVarName("changeValue",
             VariableType.IntVariable, true);
-    private static final VariableDescription<IntVariable> loopIndex = VariableNames.calcVarName("loopIndex",
+    private static final LocalVariableDescription<IntVariable> loopIndex = VariableNames.localCalcVarName("loopIndex",
             VariableType.IntVariable, true);
-    private static final VariableDescription<IntVariable> arrayLength = VariableNames.calcVarName("arrayLength",
+    private static final LocalVariableDescription<IntVariable> arrayLength = VariableNames.localCalcVarName("arrayLength",
             VariableType.IntVariable, true);
 
     @Override

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsScalarFunctions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/inference/metropolisHastings/MetropolisHastingsScalarFunctions.java
@@ -28,6 +28,7 @@ import org.sandwood.compiler.compilation.util.TreeUtils;
 import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.ProducingDataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.auxillary.DataflowTaskArgDesc;
@@ -56,22 +57,22 @@ public abstract class MetropolisHastingsScalarFunctions<A extends ScalarVariable
         extends InferenceGeneratorScalarProb<A, B, MetropolisHastingsScalarFunctions.MetropolisHastingsData<A, B>> {
     protected static class MetropolisHastingsData<A extends ScalarVariable<A>, B extends RandomVariable<A, B>>
             extends InferenceGeneratorScalarProb.ScalarProbFunctionData<A, B> {
-        final VariableDescription<A> originalValueName;
-        final VariableDescription<A> proposedValueName;
+        final LocalVariableDescription<A> originalValueName;
+        final LocalVariableDescription<A> proposedValueName;
 
         public ScopeConstructor sampleTargetScope;
 
         protected MetropolisHastingsData(SampleTask<A, B> sample, CompilationContext compilationCtx) {
             super(sample, IntVariable.intVariable(2), compilationCtx);
-            originalValueName = VariableNames.calcVarName("originalValue", sample.getOutputType(), true);
-            proposedValueName = VariableNames.calcVarName("proposedValue", sample.getOutputType(), true);
+            originalValueName = VariableNames.localCalcVarName("originalValue", sample.getOutputType(), true);
+            proposedValueName = VariableNames.localCalcVarName("proposedValue", sample.getOutputType(), true);
         }
     }
 
-    private static final VariableDescription<DoubleVariable> originalProbabilityName = VariableNames
-            .calcVarName("originalProbability", VariableType.DoubleVariable, true);
-    private static final VariableDescription<DoubleVariable> proposedProbabilityName = VariableNames
-            .calcVarName("proposedProbability", VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> originalProbabilityName = VariableNames
+            .localCalcVarName("originalProbability", VariableType.DoubleVariable, true);
+    private static final LocalVariableDescription<DoubleVariable> proposedProbabilityName = VariableNames
+            .localCalcVarName("proposedProbability", VariableType.DoubleVariable, true);
 
     @Override
     protected String getInferenceType() {
@@ -192,7 +193,7 @@ public abstract class MetropolisHastingsScalarFunctions<A extends ScalarVariable
 
     @Override
     protected void addSampleValueTree(MetropolisHastingsData<A, B> funcData) {
-        VariableDescription<DoubleVariable> ratioName = VariableNames.calcVarName("ratio", VariableType.DoubleVariable,
+        LocalVariableDescription<DoubleVariable> ratioName = VariableNames.localCalcVarName("ratio", VariableType.DoubleVariable,
                 true);
         IRTreeReturn<DoubleVariable> ratio = subtractDD(load(proposedProbabilityName), load(originalProbabilityName));
         funcData.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(ratioName, ratio,

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/util/FunctionUtils.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/util/FunctionUtils.java
@@ -29,6 +29,9 @@ import org.sandwood.compiler.dataflowGraph.scopes.Scope;
 import org.sandwood.compiler.dataflowGraph.scopes.Scope.ScopeType;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ForTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ParForTask;
+import org.sandwood.compiler.dataflowGraph.variables.GlobalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.ScratchVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -56,16 +59,16 @@ public class FunctionUtils {
                 } else {
                     List<IRTreeVoid> subtrees = new ArrayList<>();
 
-                    VariableDescription<IntVariable> threadCount = VariableNames.calcVarName("threadCount",
+                    LocalVariableDescription<IntVariable> threadCount = VariableNames.localCalcVarName("threadCount",
                             VariableType.IntVariable, true);
-                    VariableDescription<ArrayVariable<V>> arrayFieldName = VariableNames.altTypeName(fieldName,
-                            VariableType.arrayType(fieldName.type));
+                    VariableDescription<ArrayVariable<V>> arrayFieldName = fieldName
+                            .alternativeType(VariableType.arrayType(fieldName.type));
                     ArrayType<V> arrayType = VariableType.arrayType(localAllocation.getOutputType());
                     subtrees.add(initializeVariable(threadCount,
                             functionCallReturn(VariableType.IntVariable, "threadCount"), "Get the thread count."));
                     subtrees.add(store(arrayFieldName, newArray(load(threadCount), arrayType),
                             "Allocate an array to hold a copy per thread"));
-                    VariableDescription<IntVariable> index = VariableNames.calcVarName("index",
+                    LocalVariableDescription<IntVariable> index = VariableNames.localCalcVarName("index",
                             VariableType.IntVariable, true);
                     IRTreeVoid body = arrayPut(load(arrayFieldName), load(index), localAllocation, Tree.NoComment);
                     subtrees.add(forStmt(body, constant(0), load(threadCount), constant(1), index, true,
@@ -83,18 +86,18 @@ public class FunctionUtils {
         return isSerial;
     }
 
-    public static <V extends Variable<V>> boolean createGlobalField(VariableDescription<V> fieldName,
+    public static <V extends Variable<V>> boolean createScratchClassField(ScratchVariableDescription<V> fieldName,
             IRTreeVoid allocator, boolean isSerial, Scope innerScope, CompilationContext compilationCtx) {
         isSerial = checkIsSerial(isSerial, innerScope, compilationCtx);
         switch(compilationCtx.target) {
             case SingleThreadCPU:
             case MultiThreadCPU: {
                 if(isSerial) {
-                    compilationCtx.addConstructedClassField(fieldName, allocator);
+                    compilationCtx.addScratchClassField(fieldName, allocator);
                 } else {
-                    VariableDescription<ArrayVariable<V>> arrayVariable = VariableNames.altTypeName(fieldName,
-                            VariableType.arrayType(fieldName.type));
-                    compilationCtx.addConstructedClassField(arrayVariable, allocator);
+                    ScratchVariableDescription<ArrayVariable<V>> arrayVariable = fieldName
+                            .alternativeType(VariableType.arrayType(fieldName.type));
+                    compilationCtx.addScratchClassField(arrayVariable, allocator);
                 }
                 break;
             }
@@ -115,8 +118,8 @@ public class FunctionUtils {
                 if(isSerial) {
                     return load(varDesc);
                 } else {
-                    VariableDescription<ArrayVariable<V>> arrayName = VariableNames.altTypeName(varDesc,
-                            VariableType.arrayType(varDesc.type));
+                    VariableDescription<ArrayVariable<V>> arrayName = varDesc
+                            .alternativeType(VariableType.arrayType(varDesc.type));
                     IRTreeReturn<ArrayVariable<V>> array = load(arrayName);
                     Scope s = innerScope;
                     while(s.isSerial(compilationCtx))

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/util/SampleDescScalar.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/util/SampleDescScalar.java
@@ -12,6 +12,7 @@ import org.sandwood.compiler.compilation.CompilationContext;
 import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.ProducingDataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.randomVariables.RandomVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.ScalarVariable;
@@ -45,7 +46,8 @@ public class SampleDescScalar<A extends ScalarVariable<A>, B extends RandomVaria
                             "Write out the new value of the sample."));
         // Otherwise create a variable to hold the value.
         else {
-            compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(output.getUniqueVarDesc(),
+            compilationCtx.addTreeToScope(GlobalScope.scope, IRTree.initializeVariable(
+                    (LocalVariableDescription<A>)output.getUniqueVarDesc(),
                     sampleValue,
                     "Write out the value of the sample to a temporary variable prior to updating the intermediate variables."));
             Variable<A> v = (Variable<A>) sampleVarDesc.sampleVariable;

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/util/TreeUtils.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/compilation/util/TreeUtils.java
@@ -51,6 +51,8 @@ import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.arrayTasks.PutTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ForTask;
+import org.sandwood.compiler.dataflowGraph.variables.GlobalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableName;
@@ -444,11 +446,11 @@ public class TreeUtils {
         Map<Scope, Map<Index, VariableDescription<?>>> declaredSubArrays = declaredArrays.computeIfAbsent(depth,
                 k -> new HashMap<>());
         Scope s = element.scope;
-        VariableDescription<ArrayVariable<ArrayVariable<A>>> name;
+        LocalVariableDescription<ArrayVariable<ArrayVariable<A>>> name;
         while(s != null) {
             Map<Index, VariableDescription<?>> d = declaredSubArrays.get(s);
             if(d != null) {
-                name = (VariableDescription<ArrayVariable<ArrayVariable<A>>>) d.get(new Index(element.index));
+                name = (LocalVariableDescription<ArrayVariable<ArrayVariable<A>>>) d.get(new Index(element.index));
                 if(name != null)
                     return name;
             }
@@ -606,7 +608,7 @@ public class TreeUtils {
             // state changes are tracked.
             Type<?> vType = VariableType.getType(value.getOutputType(), size);
             @SuppressWarnings("rawtypes")
-            IRTreeReturn t = load(VariableNames.altTypeName(variableName, vType));
+            IRTreeReturn t = load(variableName.alternativeType(vType));
             for(int i = 0; i < size - 1; i++)
                 t = arrayGet(t, args.get(i));
             return arrayPut(t, args.get(size - 1), value, comment);
@@ -674,7 +676,7 @@ public class TreeUtils {
             List<IRTreeReturn<IntVariable>> args) {
         int size = args.size();
         @SuppressWarnings("rawtypes")
-        IRTreeReturn t = load(VariableNames.altTypeName(variableDesc, VariableType.getType(variableDesc.type, size)));
+        IRTreeReturn t = load(variableDesc.alternativeType(VariableType.getType(variableDesc.type, size)));
         for(int i = 0; i < size; i++) {
             IRTreeReturn<IntVariable> arg = args.get(i);
             t = arrayGet(t, arg);
@@ -703,7 +705,7 @@ public class TreeUtils {
 
         @SuppressWarnings("rawtypes")
         IRTreeReturn result = load(
-                VariableNames.altTypeName(var.getUniqueVarDesc(), VariableType.getType(var.getType(), implicitDepth)));
+                var.getUniqueVarDesc().alternativeType(VariableType.getType(var.getType(), implicitDepth)));
         for(int i = 0; i < implicitDepth; i++) {
             IntVariable arg = args.get(i);
             result = arrayGet(result, arg.getForwardIR(compilationCtx));
@@ -1213,9 +1215,9 @@ public class TreeUtils {
      * @param compilationCtx
      * @return
      */
-    public static <X extends Variable<X>> IRTreeVoid constructVariable(VariableDescription<X> varDesc,
+    public static <X extends Variable<X>> IRTreeVoid constructGlobalVariable(GlobalVariableDescription<X> varDesc,
             IRTreeReturn<X> value, List<ScopeDesc> scopes, FieldType fieldType, CompilationContext compilationCtx) {
-        return constructVariable(varDesc, value, scopes, fieldType, null, compilationCtx);
+        return constructGlobalVariable(varDesc, value, scopes, fieldType, null, compilationCtx);
     }
 
     /**
@@ -1230,8 +1232,8 @@ public class TreeUtils {
      * @param compilationCtx
      * @return
      */
-    public static <A extends Variable<A>, X extends Variable<X>> IRTreeVoid constructVariable(
-            VariableDescription<X> varDesc, IRTreeReturn<X> value, List<ScopeDesc> scopes, FieldType fieldType,
+    public static <A extends Variable<A>, X extends Variable<X>> IRTreeVoid constructGlobalVariable(
+            GlobalVariableDescription<X> varDesc, IRTreeReturn<X> value, List<ScopeDesc> scopes, FieldType fieldType,
             String comment, CompilationContext compilationCtx) {
         int size = scopes.size() - 1;
         if(size == 0) {
@@ -1240,7 +1242,7 @@ public class TreeUtils {
         } else {
             // Construct a descriptor of the array.
             ArrayDesc<A> arrayDesc = getArrayDescription(scopes, varDesc.type);
-            VariableDescription<ArrayVariable<A>> arrayName = VariableNames.altTypeName(varDesc, arrayDesc.type);
+            GlobalVariableDescription<ArrayVariable<A>> arrayName = varDesc.alternativeType(arrayDesc.type);
             compilationCtx.addConstructedClassField(arrayName,
                     // Allocate the variable
                     allocate(arrayName, arrayDesc, compilationCtx), fieldType, comment);
@@ -1364,13 +1366,13 @@ public class TreeUtils {
 
     public static IRTreeVoid lseAdd(IRTreeReturn<ArrayVariable<DoubleVariable>> arrayValue,
             VariableDescription<DoubleVariable> targetName, IRTreeReturn<IntVariable> bound, String comment) {
-        VariableDescription<DoubleVariable> maxName = VariableNames.calcVarName("lseMax", VariableType.DoubleVariable,
+        LocalVariableDescription<DoubleVariable> maxName = VariableNames.localCalcVarName("lseMax", VariableType.DoubleVariable,
                 true);
-        VariableDescription<DoubleVariable> elementName = VariableNames.calcVarName("lseElementValue",
+        LocalVariableDescription<DoubleVariable> elementName = VariableNames.localCalcVarName("lseElementValue",
                 VariableType.DoubleVariable, true);
-        VariableDescription<IntVariable> indexName = VariableNames.calcVarName("lseIndex", VariableType.IntVariable,
+        LocalVariableDescription<IntVariable> indexName = VariableNames.localCalcVarName("lseIndex", VariableType.IntVariable,
                 true);
-        VariableDescription<DoubleVariable> sumName = VariableNames.calcVarName("lseSum", VariableType.DoubleVariable,
+        LocalVariableDescription<DoubleVariable> sumName = VariableNames.localCalcVarName("lseSum", VariableType.DoubleVariable,
                 true);
 
         List<IRTreeVoid> stmts = new ArrayList<>();
@@ -1419,13 +1421,13 @@ public class TreeUtils {
             IRTreeReturn<ArrayVariable<A>> source, IRTreeReturn<ArrayVariable<A>> target, int i) {
         List<IRTreeVoid> ts = new ArrayList<>();
 
-        VariableDescription<ArrayVariable<A>> sourceName = VariableNames.calcVarName("source" + i,
+        LocalVariableDescription<ArrayVariable<A>> sourceName = VariableNames.localCalcVarName("source" + i,
                 source.getOutputType(), true);
-        VariableDescription<ArrayVariable<A>> targetName = VariableNames.calcVarName("target" + i,
+        LocalVariableDescription<ArrayVariable<A>> targetName = VariableNames.localCalcVarName("target" + i,
                 source.getOutputType(), true);
-        VariableDescription<IntVariable> lengthName = VariableNames.calcVarName("length" + i, VariableType.IntVariable,
+        LocalVariableDescription<IntVariable> lengthName = VariableNames.localCalcVarName("length" + i, VariableType.IntVariable,
                 true);
-        VariableDescription<IntVariable> indexName = VariableNames.calcVarName("index" + i, VariableType.IntVariable,
+        LocalVariableDescription<IntVariable> indexName = VariableNames.localCalcVarName("index" + i, VariableType.IntVariable,
                 true);
 
         // Local variables for the arrays.
@@ -1483,7 +1485,7 @@ public class TreeUtils {
         // Pass in the threads random number generator.
         if(threadIdName != null) {
             args.add(new ArgDesc<>(threadIdName));
-            args.add(new ArgDesc<>(VariableNames.rngName(0)));
+            args.add(new ArgDesc<>(VariableNames.rngName()));
         }
 
         return args.toArray(new ArgDesc[args.size()]);
@@ -1501,7 +1503,7 @@ public class TreeUtils {
         IRTreeReturn<IntVariable> start = constant(0);
         IRTreeReturn<IntVariable> end = getIntField(load(subArrayName), "length");
         IRTreeReturn<IntVariable> step = constant(1);
-        VariableDescription<IntVariable> indexName = VariableNames.indexName(baseName, Integer.toString(i));
+        LocalVariableDescription<IntVariable> indexName = VariableNames.indexName(baseName, Integer.toString(i));
 
         Type<A> elementType = ((ArrayType<A>) subArrayName.type).getElementType();
         IRTreeReturn<ArrayVariable<A>> subArray = load(subArrayName);
@@ -1509,7 +1511,7 @@ public class TreeUtils {
 
         IRTreeVoid body;
         if(elementType.isArray()) {
-            VariableDescription<A> elementDesc = VariableNames.calcVarName(baseName.getName(), Integer.toString(i),
+            LocalVariableDescription<A> elementDesc = VariableNames.localCalcVarName(baseName.getName(), Integer.toString(i),
                     elementType, true);
             IRTreeVoid innerArrayGet = initializeVariable(elementDesc, arrayGet(subArray, index), IRTree.NoComment);
             IRTreeVoid innerArraySet = setArray(baseName, (VariableDescription<ArrayVariable<C>>) elementDesc, i + 1,

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/scopes/ReductionScope.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/scopes/ReductionScope.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.sandwood.compiler.compilation.CompilationContext;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ForTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
@@ -21,14 +22,14 @@ import org.sandwood.compiler.names.VariableNames;
 
 public class ReductionScope<A extends Variable<A>> extends ReductionScopeBase<A> {
     private int varId = 0;
-    private VariableDescription<A> returnName;
+    private LocalVariableDescription<A> returnName;
 
     public ReductionScope(IntVariable start, IntVariable end, ArrayVariable<A> array, Variable<A> emptyValue) {
         super(start, end, array, emptyValue);
     }
     
     @Override
-    protected VariableDescription<A> getReturnName() {
+    protected LocalVariableDescription<A> getReturnName() {
             returnName = VariableNames.reduceName(returnVar, varId++);
             return returnName;
     }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/scopes/ReductionScopeBase.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/scopes/ReductionScopeBase.java
@@ -15,6 +15,7 @@ import org.sandwood.compiler.compilation.CompilationContext;
 import org.sandwood.compiler.compilation.scopesState.ScopeTracking;
 import org.sandwood.compiler.dataflowGraph.Id;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ReductionInput;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -73,13 +74,13 @@ public abstract class ReductionScopeBase<A extends Variable<A>> extends Id imple
             CompilationContext compilationCtx) {
         List<IRTreeVoid> reduceBody = new ArrayList<>();
 
-        VariableDescription<A> returnName = getReturnName();
+        LocalVariableDescription<A> returnName = getReturnName();
 
         reduceBody.add(IRTree.initializeVariable(returnName, emptyValue.getForwardIR(compilationCtx),
                 "A generated name to prevent name collisions if the reduction is implemented more than once in "
                         + "inference and probability code. Initialize the variable to the unit value"));
 
-        VariableDescription<IntVariable> indexName = indexName();
+        LocalVariableDescription<IntVariable> indexName = indexName();
         List<IRTreeVoid> forBody = new ArrayList<>();
 
         forBody.add(IRTree.initializeVariable(i, IRTree.load(returnName),
@@ -97,16 +98,16 @@ public abstract class ReductionScopeBase<A extends Variable<A>> extends Id imple
     }
 
     protected void constructForStmt(List<IRTreeVoid> reduceBody, List<IRTreeVoid> forBody,
-            VariableDescription<IntVariable> indexName, CompilationContext compilationCtx) {
+            LocalVariableDescription<IntVariable> indexName, CompilationContext compilationCtx) {
         reduceBody.add(IRTree.forStmt(IRTree.sequential(forBody, Tree.NoComment), start.getForwardIR(compilationCtx),
                 end.getForwardIR(compilationCtx), IRTree.constant(1), indexName, true,
                 "For each index in the array to be reduced"));
     }
 
-    protected abstract VariableDescription<A> getReturnName();
+    protected abstract LocalVariableDescription<A> getReturnName();
 
-    private VariableDescription<IntVariable> indexName() {
-        return VariableNames.calcVarName("reduction" + id() + "Index", VariableType.IntVariable, false);
+    private LocalVariableDescription<IntVariable> indexName() {
+        return VariableNames.localCalcVarName("reduction" + id() + "Index", VariableType.IntVariable, false);
     }
 
     // Use the first value in the array as the empty value so that all the values in the array can be processed.
@@ -140,7 +141,7 @@ public abstract class ReductionScopeBase<A extends Variable<A>> extends Id imple
         returnVar.calculateIntermediate(true);
         IRTreeReturn<A> reduced = returnVar.getForwardIR(compilationCtx);
         returnVar.calculateIntermediate(false);
-        VariableDescription<A> reducedName = VariableNames.calcVarName("reduced" + reductionScope.id(),
+        LocalVariableDescription<A> reducedName = VariableNames.localCalcVarName("reduced" + reductionScope.id(),
                 reduced.getOutputType(), true);
         IRTreeVoid reducedStore = IRTree.initializeVariable(reducedName, reduced, Tree.NoComment);
         compilationCtx.addTreeToScope(ifScope, reducedStore);

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/scopes/ReductionScopeCopied.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/scopes/ReductionScopeCopied.java
@@ -11,6 +11,7 @@ package org.sandwood.compiler.dataflowGraph.scopes;
 import java.util.List;
 
 import org.sandwood.compiler.compilation.CompilationContext;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
@@ -36,13 +37,13 @@ public class ReductionScopeCopied<A extends Variable<A>> extends ReductionScopeB
 
 
     @Override
-    protected VariableDescription<A> getReturnName() {
+    protected LocalVariableDescription<A> getReturnName() {
         return original.getReturnName();
     }
 
     @Override
     protected void constructForStmt(List<IRTreeVoid> reduceBody, List<IRTreeVoid> forBody,
-            VariableDescription<IntVariable> indexName, CompilationContext compilationCtx) {
+            LocalVariableDescription<IntVariable> indexName, CompilationContext compilationCtx) {
         if(maskedValue==null) {
             super.constructForStmt(reduceBody, forBody, indexName, compilationCtx);
         } else {

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/ConstructArrayInput.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/ConstructArrayInput.java
@@ -1,7 +1,7 @@
 /*
  * Sandwood
  *
- * Copyright (c) 2019-2025, Oracle and/or its affiliates
+ * Copyright (c) 2019-2026, Oracle and/or its affiliates
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
@@ -15,7 +15,6 @@ import org.sandwood.compiler.compilation.CompilationContext;
 import org.sandwood.compiler.dataflowGraph.tasks.ArrayProducingDataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.ConstructInput;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.ArrayType;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
@@ -85,16 +84,11 @@ public class ConstructArrayInput<A extends Variable<A>> extends ConstructInput<A
         // Calculate the dimension of the input array
         int arrayDim = getOutputType().getDepth();
 
-        if(arrayDim == 1) // TODO tidy up the creation and removal of VariableName's here.
-            shapeVar = Variable.observeInt(
-                    VariableNames.lengthName(new VariableDescription<>(name, VariableType.IntVariable, false)).name
-                            .getName(),
-                    getLocation());
+        if(arrayDim == 1) 
+            shapeVar = Variable.observeInt(VariableNames.lengthName(name), getLocation());
         else {
             ArrayType<?> lengthType = (ArrayType<?>) VariableType.getType(VariableType.IntVariable, arrayDim - 1);
-            shapeVar = Variable.observeArray(
-                    VariableNames.lengthName(new VariableDescription<>(name, lengthType, false)).name.getName(),
-                    lengthType, getLocation());
+            shapeVar = Variable.observeArray(VariableNames.lengthName(name), lengthType, getLocation());
         }
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/GetArrayTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/GetArrayTask.java
@@ -31,6 +31,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.ArrayProducingDataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.DFType;
 import org.sandwood.compiler.dataflowGraph.tasks.ProducingDataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ReductionReturnTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -87,7 +88,7 @@ public class GetArrayTask<A extends Variable<A>> extends GetTask<ArrayVariable<A
                 gets.push(producingGt);
                 arrayParent = producingGt.array.getParent();
             }
-            VariableDescription<IntVariable> returnLength = VariableNames.calcVarName(gt.array,
+            LocalVariableDescription<IntVariable> returnLength = VariableNames.localCalcVarName(gt.array,
                     findMax ? "max" : "min" + "Length", VariableType.IntVariable);
 
             List<IRTreeVoid> stmts = new ArrayList<>();
@@ -101,7 +102,7 @@ public class GetArrayTask<A extends Variable<A>> extends GetTask<ArrayVariable<A
             return load(returnLength);
 
         } else {
-            VariableDescription<IntVariable> returnName = VariableNames.calcVarName(array, findMax ? "max" : "min",
+            LocalVariableDescription<IntVariable> returnName = VariableNames.localCalcVarName(array, findMax ? "max" : "min",
                     VariableType.IntVariable);
 
             PriorityQueue<PutTask<ArrayVariable<A>>> p = new PriorityQueue<>(puts);
@@ -134,13 +135,13 @@ public class GetArrayTask<A extends Variable<A>> extends GetTask<ArrayVariable<A
         ArrayVariable<A> v = gt.array;
         VariableDescription<ArrayVariable<A>> parentArrayDesc = v.getUniqueVarDesc();
 
-        VariableDescription<IntVariable> length = VariableNames.calcVarName(v, "length", VariableType.IntVariable);
+        LocalVariableDescription<IntVariable> length = VariableNames.localCalcVarName(v, "length", VariableType.IntVariable);
         stmts.add(initializeVariable(length, getIntField(load(parentArrayDesc), "length"), Tree.NoComment));
 
-        VariableDescription<IntVariable> index = VariableNames.indexName(parentArrayDesc);
+        LocalVariableDescription<IntVariable> index = VariableNames.indexName(parentArrayDesc);
 
         List<IRTreeVoid> bodyStmts = new ArrayList<>();
-        VariableDescription<A> outputName = gt.getOutput().getVarDesc();
+        LocalVariableDescription<A> outputName = (LocalVariableDescription<A>)gt.getOutput().getVarDesc();
         bodyStmts.add(initializeVariable(outputName, arrayGet(load(parentArrayDesc), load(index)), Tree.NoComment));
         if(gets.isEmpty()) {
             IRTreeReturn<IntVariable> localLength = getIntField(load(outputName), "length");
@@ -196,7 +197,7 @@ public class GetArrayTask<A extends Variable<A>> extends GetTask<ArrayVariable<A
                 return tree;
             }
         } else {
-            VariableDescription<IntVariable> lengthName = VariableNames.lengthCVName(array.getVarDesc().name, id(),
+            LocalVariableDescription<IntVariable> lengthName = VariableNames.lengthCVName(array.getVarDesc().name, id(),
                     lengthId++);
             compilationCtx.enterScope(scope());
             compilationCtx.addTreeToScope(scope(), IRTree.initializeVariable(lengthName, IRTree.constant(-1),

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/GetNumberTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/GetNumberTask.java
@@ -22,6 +22,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.ArrayProducingDataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.DFType;
 import org.sandwood.compiler.dataflowGraph.tasks.NumberProducingDataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ForTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -46,7 +47,7 @@ public class GetNumberTask<A extends NumberVariable<A>> extends GetTask<A> imple
     @Override
     public IRTreeReturn<A> getMax(CompilationContext compilationCtx) {
         compilationCtx.enterScope(scope());
-        VariableDescription<A> max = VariableNames.calcVarName(output, "max", getOutputType());
+        LocalVariableDescription<A> max = VariableNames.localCalcVarName(output, "max", getOutputType());
 
         ArrayProducingDataflowTask<?> source = array.getSource();
         if(source.getType() == DFType.CONSTRUCT_INPUT) {
@@ -79,7 +80,7 @@ public class GetNumberTask<A extends NumberVariable<A>> extends GetTask<A> imple
                 IRTreeReturn<IntVariable> start = IRTree.max(IRTree.constant(0), index.getMin(compilationCtx));
                 IRTreeReturn<IntVariable> end = IRTree.min(array.getLength(compilationCtx),
                         IRTree.addII(index.getMax(compilationCtx), IRTree.constant(1)));
-                VariableDescription<IntVariable> indexDesc = VariableNames.calcVarName(output, "maxIndex",
+                LocalVariableDescription<IntVariable> indexDesc = VariableNames.localCalcVarName(output, "maxIndex",
                         VariableType.IntVariable);
                 t = IRTree.store(max, IRTree.max(IRTree.load(max), IRTree.arrayGet(arrayTree, IRTree.load(indexDesc))),
                         Tree.NoComment);
@@ -124,7 +125,7 @@ public class GetNumberTask<A extends NumberVariable<A>> extends GetTask<A> imple
     @Override
     public IRTreeReturn<A> getMin(CompilationContext compilationCtx) {
         compilationCtx.enterScope(scope());
-        VariableDescription<A> min = VariableNames.calcVarName(getOutput(), "min", getOutputType());
+        LocalVariableDescription<A> min = VariableNames.localCalcVarName(getOutput(), "min", getOutputType());
 
         ArrayProducingDataflowTask<?> source = array.getSource();
         if(source.getType() == DFType.CONSTRUCT_INPUT) {
@@ -158,7 +159,7 @@ public class GetNumberTask<A extends NumberVariable<A>> extends GetTask<A> imple
                 IRTreeReturn<IntVariable> end = IRTree.min(
                         IRTree.getIntField(array.getForwardIR(compilationCtx), "length"),
                         IRTree.addII(index.getMax(compilationCtx), IRTree.constant(1)));
-                VariableDescription<IntVariable> indexDesc = VariableNames.calcVarName(output, "maxIndex",
+                LocalVariableDescription<IntVariable> indexDesc = VariableNames.localCalcVarName(output, "maxIndex",
                         VariableType.IntVariable);
                 t = IRTree.store(min, IRTree.min(IRTree.load(min), IRTree.arrayGet(arrayTree, IRTree.load(indexDesc))),
                         Tree.NoComment);
@@ -209,7 +210,7 @@ public class GetNumberTask<A extends NumberVariable<A>> extends GetTask<A> imple
 
         IRTreeReturn<ArrayVariable<ArrayVariable<B>>> outerArrayTree = getInputArrayTree(outerArray, substitutions, tag,
                 id - 1, compilationCtx);
-        VariableDescription<ArrayVariable<B>> innerName = VariableNames.calcVarName(output, tag + "Array" + id,
+        LocalVariableDescription<ArrayVariable<B>> innerName = VariableNames.localCalcVarName(output, tag + "Array" + id,
                 array.getType());
         IntVariable arrayIndex = desc.getIndex();
         Scope arrayScope = desc.getScope();
@@ -226,11 +227,11 @@ public class GetNumberTask<A extends NumberVariable<A>> extends GetTask<A> imple
                     IRTree.addII(index.getMax(compilationCtx), IRTree.constant(1)));
 
             // Construct local value names to hold them
-            VariableDescription<IntVariable> startDesc = VariableNames.calcVarName(output, tag + "Start" + id,
+            LocalVariableDescription<IntVariable> startDesc = VariableNames.localCalcVarName(output, tag + "Start" + id,
                     VariableType.IntVariable);
-            VariableDescription<IntVariable> endDesc = VariableNames.calcVarName(output, tag + "End" + id,
+            LocalVariableDescription<IntVariable> endDesc = VariableNames.localCalcVarName(output, tag + "End" + id,
                     VariableType.IntVariable);
-            VariableDescription<IntVariable> indexDesc = VariableNames.calcVarName(output, tag + "Index" + id,
+            LocalVariableDescription<IntVariable> indexDesc = VariableNames.localCalcVarName(output, tag + "Index" + id,
                     VariableType.IntVariable);
 
             // Add the value to the scope

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/PutTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/arrayTasks/PutTask.java
@@ -30,6 +30,7 @@ import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.ProducingDataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.ProducingDataflowTaskImplementation;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ForTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableName;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
@@ -394,7 +395,8 @@ public class PutTask<A extends Variable<A>> extends ProducingDataflowTaskImpleme
                  */
                 if(!compilationCtx.initializedInScope(value)) {
                     Variable<A> initValue = compilationCtx.addInitialized(value);
-                    IRTreeVoid t = initializeVariable(Visibility.DEFAULT, initValue.getUniqueVarDesc(),
+                    IRTreeVoid t = initializeVariable(Visibility.DEFAULT,
+                            (LocalVariableDescription<A>)initValue.getUniqueVarDesc(),
                             arrayGet(arrayTree, index.getForwardIR(compilationCtx)), Tree.NoComment);
                     Scope targetScope = value.aliasSet() ? value.scope()
                             : Scope.innerScope(array.scope(), index.scope());

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/returnTasks/SampleTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/returnTasks/SampleTask.java
@@ -11,7 +11,7 @@ package org.sandwood.compiler.dataflowGraph.tasks.returnTasks;
 import org.sandwood.compiler.dataflowGraph.tasks.DFType;
 import org.sandwood.compiler.dataflowGraph.tasks.ProducingDataflowTaskImplementation;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.VariableName;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
 import org.sandwood.compiler.dataflowGraph.variables.auxillary.DataflowTaskArgDesc;
 import org.sandwood.compiler.dataflowGraph.variables.randomVariables.RandomVariable;
@@ -39,7 +39,7 @@ public abstract class SampleTask<A extends Variable<A>, B extends RandomVariable
 
     public abstract Type<A> getBaseType();
 
-    public VariableDescription<A> getUniqueVarDesc() {
-        return new VariableDescription<>("sample" + id(), getBaseType(), false);
+    public VariableName getSampleName() {
+        return new VariableName("sample" + id(), false);
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/returnTasks/rvConstructor/MultinomialTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/returnTasks/rvConstructor/MultinomialTask.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.sandwood.compiler.compilation.CompilationContext;
 import org.sandwood.compiler.dataflowGraph.scopes.GlobalScope;
 import org.sandwood.compiler.dataflowGraph.tasks.DFType;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
@@ -95,9 +96,9 @@ public class MultinomialTask extends RandomVariableConstructorTask<ArrayVariable
     public IRTreeReturn<?> getInverseArg(IRTreeReturn<ArrayVariable<IntVariable>> current, int argPos,
             CompilationContext compilationCtx) {
         if(argPos == 1) {
-            VariableDescription<IntVariable> accName = VariableNames.calcVarName("multinomialSum" + id(),
+            LocalVariableDescription<IntVariable> accName = VariableNames.localCalcVarName("multinomialSum" + id(),
                     VariableType.IntVariable, true);
-            VariableDescription<IntVariable> indexName = VariableNames.calcVarName("multinomialIndex" + id(),
+            LocalVariableDescription<IntVariable> indexName = VariableNames.localCalcVarName("multinomialIndex" + id(),
                     VariableType.IntVariable, true);
             compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(accName, constant(0), Tree.NoComment));
             IRTreeVoid sum = store(accName, addII(arrayGet(current, load(indexName)), load(accName)), Tree.NoComment);

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/sandwoodOperators/ForTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/sandwoodOperators/ForTask.java
@@ -22,8 +22,8 @@ import org.sandwood.compiler.compilation.scopesState.ScopeTracking;
 import org.sandwood.compiler.dataflowGraph.scopes.Scope;
 import org.sandwood.compiler.dataflowGraph.tasks.DFType;
 import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.BooleanVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
@@ -180,7 +180,7 @@ public class ForTask extends ScopedNumberProducingDataflowTask<IntVariable> {
         IRTreeReturn<IntVariable> startTree = start.getForwardIR(compilationCtx);
         IRTreeReturn<IntVariable> endTree = end.getForwardIR(compilationCtx);
         IRTreeReturn<IntVariable> stepTree = step.getForwardIR(compilationCtx);
-        VariableDescription<IntVariable> indexDesc = index.getUniqueVarDesc();
+        LocalVariableDescription<IntVariable> indexDesc = (LocalVariableDescription<IntVariable>)index.getUniqueVarDesc();
         if(reverseScopes) {
             // End must be updated first as it depends on the current start value.
             endTree = updateEnd(startTree, endTree, stepTree, incrementing);

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/sandwoodOperators/IfElseAssignmentTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/sandwoodOperators/IfElseAssignmentTask.java
@@ -16,6 +16,7 @@ import org.sandwood.compiler.dataflowGraph.scopes.Scope.ScopeType;
 import org.sandwood.compiler.dataflowGraph.tasks.DFType;
 import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.ProducingDataflowTaskImplementation;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -88,25 +89,26 @@ public class IfElseAssignmentTask<A extends Variable<A>> extends ProducingDatafl
                 if(newScope.getScopeType() == ScopeType.ELSE && ifScope.guard == ((ElseScope) newScope).ifScope.guard) {
                     compilationCtx.enterScope(ifScope);
                     if(!output.isIntermediate()) {
+                        LocalVariableDescription<A> localOutputDesc = (LocalVariableDescription<A>) outputDesc;
                         if(compilationCtx.codeGuardSet()) {
                             // If the is a guard set for the code placed into scopes, the variable must be
                             // initialized to keep the compiler happy.
                             Type<?> type = output.getType();
                             if(type == VariableType.IntVariable) {
-                                compilationCtx.addTreeToScope(output.scope(), IRTree.initializeVariable(outputDesc,
+                                compilationCtx.addTreeToScope(output.scope(), IRTree.initializeVariable(localOutputDesc,
                                         (IRTreeReturn<A>) IRTree.constant(0), Tree.NoComment));
                             } else if(type == VariableType.DoubleVariable) {
-                                compilationCtx.addTreeToScope(output.scope(), IRTree.initializeVariable(outputDesc,
+                                compilationCtx.addTreeToScope(output.scope(), IRTree.initializeVariable(localOutputDesc,
                                         (IRTreeReturn<A>) IRTree.constant(0.0), Tree.NoComment));
                             } else if(type == VariableType.BooleanVariable) {
-                                compilationCtx.addTreeToScope(output.scope(), IRTree.initializeVariable(outputDesc,
+                                compilationCtx.addTreeToScope(output.scope(), IRTree.initializeVariable(localOutputDesc,
                                         (IRTreeReturn<A>) IRTree.constant(false), Tree.NoComment));
                             } else {
                                 throw new CompilerException("Unknown type");
                             }
                         } else {
                             compilationCtx.addTreeToScope(output.scope(),
-                                    IRTree.initializeUnsetVariable(outputDesc, Tree.NoComment));
+                                    IRTree.initializeUnsetVariable(localOutputDesc, Tree.NoComment));
                         }
                     }
 
@@ -125,8 +127,9 @@ public class IfElseAssignmentTask<A extends Variable<A>> extends ProducingDatafl
                         compilationCtx.addTreeToScope(output.scope(),
                                 IRTree.store(outputDesc, elseValue.getForwardIR(compilationCtx), Tree.NoComment));
                     else
-                        compilationCtx.addTreeToScope(output.scope(), IRTree.initializeVariable(outputDesc,
-                                elseValue.getForwardIR(compilationCtx), Tree.NoComment));
+                        compilationCtx.addTreeToScope(output.scope(),
+                                IRTree.initializeVariable((LocalVariableDescription<A>) outputDesc,
+                                        elseValue.getForwardIR(compilationCtx), Tree.NoComment));
                 }
             } else {
                 // "If" is a non conditional location and should be set directly
@@ -134,8 +137,9 @@ public class IfElseAssignmentTask<A extends Variable<A>> extends ProducingDatafl
                     compilationCtx.addTreeToScope(output.scope(),
                             IRTree.store(outputDesc, ifValue.getForwardIR(compilationCtx), Tree.NoComment));
                 else
-                    compilationCtx.addTreeToScope(output.scope(), IRTree.initializeVariable(outputDesc,
-                            ifValue.getForwardIR(compilationCtx), Tree.NoComment));
+                    compilationCtx.addTreeToScope(output.scope(),
+                            IRTree.initializeVariable((LocalVariableDescription<A>) outputDesc,
+                                    ifValue.getForwardIR(compilationCtx), Tree.NoComment));
             }
             return IRTree.load(outputDesc);
         }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/sandwoodOperators/ParForTask.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/tasks/sandwoodOperators/ParForTask.java
@@ -13,7 +13,7 @@ import static org.sandwood.compiler.trees.irTree.IRTree.parallelForStmt;
 import org.sandwood.compiler.compilation.CompilationContext;
 import org.sandwood.compiler.compilation.scopesState.ScopeTracking;
 import org.sandwood.compiler.dataflowGraph.tasks.DFType;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
 import org.sandwood.compiler.srcTools.sourceToSource.Location;
 import org.sandwood.compiler.trees.Tree;
@@ -49,7 +49,7 @@ public class ParForTask extends ForTask {
             IRTreeReturn<IntVariable> startTree = start.getForwardIR(compilationCtx);
             IRTreeReturn<IntVariable> endTree = end.getForwardIR(compilationCtx);
             IRTreeReturn<IntVariable> stepTree = step.getForwardIR(compilationCtx);
-            VariableDescription<IntVariable> indexDesc = index.getUniqueVarDesc();
+            LocalVariableDescription<IntVariable> indexDesc = (LocalVariableDescription<IntVariable>)index.getUniqueVarDesc();
             if(reverseScopes) {
                 startTree = updateStart(startTree, incrementing);
                 endTree = updateEnd(startTree, endTree, stepTree, incrementing);

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/ClassVariableDescription.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/ClassVariableDescription.java
@@ -10,8 +10,9 @@ package org.sandwood.compiler.dataflowGraph.variables;
 
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
 
-public abstract class ClassVariableDescription<A extends Variable<A>> extends VariableDescription<A> {
-    
+public abstract sealed class ClassVariableDescription<A extends Variable<A>> extends VariableDescription<A>
+        permits GlobalVariableDescription, ScratchVariableDescription {
+
     ClassVariableDescription(VariableName name, Type<A> type) {
         super(name, type);
     }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/ClassVariableDescription.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/ClassVariableDescription.java
@@ -1,0 +1,18 @@
+/*
+ * Sandwood
+ *
+ * Copyright (c) 2019-2026, Oracle and/or its affiliates
+ * 
+ * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package org.sandwood.compiler.dataflowGraph.variables;
+
+import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
+
+public abstract class ClassVariableDescription<A extends Variable<A>> extends VariableDescription<A> {
+    
+    ClassVariableDescription(VariableName name, Type<A> type) {
+        super(name, type);
+    }
+}

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/GlobalVariableDescription.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/GlobalVariableDescription.java
@@ -1,0 +1,27 @@
+/*
+ * Sandwood
+ *
+ * Copyright (c) 2019-2026, Oracle and/or its affiliates
+ * 
+ * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package org.sandwood.compiler.dataflowGraph.variables;
+
+import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
+
+public class GlobalVariableDescription<A extends Variable<A>> extends ClassVariableDescription<A> {
+
+    public GlobalVariableDescription(String name, Type<A> type, boolean comment) {
+        this(new VariableName(name, comment), type);
+    }
+
+    public GlobalVariableDescription(VariableName name, Type<A> type) {
+        super(name, type);
+    }
+
+    @Override
+    public <B extends Variable<B>> GlobalVariableDescription<B> alternativeType(Type<B> type) {
+        return new GlobalVariableDescription<>(name, type);
+    }
+}

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/GlobalVariableDescription.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/GlobalVariableDescription.java
@@ -10,7 +10,7 @@ package org.sandwood.compiler.dataflowGraph.variables;
 
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
 
-public class GlobalVariableDescription<A extends Variable<A>> extends ClassVariableDescription<A> {
+public final class GlobalVariableDescription<A extends Variable<A>> extends ClassVariableDescription<A> {
 
     public GlobalVariableDescription(String name, Type<A> type, boolean comment) {
         this(new VariableName(name, comment), type);

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/LocalVariableDescription.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/LocalVariableDescription.java
@@ -1,0 +1,27 @@
+/*
+ * Sandwood
+ *
+ * Copyright (c) 2019-2026, Oracle and/or its affiliates
+ * 
+ * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package org.sandwood.compiler.dataflowGraph.variables;
+
+import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
+
+public class LocalVariableDescription<A extends Variable<A>> extends VariableDescription<A> {
+
+    public LocalVariableDescription(String name, Type<A> type, boolean comment) {
+        this(new VariableName(name, comment), type);
+    }
+
+    public LocalVariableDescription(VariableName name, Type<A> type) {
+        super(name, type);
+    }
+
+    @Override
+    public <B extends Variable<B>> LocalVariableDescription<B> alternativeType(Type<B> type) {
+        return new LocalVariableDescription<>(name, type);
+    }
+}

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/LocalVariableDescription.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/LocalVariableDescription.java
@@ -10,7 +10,7 @@ package org.sandwood.compiler.dataflowGraph.variables;
 
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
 
-public class LocalVariableDescription<A extends Variable<A>> extends VariableDescription<A> {
+public final class LocalVariableDescription<A extends Variable<A>> extends VariableDescription<A> {
 
     public LocalVariableDescription(String name, Type<A> type, boolean comment) {
         this(new VariableName(name, comment), type);

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/ScratchVariableDescription.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/ScratchVariableDescription.java
@@ -10,7 +10,7 @@ package org.sandwood.compiler.dataflowGraph.variables;
 
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
 
-public class ScratchVariableDescription<A extends Variable<A>> extends ClassVariableDescription<A> {
+public final class ScratchVariableDescription<A extends Variable<A>> extends ClassVariableDescription<A> {
 
     public ScratchVariableDescription(String name, Type<A> type, boolean comment) {
         this(new VariableName(name, comment), type);

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/ScratchVariableDescription.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/ScratchVariableDescription.java
@@ -1,0 +1,27 @@
+/*
+ * Sandwood
+ *
+ * Copyright (c) 2019-2026, Oracle and/or its affiliates
+ * 
+ * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package org.sandwood.compiler.dataflowGraph.variables;
+
+import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
+
+public class ScratchVariableDescription<A extends Variable<A>> extends ClassVariableDescription<A> {
+
+    public ScratchVariableDescription(String name, Type<A> type, boolean comment) {
+        this(new VariableName(name, comment), type);
+    }
+
+    public ScratchVariableDescription(VariableName name, Type<A> type) {
+        super(name, type);
+    }
+
+    @Override
+    public <B extends Variable<B>> ScratchVariableDescription<B> alternativeType(Type<B> type) {
+        return new ScratchVariableDescription<>(name, type);
+    }
+}

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/VariableDescription.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/VariableDescription.java
@@ -23,7 +23,8 @@ import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
  * @author djgoodma
  *
  */
-public abstract class VariableDescription<A extends Variable<A>> implements Comparable<VariableDescription<?>> {
+public abstract sealed class VariableDescription<A extends Variable<A>> implements Comparable<VariableDescription<?>>
+        permits ClassVariableDescription, LocalVariableDescription {
     /**
      * The name of the variable.
      */
@@ -70,6 +71,6 @@ public abstract class VariableDescription<A extends Variable<A>> implements Comp
     public int compareTo(VariableDescription<?> o) {
         return name.compareTo(o.name);
     }
-    
+
     public abstract <B extends Variable<B>> VariableDescription<B> alternativeType(Type<B> type);
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/VariableDescription.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/VariableDescription.java
@@ -8,6 +8,8 @@
 
 package org.sandwood.compiler.dataflowGraph.variables;
 
+import java.util.Objects;
+
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
 
 /**
@@ -21,7 +23,7 @@ import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
  * @author djgoodma
  *
  */
-public class VariableDescription<A extends Variable<A>> implements Comparable<VariableDescription<?>> {
+public abstract class VariableDescription<A extends Variable<A>> implements Comparable<VariableDescription<?>> {
     /**
      * The name of the variable.
      */
@@ -32,14 +34,9 @@ public class VariableDescription<A extends Variable<A>> implements Comparable<Va
      */
     public final Type<A> type;
 
-    public VariableDescription(String name, Type<A> type, boolean comment) {
-        this(new VariableName(name, comment), type);
-    }
-
     public VariableDescription(VariableName name, Type<A> type) {
         this.name = name;
-        if(type == null)
-            throw new NullPointerException();
+        Objects.requireNonNull(type);
         this.type = type;
     }
 
@@ -73,4 +70,6 @@ public class VariableDescription<A extends Variable<A>> implements Comparable<Va
     public int compareTo(VariableDescription<?> o) {
         return name.compareTo(o.name);
     }
+    
+    public abstract <B extends Variable<B>> VariableDescription<B> alternativeType(Type<B> type);
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/VariableImplementation.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/VariableImplementation.java
@@ -204,10 +204,19 @@ public abstract class VariableImplementation<A extends Variable<A>> implements V
     @Override
     public VariableDescription<A> getVarDesc() {
         String alias = instanceHandle().getAlias();
-        if(alias != null)
-            return new VariableDescription<>(alias, getType(), false);
-        else
-            return new VariableDescription<>("var" + getHandleId(), getType(), true);
+        boolean isSubArray = getType().isArray() && ((ArrayVariable<?>)this).isSubArray();
+        if(alias != null) {
+            if(isIntermediate() || (isSample() && ! isSubArray) || parent.getType() == DFType.CONSTRUCT_INPUT)
+                return new GlobalVariableDescription<>(alias, getType(), false);
+            else
+                return new LocalVariableDescription<>(alias, getType(), false);
+        }
+        else {
+            if(isSample() && ! isSubArray)
+                return new GlobalVariableDescription<>("var" + getHandleId(), getType(), true);
+            else
+                return new LocalVariableDescription<>("var" + getHandleId(), getType(), true);
+        }
     }
 
     /**
@@ -228,8 +237,10 @@ public abstract class VariableImplementation<A extends Variable<A>> implements V
     private void constructUniqueName(Type<A> type) {
         Variable<?> i = instanceHandle();
         String alias = (i != null) ? i.getAlias() : this.alias;
-
-        uniqueName = VariableNames.variableName(alias, getHandleId(), type, false);
+        if(parent.getType() == DFType.CONSTRUCT_INPUT)
+            uniqueName = VariableNames.globalVariableName(alias, getHandleId(), type);
+        else
+            uniqueName = VariableNames.localVariableName(alias, getHandleId(), type, false);
     }
 
     /**
@@ -297,11 +308,11 @@ public abstract class VariableImplementation<A extends Variable<A>> implements V
     }
 
     @Override
-    public void setUniqueVarDesc(VariableDescription<A> varDesc) {
-        if(this == instanceHandle() || instanceHandle() == null) {
-            this.uniqueName = varDesc;
-        } else
-            instanceHandle().setUniqueVarDesc(varDesc);
+    public void setUniqueVarDesc(VariableDescription<A> uniqueName) {
+        if(this == instanceHandle() || instanceHandle() == null)
+            this.uniqueName = uniqueName;
+        else
+            instanceHandle().setUniqueVarDesc(uniqueName);
     }
 
     /**
@@ -548,8 +559,10 @@ public abstract class VariableImplementation<A extends Variable<A>> implements V
     @Override
     public void setIntermediate() {
         Variable<A> i = instanceHandle();
-        if(this == i)
+        if(this == i) {
             intermediateVariable = true;
+            uniqueName = VariableNames.makeGlobal(uniqueName);
+        }
         else
             i.setIntermediate();
     }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/VariableImplementation.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/dataflowGraph/variables/VariableImplementation.java
@@ -204,15 +204,14 @@ public abstract class VariableImplementation<A extends Variable<A>> implements V
     @Override
     public VariableDescription<A> getVarDesc() {
         String alias = instanceHandle().getAlias();
-        boolean isSubArray = getType().isArray() && ((ArrayVariable<?>)this).isSubArray();
+        boolean isSubArray = getType().isArray() && ((ArrayVariable<?>) this).isSubArray();
         if(alias != null) {
-            if(isIntermediate() || (isSample() && ! isSubArray) || parent.getType() == DFType.CONSTRUCT_INPUT)
+            if(isIntermediate() || (isSample() && !isSubArray) || parent.getType() == DFType.CONSTRUCT_INPUT)
                 return new GlobalVariableDescription<>(alias, getType(), false);
             else
                 return new LocalVariableDescription<>(alias, getType(), false);
-        }
-        else {
-            if(isSample() && ! isSubArray)
+        } else {
+            if(isSample() && !isSubArray)
                 return new GlobalVariableDescription<>("var" + getHandleId(), getType(), true);
             else
                 return new LocalVariableDescription<>("var" + getHandleId(), getType(), true);
@@ -562,8 +561,7 @@ public abstract class VariableImplementation<A extends Variable<A>> implements V
         if(this == i) {
             intermediateVariable = true;
             uniqueName = VariableNames.makeGlobal(uniqueName);
-        }
-        else
+        } else
             i.setIntermediate();
     }
 
@@ -793,7 +791,7 @@ public abstract class VariableImplementation<A extends Variable<A>> implements V
         var.add(this);
         return Variable.collectInputVariable(var, stopTypes);
     }
-    
+
     /**
      * Method to get the observation status of a variable.
      * 

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/names/FunctionName.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/names/FunctionName.java
@@ -10,7 +10,6 @@ package org.sandwood.compiler.names;
 
 import org.sandwood.compiler.compilation.CompilationContext.SampleFunctionClass;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableName;
 import org.sandwood.compiler.exceptions.CompilerException;
 
@@ -54,20 +53,20 @@ public class FunctionName extends Name {
         return new FunctionName(name.getName());
     }
 
-    private static String logProbabilityDistributionName(VariableDescription<?> varDesc) {
-        return "logProbabilityDistribution" + Name.prefix + varDesc;
+    private static String logProbabilityDistributionName(VariableName varName) {
+        return "logProbabilityDistribution" + Name.prefix + varName;
     }
 
-    public static String logProbabilityValueName(VariableDescription<?> varDesc) {
-        return "logProbabilityValue" + Name.prefix + varDesc;
+    public static String logProbabilityValueName(VariableName varName) {
+        return "logProbabilityValue" + Name.prefix + varName;
     }
 
     public static FunctionName createFunctionName(SampleFunctionClass functionClass, SampleTask<?, ?> sample) {
         return switch(functionClass) {
             case INFERENCE -> new FunctionName("inferSample" + sample.id());
             case LOG_PROBABILITY_DISTRIBUTIONS -> new FunctionName(
-                    logProbabilityDistributionName(sample.getUniqueVarDesc()));
-            case LOG_PROBABILITY_VALUE -> new FunctionName(logProbabilityValueName(sample.getUniqueVarDesc()));
+                    logProbabilityDistributionName(sample.getSampleName()));
+            case LOG_PROBABILITY_VALUE -> new FunctionName(logProbabilityValueName(sample.getSampleName()));
             case SAMPLE -> new FunctionName("drawValueSample" + sample.id());
         };
     }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/names/VariableNames.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/names/VariableNames.java
@@ -82,6 +82,10 @@ public final class VariableNames {
         return name.getName().startsWith(lengthPrefix);
     }
 
+    public static String lengthName(String varName) {
+        return lengthPrefix + varName;
+    }
+
     public static VariableDescription<IntVariable> lengthName(VariableDescription<?> varDesc) {
         return new VariableDescription<>(lengthPrefix + varDesc, VariableType.IntVariable, varDesc.name.comment);
     }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/names/VariableNames.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/names/VariableNames.java
@@ -12,6 +12,9 @@ import org.sandwood.compiler.dataflowGraph.tasks.DFType;
 import org.sandwood.compiler.dataflowGraph.tasks.DataflowTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
+import org.sandwood.compiler.dataflowGraph.variables.GlobalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.ScratchVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableName;
@@ -24,13 +27,11 @@ import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.BooleanVari
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.DoubleVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
 
-//TODO Separate this out so that we have regular names and global names, and only global names can be used to create class fields.
-
 public final class VariableNames {
     private VariableNames() {}
 
-    public static <A extends Variable<A>> VariableDescription<A> internalName(VariableDescription<A> varDesc) {
-        return new VariableDescription<>(Name.prefix + varDesc, varDesc.type, varDesc.name.comment);
+    public static <A extends Variable<A>> GlobalVariableDescription<A> internalName(VariableDescription<A> varDesc) {
+        return new GlobalVariableDescription<>(Name.prefix + varDesc, varDesc.type, varDesc.name.comment);
     }
 
     public static VariableName internalName(VariableName name) {
@@ -47,27 +48,30 @@ public final class VariableNames {
 
     private static final String rng = "RNG" + Name.prefix;
 
-    public static VariableDescription<RandomNumberGenerator> rngName(int depth) {
-        if(depth == 0)
-            return new VariableDescription<>(rng, VariableType.RNG, true);
-        else
-            return new VariableDescription<>(rng + depth, VariableType.RNG, true);
+    public static GlobalVariableDescription<RandomNumberGenerator> rngName() {
+        return new GlobalVariableDescription<>(rng, VariableType.RNG, true);
+    }
+
+    public static LocalVariableDescription<RandomNumberGenerator> rngName(int depth) {
+        assert (depth > 0);
+        return new LocalVariableDescription<>(rng + depth, VariableType.RNG, true);
     }
 
     private static final String threadId = "threadID" + Name.prefix;
 
-    public static VariableDescription<IntVariable> threadIdName(VariableName name) {
-        return new VariableDescription<>(threadId + name, VariableType.IntVariable, name.comment);
+    public static LocalVariableDescription<IntVariable> threadIdName(VariableName name) {
+        return new LocalVariableDescription<>(threadId + name, VariableType.IntVariable, name.comment);
     }
 
     private static final String logProbability = "logProbability" + Name.prefix;
 
-    public static VariableDescription<DoubleVariable> logProbabilityName(VariableDescription<?> varDesc) {
-        return new VariableDescription<>(logProbability + varDesc, VariableType.DoubleVariable, varDesc.name.comment);
+    public static GlobalVariableDescription<DoubleVariable> logProbabilityName(VariableDescription<?> varDesc) {
+        return new GlobalVariableDescription<>(logProbability + varDesc, VariableType.DoubleVariable,
+                varDesc.name.comment);
     }
 
-    public static VariableDescription<DoubleVariable> logProbabilityName(VariableName name) {
-        return new VariableDescription<>(logProbability + name, VariableType.DoubleVariable, name.comment);
+    public static GlobalVariableDescription<DoubleVariable> logProbabilityName(VariableName name) {
+        return new GlobalVariableDescription<>(logProbability + name, VariableType.DoubleVariable, name.comment);
     }
 
     private static final String fixedSampleProbability = "fixedSampleDistProbability" + Name.prefix;
@@ -86,27 +90,18 @@ public final class VariableNames {
         return lengthPrefix + varName;
     }
 
-    public static VariableDescription<IntVariable> lengthName(VariableDescription<?> varDesc) {
-        return new VariableDescription<>(lengthPrefix + varDesc, VariableType.IntVariable, varDesc.name.comment);
-    }
-
     public static VariableName lengthName(VariableName name) {
         return new VariableName(lengthPrefix + name, name.comment);
     }
 
     private static final String lengthCVPrefix = "lengthCV" + Name.prefix;
 
-    public static VariableDescription<IntVariable> lengthCVName(VariableName name, int taskId, int tag) {
-        return new VariableDescription<>(lengthCVPrefix + name + Name.prefix + taskId + "_" + tag,
+    public static LocalVariableDescription<IntVariable> lengthCVName(VariableName name, int taskId, int tag) {
+        return new LocalVariableDescription<>(lengthCVPrefix + name + Name.prefix + taskId + "_" + tag,
                 VariableType.IntVariable, true);
     }
 
     private static final String shape = "Shape";
-
-    public static <A extends Variable<A>> VariableDescription<A> shapeName(VariableDescription<?> varDesc,
-            Type<A> type) {
-        return new VariableDescription<>(varDesc + shape, type, varDesc.name.comment);
-    }
 
     public static VariableName shapeName(VariableName name) {
         return new VariableName(name + shape, name.comment);
@@ -114,35 +109,52 @@ public final class VariableNames {
 
     private static final String calcVar = "cv" + Name.prefix;
 
-    public static <A extends Variable<A>> VariableDescription<A> calcVarName(Variable<?> v, String postfix,
+    public static <A extends Variable<A>> LocalVariableDescription<A> localCalcVarName(Variable<?> v, String postfix,
             Type<A> type) {
-        return VariableNames.calcVarName("var" + v.getId() + Name.prefix + postfix, type, true);
+        return localCalcVarName("var" + v.getId() + Name.prefix + postfix, type, true);
     }
 
-    // TODO remove the generated flag from here and set it to a static true.
-    public static <A extends Variable<A>> VariableDescription<A> calcVarName(String name, Type<A> type,
+    // TODO remove the generated flag from here and replace it with an enumeration so that it is clear what is being
+    // set. This will encourage it to be used correctly.
+    public static <A extends Variable<A>> LocalVariableDescription<A> localCalcVarName(String name, Type<A> type,
             boolean generated) {
-        return new VariableDescription<>(calcVar + name, type, generated);
+        return new LocalVariableDescription<>(calcVar + name, type, generated);
     }
 
-    public static <A extends Variable<A>> VariableDescription<A> calcVarName(String name1, String name2, Type<A> type,
-            boolean generated) {
-        return new VariableDescription<>(calcVar + name1 + Name.prefix + name2, type, generated);
-    }
-
-    public static <A extends Variable<A>> VariableDescription<A> calcVarName(String name1, String name2, String name3,
+    public static <A extends Variable<A>> LocalVariableDescription<A> localCalcVarName(String name1, String name2,
             Type<A> type, boolean generated) {
-        return new VariableDescription<>(calcVar + name1 + Name.prefix + name2 + Name.prefix + name3, type, generated);
+        return new LocalVariableDescription<>(calcVar + name1 + Name.prefix + name2, type, generated);
     }
 
-    public static <A extends Variable<A>> VariableDescription<A> calcVarName(VariableDescription<?> varDesc,
+    public static <A extends Variable<A>> LocalVariableDescription<A> localCalcVarName(String name1, String name2,
+            String name3, Type<A> type, boolean generated) {
+        return new LocalVariableDescription<>(calcVar + name1 + Name.prefix + name2 + Name.prefix + name3, type,
+                generated);
+    }
+
+    public static <A extends Variable<A>> LocalVariableDescription<A> localCalcVarName(VariableDescription<?> varDesc,
             Type<A> type) {
-        return new VariableDescription<>(calcVar + varDesc, type, varDesc.name.comment);
+        return new LocalVariableDescription<>(calcVar + varDesc, type, varDesc.name.comment);
     }
 
-    public static <A extends Variable<A>> VariableDescription<A> calcVarName(VariableDescription<?> varDesc,
+    public static <A extends Variable<A>> LocalVariableDescription<A> localCalcVarName(VariableDescription<?> varDesc,
             String postfix, Type<A> type) {
-        return new VariableDescription<>(calcVar + varDesc + Name.prefix + postfix, type, varDesc.name.comment);
+        return new LocalVariableDescription<>(calcVar + varDesc + Name.prefix + postfix, type, varDesc.name.comment);
+    }
+
+    public static <A extends Variable<A>> ScratchVariableDescription<A> globalScratchVarName(Variable<?> v, String postfix,
+            Type<A> type) {
+        return globalScratchVarName("var" + v.getId() + Name.prefix + postfix, type, true);
+    }
+
+    public static <A extends Variable<A>> ScratchVariableDescription<A> globalScratchVarName(String name, Type<A> type,
+            boolean generated) {
+        return new ScratchVariableDescription<>(calcVar + name, type, generated);
+    }
+
+    public static <A extends Variable<A>> ScratchVariableDescription<A> globalScratchVarName(String name1, String name2,
+            Type<A> type, boolean generated) {
+        return new ScratchVariableDescription<>(calcVar + name1 + Name.prefix + name2, type, generated);
     }
 
     public static VariableName calcVarName(VariableName name) {
@@ -155,36 +167,37 @@ public final class VariableNames {
 
     private static final String scopeVar = "scopeVariable" + Name.prefix;
 
-    public static <A extends Variable<A>> VariableDescription<A> scopeVarName(String name, Type<A> type) {
-        return new VariableDescription<>(scopeVar + name, type, true);
+    public static <A extends Variable<A>> LocalVariableDescription<A> scopeVarName(String name, Type<A> type) {
+        return new LocalVariableDescription<>(scopeVar + name, type, true);
     }
 
     private static final String distTempVar = "distributionTempVariable" + Name.prefix;
 
-    public static <A extends Variable<A>> VariableDescription<A> distributionTempName(VariableName name, int id,
+    public static <A extends Variable<A>> LocalVariableDescription<A> distributionTempName(VariableName name, int id,
             Type<A> type) {
-        return new VariableDescription<>(distTempVar + name + Name.prefix + id, type, true);
+        return new LocalVariableDescription<>(distTempVar + name + Name.prefix + id, type, true);
     }
 
     private static final String traceTempVar = "traceTempVariable" + Name.prefix;
 
-    public static <A extends Variable<A>> VariableDescription<A> traceTempName(VariableName name, int globalId,
+    public static <A extends Variable<A>> LocalVariableDescription<A> traceTempName(VariableName name, int globalId,
             int localId, Type<A> type) {
-        return new VariableDescription<>(traceTempVar + name + Name.prefix + globalId + "_" + localId, type, true);
+        return new LocalVariableDescription<>(traceTempVar + name + Name.prefix + globalId + "_" + localId, type, true);
     }
 
     private static final String reduceTempVar = "reduceVar" + Name.prefix;
 
-    public static <A extends Variable<A>> VariableDescription<A> reduceName(Variable<A> returnVar, int id) {
+    public static <A extends Variable<A>> LocalVariableDescription<A> reduceName(Variable<A> returnVar, int id) {
         VariableDescription<A> desc = returnVar.getUniqueVarDesc();
-        return new VariableDescription<>(reduceTempVar + desc.name + Name.prefix + id, desc.type, true);
+        return new LocalVariableDescription<>(reduceTempVar + desc.name + Name.prefix + id, desc.type, true);
     }
 
     private static final String fixedFlag = "fixedFlag" + Name.prefix;
 
-    public static VariableDescription<BooleanVariable> fixedFlagName(SampleTask<?, ?> task) {
-        VariableDescription<?> varDesc = task.getUniqueVarDesc();
-        return new VariableDescription<>(fixedFlag + varDesc, VariableType.BooleanVariable, varDesc.name.comment);
+    public static GlobalVariableDescription<BooleanVariable> fixedFlagName(SampleTask<?, ?> task) {
+        VariableName sampleName = task.getSampleName();
+        return new GlobalVariableDescription<>(fixedFlag + sampleName, VariableType.BooleanVariable,
+                sampleName.comment);
     }
 
     /**
@@ -193,78 +206,88 @@ public final class VariableNames {
      */
     private static final String constrainedFlag = "constrainedFlag" + Name.prefix;
 
-    public static VariableDescription<BooleanVariable> constrainedFlagName(SampleTask<?, ?> task) {
-        VariableDescription<?> varDesc = task.getUniqueVarDesc();
-        return new VariableDescription<BooleanVariable>(constrainedFlag + varDesc, VariableType.BooleanVariable, false);
+    public static GlobalVariableDescription<BooleanVariable> constrainedFlagName(SampleTask<?, ?> task) {
+        VariableName sampleName = task.getSampleName();
+        return new GlobalVariableDescription<BooleanVariable>(constrainedFlag + sampleName,
+                VariableType.BooleanVariable, false);
     }
 
     private static final String fixedProbFlag = "fixedProbFlag" + Name.prefix;
 
-    public static VariableDescription<BooleanVariable> getProbabilityFixedFlag(SampleTask<?, ?> task) {
-        VariableDescription<?> varDesc = task.getUniqueVarDesc();
-        return new VariableDescription<>(fixedProbFlag + varDesc, VariableType.BooleanVariable, varDesc.name.comment);
+    public static GlobalVariableDescription<BooleanVariable> getProbabilityFixedFlag(SampleTask<?, ?> task) {
+        VariableName sampleName = task.getSampleName();
+        return new GlobalVariableDescription<>(fixedProbFlag + sampleName, VariableType.BooleanVariable,
+                sampleName.comment);
     }
 
     private static final String index = "index" + Name.prefix;
 
-    public static VariableDescription<IntVariable> indexName(VariableDescription<?> desc) {
-        return new VariableDescription<>(index + desc.name, VariableType.IntVariable, desc.name.comment);
+    public static LocalVariableDescription<IntVariable> indexName(VariableDescription<?> desc) {
+        return new LocalVariableDescription<>(index + desc.name, VariableType.IntVariable, desc.name.comment);
     }
 
-    public static VariableDescription<IntVariable> indexName(VariableDescription<?> desc, String id) {
-        return new VariableDescription<>(index + desc.name + Name.prefix + id, VariableType.IntVariable,
+    public static LocalVariableDescription<IntVariable> indexName(VariableDescription<?> desc, String id) {
+        return new LocalVariableDescription<>(index + desc.name + Name.prefix + id, VariableType.IntVariable,
                 desc.name.comment);
     }
 
-    public static VariableDescription<IntVariable> indexName(VariableName name, String id) {
-        return new VariableDescription<>(index + name + Name.prefix + id, VariableType.IntVariable, name.comment);
+    public static LocalVariableDescription<IntVariable> indexName(VariableName name, String id) {
+        return new LocalVariableDescription<>(index + name + Name.prefix + id, VariableType.IntVariable, name.comment);
     }
 
-    public static <A extends Variable<A>> VariableDescription<A> variableName(String alias, int id, Type<A> type,
-            boolean generated) {
-        if(alias != null)
-            return new VariableDescription<>(alias + Name.prefix + "var" + id, type, generated);
+    public static <A extends Variable<A>> LocalVariableDescription<A> localVariableName(String alias, int id,
+            Type<A> type, boolean generated) {
+        if(alias == null)
+            return new LocalVariableDescription<>(Name.prefix + "var" + id, type, generated);
         else
-            return new VariableDescription<>(Name.prefix + "var" + id, type, generated);
+            return new LocalVariableDescription<>(alias + Name.prefix + "var" + id, type, generated);
+    }
+
+    public static <A extends Variable<A>> GlobalVariableDescription<A> globalVariableName(String alias, int id,
+            Type<A> type) {
+        assert alias != null;
+        return new GlobalVariableDescription<>(alias + Name.prefix + "var" + id, type, false);
     }
 
     private static final String forEnd = "forEnd" + Name.prefix;
 
-    public static VariableDescription<IntVariable> parForEnd(VariableDescription<IntVariable> varDesc) {
-        return new VariableDescription<>(forEnd + varDesc, varDesc.type, varDesc.name.comment);
+    public static LocalVariableDescription<IntVariable> parForEnd(VariableDescription<IntVariable> varDesc) {
+        return new LocalVariableDescription<>(forEnd + varDesc, varDesc.type, varDesc.name.comment);
     }
 
     private static final String forStart = "forStart" + Name.prefix;
 
-    public static VariableDescription<IntVariable> parForStart(VariableDescription<IntVariable> varDesc) {
-        return new VariableDescription<>(forStart + varDesc, varDesc.type, varDesc.name.comment);
+    public static LocalVariableDescription<IntVariable> parForStart(VariableDescription<IntVariable> varDesc) {
+        return new LocalVariableDescription<>(forStart + varDesc, varDesc.type, varDesc.name.comment);
     }
 
     private static final String distribution = "distribution" + Name.prefix;
 
-    public static VariableDescription<ArrayVariable<DoubleVariable>> distribution(DistributionSampleTask<?, ?> sTask) {
-        VariableDescription<?> varDesc = sTask.getUniqueVarDesc();
-        return new VariableDescription<>(distribution + varDesc, VariableType.arrayType(VariableType.DoubleVariable),
-                varDesc.name.comment);
+    public static GlobalVariableDescription<ArrayVariable<DoubleVariable>> distribution(
+            DistributionSampleTask<?, ?> sTask) {
+        VariableName sampleName = sTask.getSampleName();
+        return new GlobalVariableDescription<>(distribution + sampleName,
+                VariableType.arrayType(VariableType.DoubleVariable), sampleName.comment);
     }
 
-    public static VariableDescription<DoubleVariable> distributionAccumulator(RandomVariable<?, ?> rv) {
-        return new VariableDescription<>(distribution + "randomVariable" + Name.prefix + rv.getId() + "accumulator",
-                VariableType.DoubleVariable, false);
+    public static LocalVariableDescription<DoubleVariable> distributionAccumulator(RandomVariable<?, ?> rv) {
+        return new LocalVariableDescription<>(
+                distribution + "randomVariable" + Name.prefix + rv.getId() + "accumulator", VariableType.DoubleVariable,
+                false);
     }
 
     private static final String guard = "guard" + Name.prefix;
 
-    public static <A extends Variable<A>> VariableDescription<A> guardName(DataflowTask<?> start, DataflowTask<?> end,
-            int id, Type<A> type) {
+    public static LocalVariableDescription<BooleanVariable> guardName(DataflowTask<?> start, DataflowTask<?> end,
+            int id) {
         if(id == 1)
-            return new VariableDescription<>(
-                    guard + typeToName(start.getType()) + start.id() + typeToName(end.getType()) + end.id(), type,
-                    true);
+            return new LocalVariableDescription<>(
+                    guard + typeToName(start.getType()) + start.id() + typeToName(end.getType()) + end.id(),
+                    VariableType.BooleanVariable, true);
         else
-            return new VariableDescription<>(
-                    guard + typeToName(start.getType()) + start.id() + typeToName(end.getType()) + end.id() + id, type,
-                    true);
+            return new LocalVariableDescription<>(
+                    guard + typeToName(start.getType()) + start.id() + typeToName(end.getType()) + end.id() + id,
+                    VariableType.BooleanVariable, true);
 
     }
 
@@ -289,39 +312,39 @@ public final class VariableNames {
         return varDesc.name.getName().startsWith(guard);
     }
 
-    public static <A extends Variable<A>> VariableDescription<A> globalGuardName(VariableDescription<?> varDesc,
+    public static <A extends Variable<A>> ScratchVariableDescription<A> globalGuardName(VariableDescription<?> varDesc,
             Type<A> type) {
-        return new VariableDescription<>(varDesc + Name.prefix + "global", type, true);
+        return new ScratchVariableDescription<>(varDesc + Name.prefix + "global", type, true);
     }
 
-    public static <A extends Variable<A>> VariableDescription<A> altTypeName(VariableDescription<?> varDesc,
-            Type<A> type) {
-        return new VariableDescription<>(varDesc.name.getName(), type, varDesc.name.comment);
+    public static <V extends Variable<V>> LocalVariableDescription<V> lambdaSubstitute(VariableDescription<V> desc,
+            int id) {
+        return new LocalVariableDescription<>(desc + Name.prefix + id, desc.type, true);
     }
 
-    public static <V extends Variable<V>> VariableDescription<V> lambdaSubstitute(VariableDescription<V> desc, int id) {
-        return new VariableDescription<>(desc + Name.prefix + id, desc.type, true);
-    }
-
-    public static <V extends Variable<V>> VariableDescription<V> scopedCopySubstitute(Variable<V> v, int id) {
+    public static <V extends Variable<V>> LocalVariableDescription<V> scopedCopySubstitute(Variable<V> v, int id) {
         VariableDescription<V> desc = v.getUniqueVarDesc();
-        return new VariableDescription<>("sc" + Name.prefix + desc + Name.prefix + id, desc.type, true);
+        return new LocalVariableDescription<>("sc" + Name.prefix + desc + Name.prefix + id, desc.type, true);
     }
 
-    public static <A extends Variable<A>> VariableDescription<ArrayVariable<ArrayVariable<A>>> subarrayName(int suffix,
-            Type<ArrayVariable<ArrayVariable<A>>> type) {
-        return new VariableDescription<>("subarray" + Name.prefix + suffix, type, true);
+    public static <A extends Variable<A>> LocalVariableDescription<ArrayVariable<ArrayVariable<A>>> subarrayName(
+            int suffix, Type<ArrayVariable<ArrayVariable<A>>> type) {
+        return new LocalVariableDescription<>("subarray" + Name.prefix + suffix, type, true);
     }
 
-    public static VariableDescription<BooleanVariable> observedGuard(Variable<?> v) {
-        return new VariableDescription<>("observationGuard" + Name.prefix + v.getUniqueVarDesc().name,
+    public static LocalVariableDescription<BooleanVariable> observedGuard(Variable<?> v) {
+        return new LocalVariableDescription<>("observationGuard" + Name.prefix + v.getUniqueVarDesc().name,
                 VariableType.BooleanVariable, true);
     }
 
-    private static final VariableDescription<BooleanVariable> allocatedFlag = new VariableDescription<>(
+    private static final LocalVariableDescription<BooleanVariable> allocatedFlag = new LocalVariableDescription<>(
             "allocated" + Name.prefix, VariableType.BooleanVariable, true);
 
-    public static VariableDescription<BooleanVariable> allocatedFlag() {
+    public static LocalVariableDescription<BooleanVariable> allocatedFlag() {
         return allocatedFlag;
+    }
+
+    public static <A extends Variable<A>> GlobalVariableDescription<A> makeGlobal(VariableDescription<A> varDesc) {
+        return new GlobalVariableDescription<A>(varDesc.name, varDesc.type);
     }
 }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/guards/ScopeConstructor.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/guards/ScopeConstructor.java
@@ -66,6 +66,8 @@ import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.DistributionSampleT
 import org.sandwood.compiler.dataflowGraph.tasks.returnTasks.SampleTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ForTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ParForTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.ScratchVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -105,28 +107,25 @@ public class ScopeConstructor {
 
     public enum Direction {
         FORWARDS,
-        BACKWARDS;
-    }
+        BACKWARDS; }
 
     public enum Guards {
         GUARDS,
-        NO_GUARDS;
-    }
+        NO_GUARDS; }
 
     public enum Values {
         PASS_VALUES,
-        IGNORE_VALUES;
-    }
+        IGNORE_VALUES; }
 
     private static class GuardDesc {
         // Name for the guard that will ensure the body of this code is only executed once. If there is only 1 trace
         // there is only 1 opportunity for the code to run.
-        final VariableDescription<BooleanVariable> varDesc;
+        final LocalVariableDescription<BooleanVariable> varDesc;
         // List of scopes that the consumer is in that can change. For each combination of values from the scopes we
         // only want to execute once.
         final List<ForTask> scopes;
 
-        GuardDesc(VariableDescription<BooleanVariable> guardVarDesc, List<ForTask> scopes) {
+        GuardDesc(LocalVariableDescription<BooleanVariable> guardVarDesc, List<ForTask> scopes) {
             this.varDesc = guardVarDesc;
             this.scopes = scopes;
         }
@@ -735,7 +734,7 @@ public class ScopeConstructor {
 
         // Get a name for the value index.
         DistributableRandomVariable<A, ?> r = disSampleTask.randomVariable;
-        VariableDescription<IntVariable> indexName = VariableNames.indexName(disSampleTask.getUniqueVarDesc(),
+        VariableDescription<IntVariable> indexName = VariableNames.indexName(disSampleTask.getSampleName(),
                 Integer.toString(id.get().next()));
 
         // Get the number of states that this variable could be generating.
@@ -750,7 +749,7 @@ public class ScopeConstructor {
 
         // Calculate the probability of this sampling. Generate a unique name for the variables. This must include an id
         // element as there may be several different values drawn from any given sample task.
-        VariableDescription<DoubleVariable> probabilityName = VariableNames.calcVarName(
+        LocalVariableDescription<DoubleVariable> probabilityName = VariableNames.localCalcVarName(
                 "probabilitySample" + disSampleTask.id() + "Value" + id.get().next(), VariableType.DoubleVariable,
                 false);
 
@@ -758,7 +757,7 @@ public class ScopeConstructor {
         IRTreeReturn<IntVariable> loopIndex = IRTree.load(indexName);
 
         // Set the sample value.
-        VariableDescription<A> tempName = VariableNames.distributionTempName(
+        LocalVariableDescription<A> tempName = VariableNames.distributionTempName(
                 disSampleTask.getOutput().getVarDesc().name, id.get().next(), disSampleTask.getOutputType());
 
         forScope.addTreeToScope(initializeVariable(tempName, r.getStateValue(load(indexName)), Tree.NoComment),
@@ -968,7 +967,7 @@ public class ScopeConstructor {
                 // If it is a single boolean value add it to each distribution description, otherwise allocate a global
                 // array for it.
                 if(guardDesc.scopes.isEmpty()) {
-                    VariableDescription<BooleanVariable> varDesc = guardDesc.varDesc;
+                    LocalVariableDescription<BooleanVariable> varDesc = guardDesc.varDesc;
                     addTree((TreeBuilderInfo info) -> info.compilationCtx.addTreeToScope(GlobalScope.scope,
                             initializeVariable(varDesc, constant(false),
                                     "Guard to check that at most one copy of the code is executed for a given set of loop iterations.")));
@@ -1248,7 +1247,7 @@ public class ScopeConstructor {
                         ForTask t = (ForTask) s;
                         IntVariable index = t.getIndex();
                         VariableDescription<IntVariable> indexName = index.getVarDesc();
-                        VariableDescription<IntVariable> newIndexName = VariableNames.indexName(indexName,
+                        LocalVariableDescription<IntVariable> newIndexName = VariableNames.indexName(indexName,
                                 Integer.toString(id.get().next()));
                         d.addTreeToScope(initializeVariable(newIndexName, load(compilationCtx.getSubstitute(index)),
                                 "Copy of index so that its values can be safely substituted"), compilationCtx);
@@ -1301,8 +1300,8 @@ public class ScopeConstructor {
 
         // Allocate guards if required.
         List<Scope> changeableScopes = getChangeableScopes(guardTask, consumerToSampleTraces);
-        VariableDescription<BooleanVariable> guardName = VariableNames.guardName(traceDesc.origin, traceDesc.consumer,
-                guardNo, VariableType.BooleanVariable);
+        LocalVariableDescription<BooleanVariable> guardName = VariableNames.guardName(traceDesc.origin,
+                traceDesc.consumer, guardNo);
         return new GuardDesc(guardName, filterForTasks(changeableScopes));
     }
 
@@ -1507,7 +1506,7 @@ public class ScopeConstructor {
             Direction direction) {
         // TODO change the allocation here to use an allocator that allows guard name to have a type of boolean.
         // TODO Likewise with the loading of global.
-        VariableDescription<ArrayVariable<A>> globalGuardName = (VariableDescription<ArrayVariable<A>>) VariableNames
+        ScratchVariableDescription<ArrayVariable<A>> globalGuardName = (ScratchVariableDescription<ArrayVariable<A>>) VariableNames
                 .globalGuardName(guardDesc.varDesc,
                         VariableType.getType(VariableType.BooleanVariable, guardDesc.scopes.size()));
         // Get the parallel scope, null if this code is not executed in parallel.
@@ -1515,7 +1514,7 @@ public class ScopeConstructor {
         allocateGlobalState(guardDesc.scopes, globalGuardName, parallelScope);
 
         addTree((TreeBuilderInfo info) -> info.compilationCtx.addTreeToScope(GlobalScope.scope, initializeVariable(
-                VariableNames.altTypeName(guardDesc.varDesc, globalGuardName.type),
+                guardDesc.varDesc.alternativeType(globalGuardName.type),
                 loadGlobalField(globalGuardName, parallelScope),
                 "Guard to check that at most one copy of the code is executed for a given random variable instance.")));
 
@@ -1637,7 +1636,7 @@ public class ScopeConstructor {
     // TODO pull these methods out and make them static util methods that can be called by this class and
     // InferenceGenerator base.
     private <A extends Variable<A>> void allocateGlobalState(List<ForTask> scopes,
-            VariableDescription<ArrayVariable<A>> guardName, ParForTask parallelScope) {
+            ScratchVariableDescription<ArrayVariable<A>> guardName, ParForTask parallelScope) {
         Map<ForTask, IntVariable> noStates = new HashMap<>();
         for(ForTask t:scopes) {
             Scope enclosingScope = t.getEnclosingScope();
@@ -1656,8 +1655,8 @@ public class ScopeConstructor {
         compilationCtx.phase = CompilationPhase.ALLOCATION;
         List<IRTreeReturn<IntVariable>> dims = new ArrayList<>();
         for(ForTask t:scopes) {
-            VariableDescription<IntVariable> maxName = VariableNames
-                    .calcVarName("max_" + t.getIndex().getUniqueVarDesc(), VariableType.IntVariable, true);
+            LocalVariableDescription<IntVariable> maxName = VariableNames
+                    .localCalcVarName("max_" + t.getIndex().getUniqueVarDesc(), VariableType.IntVariable, true);
 
             // Set initial value for the array.
             compilationCtx.enterScope(t);
@@ -1686,22 +1685,22 @@ public class ScopeConstructor {
         compilationCtx.popIsSerial();
         compilationCtx.popScopeState();
 
-        createGlobalField(guardName, allocator, parallelScope == null);
+        createScratchClassField(guardName, allocator, parallelScope == null);
     }
 
-    private <A extends Variable<A>> void createGlobalField(VariableDescription<A> fieldName, IRTreeVoid allocator,
+    private <A extends Variable<A>> void createScratchClassField(ScratchVariableDescription<A> fieldName, IRTreeVoid allocator,
             boolean isSerial) {
         switch(compilationCtx.target) {
             case SingleThreadCPU:
-                compilationCtx.addConstructedClassField(fieldName, allocator);
+                compilationCtx.addScratchClassField(fieldName, allocator);
                 break;
             case MultiThreadCPU: {
                 if(isSerial)
-                    compilationCtx.addConstructedClassField(fieldName, allocator);
+                    compilationCtx.addScratchClassField(fieldName, allocator);
                 else {
-                    VariableDescription<ArrayVariable<A>> arrayName = VariableNames.altTypeName(fieldName,
-                            VariableType.arrayType(fieldName.type));
-                    compilationCtx.addConstructedClassField(arrayName, allocator);
+                    ScratchVariableDescription<ArrayVariable<A>> arrayName = fieldName
+                            .alternativeType(VariableType.arrayType(fieldName.type));
+                    compilationCtx.addScratchClassField(arrayName, allocator);
                 }
                 break;
             }
@@ -1720,8 +1719,8 @@ public class ScopeConstructor {
                 if(parallelScope == null) {
                     return load(varDesc);
                 } else {
-                    VariableDescription<ArrayVariable<V>> altName = VariableNames.altTypeName(varDesc,
-                            VariableType.arrayType(varDesc.type));
+                    VariableDescription<ArrayVariable<V>> altName = varDesc
+                            .alternativeType(VariableType.arrayType(varDesc.type));
                     IRTreeReturn<ArrayVariable<V>> array = load(altName);
 
                     // First we have to construct the index name used in the new target, and then we can construct the
@@ -1744,7 +1743,7 @@ public class ScopeConstructor {
         return (ParForTask) sourceScope;
     }
 
-    private <A extends Variable<A>> void globalFieldAllocation(VariableDescription<A> fieldName,
+    private <A extends Variable<A>> void globalFieldAllocation(ScratchVariableDescription<A> fieldName,
             IRTreeReturn<A> localAllocation, boolean isSerial) {
         switch(compilationCtx.target) {
             case SingleThreadCPU:
@@ -1757,15 +1756,15 @@ public class ScopeConstructor {
                 } else {
                     List<IRTreeVoid> subtrees = new ArrayList<>();
 
-                    VariableDescription<ArrayVariable<A>> arrayName = VariableNames.altTypeName(fieldName,
-                            VariableType.arrayType(fieldName.type));
-                    VariableDescription<IntVariable> threadCount = VariableNames.calcVarName("threadCount",
+                    VariableDescription<ArrayVariable<A>> arrayName = fieldName
+                            .alternativeType(VariableType.arrayType(fieldName.type));
+                    LocalVariableDescription<IntVariable> threadCount = VariableNames.localCalcVarName("threadCount",
                             VariableType.IntVariable, true);
                     subtrees.add(initializeVariable(threadCount,
                             functionCallReturn(VariableType.IntVariable, "threadCount"), "Get the thread count."));
                     subtrees.add(store(arrayName, newArray(load(threadCount), (ArrayType<A>) arrayName.type),
                             "Allocate an array to hold a copy per thread"));
-                    VariableDescription<IntVariable> index = VariableNames.calcVarName("index",
+                    LocalVariableDescription<IntVariable> index = VariableNames.localCalcVarName("index",
                             VariableType.IntVariable, true);
                     IRTreeVoid body = arrayPut(load(arrayName), load(index), localAllocation, Tree.NoComment);
                     subtrees.add(forStmt(body, constant(0), load(threadCount), constant(1), index, true,

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/guards/ScopeConstructor.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/guards/ScopeConstructor.java
@@ -107,15 +107,18 @@ public class ScopeConstructor {
 
     public enum Direction {
         FORWARDS,
-        BACKWARDS; }
+        BACKWARDS;
+    }
 
     public enum Guards {
         GUARDS,
-        NO_GUARDS; }
+        NO_GUARDS;
+    }
 
     public enum Values {
         PASS_VALUES,
-        IGNORE_VALUES; }
+        IGNORE_VALUES;
+    }
 
     private static class GuardDesc {
         // Name for the guard that will ensure the body of this code is only executed once. If there is only 1 trace

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/guards/TraceArrayRestrictions.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/traces/guards/TraceArrayRestrictions.java
@@ -39,8 +39,8 @@ import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ForTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.IfElseAssignmentTask;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ReductionInput;
 import org.sandwood.compiler.dataflowGraph.tasks.sandwoodOperators.ReductionReturnTask;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.auxillary.DataflowTaskArgDesc;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.BooleanVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
@@ -1113,7 +1113,7 @@ public class TraceArrayRestrictions {
      */
     private static <A extends Variable<A>> ScopeDescription constructVarSubstitution(Variable<A> v, IRTreeReturn<?> t,
             ScopeDescription target, RestrictionsData data, CompilationContext compilationCtx) {
-        VariableDescription<A> subName = VariableNames.traceTempName(v.getVarDesc().name, data.globalID, data.localID++,
+        LocalVariableDescription<A> subName = VariableNames.traceTempName(v.getVarDesc().name, data.globalID, data.localID++,
                 v.getType());
         IRTreeVoid init = IRTree.initializeVariable(subName, (IRTreeReturn<A>) t, Tree.NoComment);
         target = target.addSubstitution(data.position, v, target.constructVariableInScope(subName));

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/irTree/IRFor.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/irTree/IRFor.java
@@ -8,7 +8,7 @@
 
 package org.sandwood.compiler.trees.irTree;
 
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
 import org.sandwood.compiler.trees.irTree.transformations.TreeTransformation;
 import org.sandwood.compiler.trees.transformationTree.TransTree;
@@ -22,12 +22,12 @@ public class IRFor extends IRTreeVoid {
     public final IRTreeReturn<IntVariable> start;
     public final IRTreeReturn<IntVariable> end;
     public final IRTreeReturn<IntVariable> step;
-    public final VariableDescription<IntVariable> indexDesc;
+    public final LocalVariableDescription<IntVariable> indexDesc;
     public final boolean parallel;
     public final boolean incrementing;
 
     IRFor(IRTreeVoid body, IRTreeReturn<IntVariable> start, IRTreeReturn<IntVariable> end,
-            IRTreeReturn<IntVariable> step, VariableDescription<IntVariable> indexDesc, boolean parallel,
+            IRTreeReturn<IntVariable> step, LocalVariableDescription<IntVariable> indexDesc, boolean parallel,
             boolean incrementing, String comment) {
         super(IRTreeType.FOR, comment);
         this.body = body;

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/irTree/IRProxyTreeSeq.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/irTree/IRProxyTreeSeq.java
@@ -58,8 +58,7 @@ public class IRProxyTreeSeq extends IRTreeVoid {
     }
 
     public static void testTree(IRTree t, IRTree start) {
-        if(t == start)
-            System.out.println("There is a cycle in the IRTree structure");
+        assert t != start;
         // This is the only way to get a cycle, so if there is a cycle it starts here.
         if(t.type == IRTreeType.PROXY_SEQ) {
             List<IRTreeVoid> proxyTrees = ((IRProxyTreeSeq) t).trees;

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/irTree/IRRVFunctionCall.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/irTree/IRRVFunctionCall.java
@@ -129,7 +129,7 @@ public class IRRVFunctionCall extends IRTreeVoid {
         // Add the required RNG.
         if(t == FunctionType.CONJUGATE_SAMPLE || t == FunctionType.SAMPLE) {
             IRTreeReturn<?>[] newArgs = new IRTreeReturn<?>[args.length + 1];
-            newArgs[0] = IRTree.load(VariableNames.rngName(0));
+            newArgs[0] = IRTree.load(VariableNames.rngName());
             System.arraycopy(args, 0, newArgs, 1, args.length);
             args = newArgs;
         }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/irTree/IRRVFunctionCallReturn.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/irTree/IRRVFunctionCallReturn.java
@@ -717,7 +717,7 @@ public class IRRVFunctionCallReturn<X extends Variable<X>> extends IRTreeReturn<
         // Add the required RNG.
         if(t == FunctionType.CONJUGATE_SAMPLE || t == FunctionType.SAMPLE) {
             IRTreeReturn<?>[] newArgs = new IRTreeReturn<?>[args.length + 1];
-            newArgs[0] = IRTree.load(VariableNames.rngName(0));
+            newArgs[0] = IRTree.load(VariableNames.rngName());
             System.arraycopy(args, 0, newArgs, 1, args.length);
             args = newArgs;
         }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/irTree/IRSandwoodClassGenerated.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/irTree/IRSandwoodClassGenerated.java
@@ -16,6 +16,7 @@ import java.util.PriorityQueue;
 import java.util.Set;
 
 import org.sandwood.compiler.compilation.CompilationContext.FieldDesc;
+import org.sandwood.compiler.dataflowGraph.variables.ScratchVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableName;
@@ -42,6 +43,7 @@ public class IRSandwoodClassGenerated {
     private final String modelCode;
     // Variable field name |-> Field Descriptor
     private final Map<VariableName, FieldDesc<?>> classFields;
+    private final Set<ScratchVariableDescription<?>> scratchFields;
     private final Map<FunctionName, IRFunction<?>> functions;
     private final List<IRFunction<?>> gettersAndSetters = new ArrayList<>();
 
@@ -51,7 +53,7 @@ public class IRSandwoodClassGenerated {
             .logProbabilityName(VariableNames.internalName("evidence"));
 
     public IRSandwoodClassGenerated(ClassName name, PackageName packageName, ClassName extendedClass,
-            ClassName[] interfaces, Map<VariableName, FieldDesc<?>> classFields,
+            ClassName[] interfaces, Map<VariableName, FieldDesc<?>> classFields, Set<ScratchVariableDescription<?>> scratchFields,
             Map<FunctionName, IRFunction<?>> functions, String modelCode) {
         this.name = name;
         this.packageName = packageName;
@@ -59,6 +61,7 @@ public class IRSandwoodClassGenerated {
         this.interfaces = interfaces;
         this.modelCode = modelCode;
         this.classFields = classFields;
+        this.scratchFields = scratchFields;
         this.functions = functions;
 
         // Add the getter and setter methods
@@ -67,9 +70,9 @@ public class IRSandwoodClassGenerated {
 
     private <A extends Variable<A>> IRTreeVoid declareField(FieldDesc<A> f) {
         if(f.initialValue == null)
-            return IRTree.initializeUnsetVariable(Visibility.PRIVATE, f.varDesc, Tree.NoComment);
+            return IRTree.initializeUnsetField(Visibility.PRIVATE, f.varDesc, Tree.NoComment);
         else
-            return IRTree.initializeVariable(Visibility.PRIVATE, f.varDesc, f.initialValue, Tree.NoComment);
+            return IRTree.initializeField(Visibility.PRIVATE, f.varDesc, f.initialValue, Tree.NoComment);
     }
 
     private void addGettersAndSetters() {
@@ -97,7 +100,7 @@ public class IRSandwoodClassGenerated {
 
         if(f.fieldType.setter) {
             ArgDesc<?>[] args = new ArgDesc[2];
-            VariableDescription<A> valueName = VariableNames.calcVarName("value", f.varDesc.type, false);
+            VariableDescription<A> valueName = VariableNames.localCalcVarName("value", f.varDesc.type, false);
             args[0] = new ArgDesc<>(valueName);
             VariableDescription<BooleanVariable> allocatedName = VariableNames.allocatedFlag();
             args[1] = new ArgDesc<>(allocatedName);
@@ -148,6 +151,9 @@ public class IRSandwoodClassGenerated {
             FieldDesc<?> f = classFields.get(fieldName);
             fieldTrees.put(fieldName, declareField(f).toTransformationTree());
         }
+
+        for(ScratchVariableDescription<?> varDesc:scratchFields)
+            fieldTrees.put(varDesc.name, IRTree.initializeUnsetField(Visibility.PRIVATE, varDesc, null).toTransformationTree());
 
         return new TransSandwoodClassGenerated(name, packageName, extendedClass, interfaces, modelCode, transFunctions,
                 fieldTrees, transGettersAndSetters);

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/irTree/IRTree.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/irTree/IRTree.java
@@ -18,6 +18,9 @@ import java.util.Set;
 import org.sandwood.common.execution.ExecutionType;
 import org.sandwood.compiler.compilation.ExternalFunction;
 import org.sandwood.compiler.compilation.FunctionType;
+import org.sandwood.compiler.dataflowGraph.variables.ClassVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.GlobalVariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
@@ -256,13 +259,13 @@ public abstract class IRTree extends Tree<IRTree> {
     }
 
     public static IRFor forStmt(IRTreeVoid body, IRTreeReturn<IntVariable> start, IRTreeReturn<IntVariable> end,
-            IRTreeReturn<IntVariable> step, VariableDescription<IntVariable> indexDesc, boolean incrementing,
+            IRTreeReturn<IntVariable> step, LocalVariableDescription<IntVariable> indexDesc, boolean incrementing,
             String comment) {
         return new IRFor(body, start, end, step, indexDesc, false, incrementing, comment);
     }
 
     public static IRFor parallelForStmt(IRTreeVoid body, IRTreeReturn<IntVariable> start, IRTreeReturn<IntVariable> end,
-            IRTreeReturn<IntVariable> step, VariableDescription<IntVariable> indexDesc, boolean incrementing,
+            IRTreeReturn<IntVariable> step, LocalVariableDescription<IntVariable> indexDesc, boolean incrementing,
             String comment) {
         return new IRFor(body, start, end, step, indexDesc, true, incrementing, comment);
     }
@@ -316,31 +319,40 @@ public abstract class IRTree extends Tree<IRTree> {
     }
 
     public static <X extends Variable<X>> IRTreeVoid initializeVariable(Visibility visibility,
-            VariableDescription<X> varDesc, IRTreeReturn<X> value, String comment) {
-        if(value.type == IRTreeType.LOAD && ((IRLoad<X>) value).varDesc.equals(varDesc))
-            return nop();
-        else
+            LocalVariableDescription<X> varDesc, IRTreeReturn<X> value, String comment) {
             return new IRInitialize<>(visibility, varDesc, value, comment);
     }
 
     public static <X extends Variable<X>> IRTreeVoid initializeVariable(Variable<X> var, IRTreeReturn<X> value,
             String comment) {
-        return initializeVariable(var.getUniqueVarDesc(), value, comment);
+        return initializeVariable((LocalVariableDescription<X>)var.getUniqueVarDesc(), value, comment);
     }
 
-    public static <X extends Variable<X>> IRTreeVoid initializeVariable(VariableDescription<X> varDesc,
+    public static <X extends Variable<X>> IRTreeVoid initializeVariable(LocalVariableDescription<X> varDesc,
             IRTreeReturn<X> value, String comment) {
         return initializeVariable(Visibility.DEFAULT, varDesc, value, comment);
     }
 
     public static <X extends Variable<X>> IRInitializeUnset<X> initializeUnsetVariable(Visibility visibility,
-            VariableDescription<X> varDesc, String comment) {
+            LocalVariableDescription<X> varDesc, String comment) {
         return new IRInitializeUnset<>(visibility, varDesc, comment);
     }
 
-    public static <X extends Variable<X>> IRInitializeUnset<X> initializeUnsetVariable(VariableDescription<X> varDesc,
+    public static <X extends Variable<X>> IRInitializeUnset<X> initializeUnsetVariable(LocalVariableDescription<X> varDesc,
             String comment) {
         return initializeUnsetVariable(Visibility.DEFAULT, varDesc, comment);
+    }
+    
+
+
+    public static <X extends Variable<X>> IRInitialize<X> initializeField(Visibility visibility, ClassVariableDescription<X> varDesc,
+            IRTreeReturn<X> value, String comment) {
+        return new IRInitialize<>(visibility, varDesc, value, comment);
+    }
+
+    public static <X extends Variable<X>> IRInitializeUnset<X> initializeUnsetField(Visibility visibility, ClassVariableDescription<X> varDesc,
+            String comment) {
+        return new IRInitializeUnset<>(visibility, varDesc, comment);
     }
 
     public static <X extends Variable<X>> IRLoad<X> load(Variable<X> v) {

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/outputTree/OutputParFor.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/outputTree/OutputParFor.java
@@ -11,19 +11,20 @@ package org.sandwood.compiler.trees.outputTree;
 import java.util.Map;
 import java.util.Set;
 
+import org.sandwood.compiler.dataflowGraph.variables.rng.RandomNumberGenerator;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
 import org.sandwood.compiler.names.VariableNames;
 
 public class OutputParFor extends OutputTree {
 
-    private final int parDepth;
+    private final OutputTreeReturn<RandomNumberGenerator> rng;
     private final OutputTreeReturn<IntVariable> start, end, step;
     private final OutputTree body;
 
-    public OutputParFor(int parDepth, OutputTreeReturn<IntVariable> start, OutputTreeReturn<IntVariable> end,
+    public OutputParFor(OutputTreeReturn<RandomNumberGenerator> rng, OutputTreeReturn<IntVariable> start, OutputTreeReturn<IntVariable> end,
             OutputTreeReturn<IntVariable> step, OutputTree body, String comment) {
         super(OutputTreeType.FORK_JOIN_FOR, true, comment);
-        this.parDepth = parDepth;
+        this.rng = rng;
         this.start = start;
         this.end = end;
         this.step = step;
@@ -32,7 +33,9 @@ public class OutputParFor extends OutputTree {
 
     @Override
     protected void toJavaInternal(StringBuilder sb, int indent, Set<String> requiredImports) {
-        sb.append("parallelFor(" + VariableNames.rngName(parDepth) + ", ");
+        sb.append("parallelFor(");
+        rng.toJava(sb, indent, requiredImports);
+        sb.append(", ");
         start.toJava(sb, indent, requiredImports);
         sb.append(", ");
         end.toJava(sb, indent, requiredImports);
@@ -61,7 +64,7 @@ public class OutputParFor extends OutputTree {
         OutputTreeReturn<IntVariable> end2 = end.copy(results);
         OutputTreeReturn<IntVariable> step2 = step.copy(results);
         OutputTree body2 = body.copy(results);
-        OutputParFor copy = new OutputParFor(parDepth, start2, end2, step2, body2, comment);
+        OutputParFor copy = new OutputParFor(rng, start2, end2, step2, body2, comment);
         results.put(this, copy);
         return copy;
     }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/outputTree/OutputTree.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/outputTree/OutputTree.java
@@ -22,6 +22,7 @@ import org.sandwood.compiler.dataflowGraph.variables.VariableType.ArrayType;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.RandomVariableType;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType.Type;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
+import org.sandwood.compiler.dataflowGraph.variables.rng.RandomNumberGenerator;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.BooleanVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.DoubleVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
@@ -367,9 +368,10 @@ public abstract class OutputTree extends Tree<OutputTree> {
         return new OutputParForLambda(parDepth, startDesc, endDesc, threadID, outputTreeInternal);
     }
 
-    public static OutputTree ForkJoinFor(int parDepth, OutputTreeReturn<IntVariable> start,
-            OutputTreeReturn<IntVariable> end, OutputTreeReturn<IntVariable> step, OutputTree body, String comment) {
-        return new OutputParFor(parDepth, start, end, step, body, comment);
+    public static OutputTree ForkJoinFor(OutputTreeReturn<RandomNumberGenerator> rng,
+            OutputTreeReturn<IntVariable> start, OutputTreeReturn<IntVariable> end, OutputTreeReturn<IntVariable> step,
+            OutputTree body, String comment) {
+        return new OutputParFor(rng, start, end, step, body, comment);
     }
 
     public static <A extends Variable<A>> OutputConditionalAssignment<A> conditionalAssignment(

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/transformationTree/TransParFor.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/transformationTree/TransParFor.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.rng.RandomNumberGenerator;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
 import org.sandwood.compiler.trees.outputTree.OutputTree;
 import org.sandwood.compiler.trees.transformationTree.transformers.Transformer;
@@ -19,26 +20,29 @@ import org.sandwood.compiler.trees.transformationTree.visitors.TreeVisitor;
 
 public class TransParFor extends TransTreeVoid {
 
-    private final int parDepth;
+    private final TransTreeReturn<RandomNumberGenerator> rng;
     private final TransTreeReturn<IntVariable> start, end, step;
     private final TransParForLambda body;
 
-    private TransParFor(int parDepth, TransTreeReturn<IntVariable> start, TransTreeReturn<IntVariable> end,
-            TransTreeReturn<IntVariable> step, TransParForLambda body, String comment) {
-        super(TransTreeType.FORK_JOIN_FOR, start.size() + step.size() + end.size() + body.size() + 1, comment);
-        this.parDepth = parDepth;
+    private TransParFor(TransTreeReturn<RandomNumberGenerator> rng, TransTreeReturn<IntVariable> start,
+            TransTreeReturn<IntVariable> end, TransTreeReturn<IntVariable> step, TransParForLambda body,
+            String comment) {
+        super(TransTreeType.FORK_JOIN_FOR, rng.size() + start.size() + step.size() + end.size() + body.size() + 1,
+                comment);
+        this.rng = rng;
         this.start = start;
         this.end = end;
         this.step = step;
         this.body = body;
     }
 
-    public static TransTreeVoid getParFor(int parDepth, TransTreeReturn<IntVariable> start,
-            TransTreeReturn<IntVariable> end, TransTreeReturn<IntVariable> step, TransTreeVoid body, String comment) {
+    public static TransTreeVoid getParFor(TransTreeReturn<RandomNumberGenerator> rng,
+            TransTreeReturn<IntVariable> start, TransTreeReturn<IntVariable> end, TransTreeReturn<IntVariable> step,
+            TransTreeVoid body, String comment) {
         if(body.type == TransTreeType.NOP)
             return body;
         else
-            return new TransParFor(parDepth, start, end, step, (TransParForLambda) body, comment);
+            return new TransParFor(rng, start, end, step, (TransParForLambda) body, comment);
     }
 
     @Override
@@ -62,12 +66,13 @@ public class TransParFor extends TransTreeVoid {
 
     @Override
     public TransTreeVoid applyTransformationInternal(Transformer t) {
-        return getParFor(parDepth, t.transform(start), t.transform(end), t.transform(step), t.transform(body), comment);
+        return getParFor(t.transform(rng), t.transform(start), t.transform(end), t.transform(step), t.transform(body),
+                comment);
     }
 
     @Override
     public OutputTree toOutputTreeInternal() {
-        return OutputTree.ForkJoinFor(parDepth, start.toOutputTreeReturnInternal(),
+        return OutputTree.ForkJoinFor(rng.toOutputTreeReturnInternal(), start.toOutputTreeReturnInternal(),
                 end.collapseConstants().toOutputTreeReturnInternal(), step.toOutputTreeReturnInternal(),
                 body.toOutputTreeInternal(), comment);
     }

--- a/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/transformationTree/transformers/ParFor.java
+++ b/Sandwood/compiler/src/main/java/org/sandwood/compiler/trees/transformationTree/transformers/ParFor.java
@@ -26,6 +26,7 @@ import java.util.Stack;
 
 import org.sandwood.compiler.dataflowGraph.variables.Variable;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.rng.RandomNumberGenerator;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
 import org.sandwood.compiler.exceptions.CompilerException;
 import org.sandwood.compiler.names.VariableNames;
@@ -174,7 +175,9 @@ public class ParFor extends Transformer {
                     TransTreeVoid l = TransParForLambda.getParForLambda(depth + 1, innerStartName, innerEndName,
                             VariableNames.threadIdName(t.indexDesc.name), innerFor);
 
-                    TransTreeVoid f = TransParFor.getParFor(depth, start, end, step, l,
+                    TransTreeVoid f = TransParFor.getParFor(
+                            depth == 0 ? load(VariableNames.rngName()) : load(VariableNames.rngName(depth)), start, end,
+                            step, l,
                             " Outer loop for dispatching multiple batches of iterations to execute in parallel");
 
                     stmts.add(f);
@@ -220,8 +223,11 @@ public class ParFor extends Transformer {
         switch(tree.type) {
             case LOAD: {
                 TransLoad<X> l = (TransLoad<X>) tree;
-                if(l.varDesc.equals(VariableNames.rngName(0))) {
-                    return (TransTreeReturn<X>) load(VariableNames.rngName(depth));
+                VariableDescription<RandomNumberGenerator> rngName = VariableNames.rngName();
+                if(l.varDesc.equals(rngName)) {
+                    if(depth != 0)
+                        rngName = VariableNames.rngName(depth);
+                    return (TransTreeReturn<X>) load(rngName);
                 } else
                     return load(getSubstitution(l.varDesc));
             }

--- a/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/transformations/ApplyConstraintsTest.java
+++ b/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/transformations/ApplyConstraintsTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.BooleanVariable;
@@ -48,21 +48,21 @@ class ApplyConstraintsTest {
     private final static String[] before;
     private final static String[] after;
 
-    private final static VariableDescription<IntVariable> indexName = new VariableDescription<>("index",
+    private final static org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription<IntVariable> indexName = new LocalVariableDescription<>("index",
             VariableType.IntVariable, true);
     private final static TransTreeReturn<IntVariable> index = load(indexName);
     private final static TransTreeReturn<IntVariable> start = load(
-            new VariableDescription<>("start", VariableType.IntVariable, true));
+            new LocalVariableDescription<>("start", VariableType.IntVariable, true));
     private final static TransTreeReturn<IntVariable> end = load(
-            new VariableDescription<>("end", VariableType.IntVariable, true));
+            new LocalVariableDescription<>("end", VariableType.IntVariable, true));
     private final static TransTreeReturn<IntVariable> x = load(
-            new VariableDescription<>("x", VariableType.IntVariable, true));
+            new LocalVariableDescription<>("x", VariableType.IntVariable, true));
     private final static TransTreeReturn<ArrayVariable<IntVariable>> a = load(
-            new VariableDescription<>("a", VariableType.arrayType(VariableType.IntVariable), true));
+            new LocalVariableDescription<>("a", VariableType.arrayType(VariableType.IntVariable), true));
     private final static TransTreeReturn<ArrayVariable<IntVariable>> b = load(
-            new VariableDescription<>("b", VariableType.arrayType(VariableType.IntVariable), true));
+            new LocalVariableDescription<>("b", VariableType.arrayType(VariableType.IntVariable), true));
     private final static TransTreeReturn<ArrayVariable<IntVariable>> c = load(
-            new VariableDescription<>("c", VariableType.arrayType(VariableType.IntVariable), true));
+            new LocalVariableDescription<>("c", VariableType.arrayType(VariableType.IntVariable), true));
 
     private static final Set<Tag> tags = Collections.emptySet();
 

--- a/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/transformations/ConstantsTest.java
+++ b/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/transformations/ConstantsTest.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.trees.ArgDesc;
 import org.sandwood.compiler.trees.transformationTree.TransTreeReturn;
@@ -58,11 +58,11 @@ class ConstantsTest {
         beforeList.add("(0.0 + 1.5)");
         afterList.add("1.5");
 
-        treeList.add(addDD(constant(0.0), load(new VariableDescription<>("i", VariableType.DoubleVariable, false))));
+        treeList.add(addDD(constant(0.0), load(new LocalVariableDescription<>("i", VariableType.DoubleVariable, false))));
         beforeList.add("(0.0 + i)");
         afterList.add("i");
 
-        treeList.add(addDD(load(new VariableDescription<>("i", VariableType.DoubleVariable, false)), constant(0.0)));
+        treeList.add(addDD(load(new LocalVariableDescription<>("i", VariableType.DoubleVariable, false)), constant(0.0)));
         beforeList.add("(i + 0.0)");
         afterList.add("i");
 
@@ -87,12 +87,12 @@ class ConstantsTest {
         afterList.add("1.5");
 
         treeList.add(
-                multiplyDD(constant(1.0), load(new VariableDescription<>("i", VariableType.DoubleVariable, false))));
+                multiplyDD(constant(1.0), load(new LocalVariableDescription<>("i", VariableType.DoubleVariable, false))));
         beforeList.add("(1.0 * i)");
         afterList.add("i");
 
         treeList.add(
-                multiplyDD(load(new VariableDescription<>("i", VariableType.DoubleVariable, false)), constant(1.0)));
+                multiplyDD(load(new LocalVariableDescription<>("i", VariableType.DoubleVariable, false)), constant(1.0)));
         beforeList.add("(i * 1.0)");
         afterList.add("i");
 
@@ -117,12 +117,12 @@ class ConstantsTest {
         afterList.add("-1.5");
 
         treeList.add(
-                subtractDD(constant(0.0), load(new VariableDescription<>("i", VariableType.DoubleVariable, false))));
+                subtractDD(constant(0.0), load(new LocalVariableDescription<>("i", VariableType.DoubleVariable, false))));
         beforeList.add("(0.0 - i)");
         afterList.add("(-i)");
 
         treeList.add(
-                subtractDD(load(new VariableDescription<>("i", VariableType.DoubleVariable, false)), constant(0.0)));
+                subtractDD(load(new LocalVariableDescription<>("i", VariableType.DoubleVariable, false)), constant(0.0)));
         beforeList.add("(i - 0.0)");
         afterList.add("i");
 
@@ -146,11 +146,11 @@ class ConstantsTest {
         beforeList.add("(1.0 / 2.0)");
         afterList.add("0.5");
 
-        treeList.add(divideDD(constant(1.0), load(new VariableDescription<>("i", VariableType.DoubleVariable, false))));
+        treeList.add(divideDD(constant(1.0), load(new LocalVariableDescription<>("i", VariableType.DoubleVariable, false))));
         beforeList.add("(1.0 / i)");
         afterList.add("(1.0 / i)");
 
-        treeList.add(divideDD(load(new VariableDescription<>("i", VariableType.DoubleVariable, false)), constant(1.0)));
+        treeList.add(divideDD(load(new LocalVariableDescription<>("i", VariableType.DoubleVariable, false)), constant(1.0)));
         beforeList.add("(i / 1.0)");
         afterList.add("i");
 
@@ -186,19 +186,19 @@ class ConstantsTest {
         beforeList.add("false");
         afterList.add("false");
 
-        treeList.add(and(constant(true), load(new VariableDescription<>("i", VariableType.BooleanVariable, false))));
+        treeList.add(and(constant(true), load(new LocalVariableDescription<>("i", VariableType.BooleanVariable, false))));
         beforeList.add("i");
         afterList.add("i");
 
-        treeList.add(and(load(new VariableDescription<>("i", VariableType.BooleanVariable, false)), constant(true)));
+        treeList.add(and(load(new LocalVariableDescription<>("i", VariableType.BooleanVariable, false)), constant(true)));
         beforeList.add("i");
         afterList.add("i");
 
-        treeList.add(lessThan(load(new VariableDescription<>("i", VariableType.IntVariable, false)), constant(2)));
+        treeList.add(lessThan(load(new LocalVariableDescription<>("i", VariableType.IntVariable, false)), constant(2)));
         beforeList.add("(i < 2)");
         afterList.add("(i < 2)");
 
-        treeList.add(lessThan(constant(2), load(new VariableDescription<>("i", VariableType.IntVariable, false))));
+        treeList.add(lessThan(constant(2), load(new LocalVariableDescription<>("i", VariableType.IntVariable, false))));
         beforeList.add("(2 < i)");
         afterList.add("(2 < i)");
 
@@ -210,11 +210,11 @@ class ConstantsTest {
         beforeList.add("(2 < 1)");
         afterList.add("false");
 
-        treeList.add(lessThanEqual(load(new VariableDescription<>("i", VariableType.IntVariable, false)), constant(2)));
+        treeList.add(lessThanEqual(load(new LocalVariableDescription<>("i", VariableType.IntVariable, false)), constant(2)));
         beforeList.add("(i <= 2)");
         afterList.add("(i <= 2)");
 
-        treeList.add(lessThanEqual(constant(2), load(new VariableDescription<>("i", VariableType.IntVariable, false))));
+        treeList.add(lessThanEqual(constant(2), load(new LocalVariableDescription<>("i", VariableType.IntVariable, false))));
         beforeList.add("(2 <= i)");
         afterList.add("(2 <= i)");
 
@@ -226,11 +226,11 @@ class ConstantsTest {
         beforeList.add("(2 <= 1)");
         afterList.add("false");
 
-        treeList.add(eq(load(new VariableDescription<>("i", VariableType.IntVariable, false)), constant(2)));
+        treeList.add(eq(load(new LocalVariableDescription<>("i", VariableType.IntVariable, false)), constant(2)));
         beforeList.add("(i == 2)");
         afterList.add("(i == 2)");
 
-        treeList.add(eq(constant(2), load(new VariableDescription<>("i", VariableType.IntVariable, false))));
+        treeList.add(eq(constant(2), load(new LocalVariableDescription<>("i", VariableType.IntVariable, false))));
         beforeList.add("(2 == i)");
         afterList.add("(2 == i)");
 
@@ -242,15 +242,15 @@ class ConstantsTest {
         beforeList.add("(2 == 1)");
         afterList.add("false");
 
-        treeList.add(remainderII(load(new VariableDescription<>("i", VariableType.IntVariable, false)), constant(2)));
+        treeList.add(remainderII(load(new LocalVariableDescription<>("i", VariableType.IntVariable, false)), constant(2)));
         beforeList.add("(i % 2)");
         afterList.add("(i % 2)");
 
-        treeList.add(remainderII(load(new VariableDescription<>("i", VariableType.IntVariable, false)), constant(1)));
+        treeList.add(remainderII(load(new LocalVariableDescription<>("i", VariableType.IntVariable, false)), constant(1)));
         beforeList.add("(i % 1)");
         afterList.add("0");
 
-        treeList.add(remainderII(constant(1), load(new VariableDescription<>("i", VariableType.IntVariable, false))));
+        treeList.add(remainderII(constant(1), load(new LocalVariableDescription<>("i", VariableType.IntVariable, false))));
         beforeList.add("(1 % i)");
         afterList.add("(1 % i)");
 

--- a/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/transformations/ConstraintMovementTest.java
+++ b/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/transformations/ConstraintMovementTest.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.BooleanVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
@@ -49,18 +49,18 @@ class ConstraintMovementTest {
     static {
         int test = 0;
 
-        VariableDescription<IntVariable> const1 = new VariableDescription<>("constant1", VariableType.IntVariable,
+        LocalVariableDescription<IntVariable> const1 = new LocalVariableDescription<>("constant1", VariableType.IntVariable,
                 false);
-        VariableDescription<IntVariable> const2 = new VariableDescription<>("constant2", VariableType.IntVariable,
+        LocalVariableDescription<IntVariable> const2 = new LocalVariableDescription<>("constant2", VariableType.IntVariable,
                 false);
-        VariableDescription<IntVariable> const3 = new VariableDescription<>("constant3", VariableType.IntVariable,
+        LocalVariableDescription<IntVariable> const3 = new LocalVariableDescription<>("constant3", VariableType.IntVariable,
                 false);
-        VariableDescription<IntVariable> i = new VariableDescription<>("i", VariableType.IntVariable, false);
-        VariableDescription<IntVariable> j = new VariableDescription<>("j", VariableType.IntVariable, false);
-        VariableDescription<IntVariable> k = new VariableDescription<>("k", VariableType.IntVariable, false);
-        VariableDescription<IntVariable> l = new VariableDescription<>("l", VariableType.IntVariable, false);
-        VariableDescription<IntVariable> m = new VariableDescription<>("m", VariableType.IntVariable, false);
-        VariableDescription<IntVariable> x = new VariableDescription<>("x", VariableType.IntVariable, false);
+        LocalVariableDescription<IntVariable> i = new LocalVariableDescription<>("i", VariableType.IntVariable, false);
+        LocalVariableDescription<IntVariable> j = new LocalVariableDescription<>("j", VariableType.IntVariable, false);
+        LocalVariableDescription<IntVariable> k = new LocalVariableDescription<>("k", VariableType.IntVariable, false);
+        LocalVariableDescription<IntVariable> l = new LocalVariableDescription<>("l", VariableType.IntVariable, false);
+        LocalVariableDescription<IntVariable> m = new LocalVariableDescription<>("m", VariableType.IntVariable, false);
+        LocalVariableDescription<IntVariable> x = new LocalVariableDescription<>("x", VariableType.IntVariable, false);
 
         {
             List<TransTreeReturn<BooleanVariable>> constraints = new ArrayList<>();

--- a/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/transformations/EmptyForLoopTest.java
+++ b/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/transformations/EmptyForLoopTest.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
 import org.sandwood.compiler.trees.ArgDesc;
@@ -42,12 +42,12 @@ class EmptyForLoopTest {
     private static final String[] after = new String[noTests];
 
     static {
-        VariableDescription<IntVariable> i = new VariableDescription<>("i", VariableType.IntVariable, false);
-        VariableDescription<IntVariable> j = new VariableDescription<>("j", VariableType.IntVariable, false);
-        VariableDescription<IntVariable> k = new VariableDescription<>("k", VariableType.IntVariable, false);
-        VariableDescription<IntVariable> l = new VariableDescription<>("l", VariableType.IntVariable, false);
-        VariableDescription<IntVariable> m = new VariableDescription<>("m", VariableType.IntVariable, false);
-        VariableDescription<IntVariable> x = new VariableDescription<>("x", VariableType.IntVariable, false);
+        LocalVariableDescription<IntVariable> i = new LocalVariableDescription<>("i", VariableType.IntVariable, false);
+        LocalVariableDescription<IntVariable> j = new LocalVariableDescription<>("j", VariableType.IntVariable, false);
+        LocalVariableDescription<IntVariable> k = new LocalVariableDescription<>("k", VariableType.IntVariable, false);
+        LocalVariableDescription<IntVariable> l = new LocalVariableDescription<>("l", VariableType.IntVariable, false);
+        LocalVariableDescription<IntVariable> m = new LocalVariableDescription<>("m", VariableType.IntVariable, false);
+        LocalVariableDescription<IntVariable> x = new LocalVariableDescription<>("x", VariableType.IntVariable, false);
 
         int test = 0;
         trees[test] = forStmt(forStmt(forStmt(

--- a/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/transformations/KnownValuesTest.java
+++ b/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/transformations/KnownValuesTest.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.IntVariable;
@@ -48,19 +48,19 @@ class KnownValuesTest {
     private final static String[] before;
     private final static String[] after;
 
-    private final static VariableDescription<IntVariable> indexName = new VariableDescription<>("index",
+    private final static LocalVariableDescription<IntVariable> indexName = new LocalVariableDescription<>("index",
             VariableType.IntVariable, true);
     private final static TransTreeReturn<IntVariable> index = load(indexName);
     private final static TransTreeReturn<IntVariable> start = load(
-            new VariableDescription<>("start", VariableType.IntVariable, true));
+            new LocalVariableDescription<>("start", VariableType.IntVariable, true));
     private final static TransTreeReturn<IntVariable> end = load(
-            new VariableDescription<>("end", VariableType.IntVariable, true));
+            new LocalVariableDescription<>("end", VariableType.IntVariable, true));
     private final static TransTreeReturn<ArrayVariable<IntVariable>> a = load(
-            new VariableDescription<>("a", VariableType.arrayType(VariableType.IntVariable), true));
+            new LocalVariableDescription<>("a", VariableType.arrayType(VariableType.IntVariable), true));
     private final static TransTreeReturn<ArrayVariable<IntVariable>> b = load(
-            new VariableDescription<>("b", VariableType.arrayType(VariableType.IntVariable), true));
+            new LocalVariableDescription<>("b", VariableType.arrayType(VariableType.IntVariable), true));
     private final static TransTreeReturn<ArrayVariable<IntVariable>> c = load(
-            new VariableDescription<>("c", VariableType.arrayType(VariableType.IntVariable), true));
+            new LocalVariableDescription<>("c", VariableType.arrayType(VariableType.IntVariable), true));
 
     private static final Set<Tag> tags = Collections.emptySet();
 

--- a/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/transformations/RemoveScopesTest.java
+++ b/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/transformations/RemoveScopesTest.java
@@ -82,10 +82,10 @@ class RemoveScopesTest {
         resultList.add(body("a", "b", "c"));
 
         treeList.add(forStmt(treeScope(body("a", "b", "c"), Tree.NoComment), constant(0), constant(100), constant(1),
-                VariableNames.variableName("index", 0, VariableType.IntVariable, false), false, true, Tree.NoComment));
+                VariableNames.localVariableName("index", 0, VariableType.IntVariable, false), false, true, Tree.NoComment));
 
         resultList.add(forStmt(body("a", "b", "c"), constant(0), constant(100), constant(1),
-                VariableNames.variableName("index", 0, VariableType.IntVariable, false), false, true, Tree.NoComment));
+                VariableNames.localVariableName("index", 0, VariableType.IntVariable, false), false, true, Tree.NoComment));
 
         treeList.add(ifElse(constant(true), treeScope(body("a", "b", "c"), Tree.NoComment), Tree.NoComment,
                 Collections.emptySet()));
@@ -112,11 +112,11 @@ class RemoveScopesTest {
     }
 
     private static TransTreeVoid body(String name1, String name2, String name3) {
-        VariableDescription<DoubleVariable> vName1 = VariableNames.variableName(name1, 0, VariableType.DoubleVariable,
+        VariableDescription<DoubleVariable> vName1 = VariableNames.localVariableName(name1, 0, VariableType.DoubleVariable,
                 false);
-        VariableDescription<DoubleVariable> vName2 = VariableNames.variableName(name2, 0, VariableType.DoubleVariable,
+        VariableDescription<DoubleVariable> vName2 = VariableNames.localVariableName(name2, 0, VariableType.DoubleVariable,
                 false);
-        VariableDescription<DoubleVariable> vName3 = VariableNames.variableName(name3, 0, VariableType.DoubleVariable,
+        VariableDescription<DoubleVariable> vName3 = VariableNames.localVariableName(name3, 0, VariableType.DoubleVariable,
                 false);
         return sequential(initializeVariable(vName1, constant(1.0), Tree.NoComment),
                 initializeVariable(vName2, constant(1.5), Tree.NoComment),

--- a/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/visitors/ReadWrite.java
+++ b/Sandwood/compiler/src/test/java/org/sandwood/compiler/tests/visitors/ReadWrite.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.sandwood.compiler.dataflowGraph.variables.VariableDescription;
+import org.sandwood.compiler.dataflowGraph.variables.LocalVariableDescription;
 import org.sandwood.compiler.dataflowGraph.variables.VariableType;
 import org.sandwood.compiler.dataflowGraph.variables.arrayVariable.ArrayVariable;
 import org.sandwood.compiler.dataflowGraph.variables.scalarVariables.BooleanVariable;
@@ -44,32 +45,32 @@ import org.sandwood.compiler.trees.transformationTree.visitors.variableTracking.
 import org.sandwood.compiler.trees.transformationTree.visitors.variableTracking.VariableTracking;
 
 public class ReadWrite {
-    private static final VariableDescription<IntVariable> a = new VariableDescription<>("a", VariableType.IntVariable,
+    private static final LocalVariableDescription<IntVariable> a = new LocalVariableDescription<>("a", VariableType.IntVariable,
             true);
-    private static final VariableDescription<IntVariable> b = new VariableDescription<>("b", VariableType.IntVariable,
+    private static final LocalVariableDescription<IntVariable> b = new LocalVariableDescription<>("b", VariableType.IntVariable,
             true);
-    private static final VariableDescription<IntVariable> c = new VariableDescription<>("c", VariableType.IntVariable,
+    private static final LocalVariableDescription<IntVariable> c = new LocalVariableDescription<>("c", VariableType.IntVariable,
             true);
-    private static final VariableDescription<IntVariable> d = new VariableDescription<>("d", VariableType.IntVariable,
+    private static final LocalVariableDescription<IntVariable> d = new LocalVariableDescription<>("d", VariableType.IntVariable,
             true);
-    private static final VariableDescription<IntVariable> e = new VariableDescription<>("e", VariableType.IntVariable,
+    private static final LocalVariableDescription<IntVariable> e = new LocalVariableDescription<>("e", VariableType.IntVariable,
             true);
 
-    private static final VariableDescription<ArrayVariable<IntVariable>> f = new VariableDescription<>("f",
+    private static final LocalVariableDescription<ArrayVariable<IntVariable>> f = new LocalVariableDescription<>("f",
             VariableType.arrayType(VariableType.IntVariable), true);
-    private static final VariableDescription<ArrayVariable<IntVariable>> g = new VariableDescription<>("g",
+    private static final LocalVariableDescription<ArrayVariable<IntVariable>> g = new LocalVariableDescription<>("g",
             VariableType.arrayType(VariableType.IntVariable), true);
-    private static final VariableDescription<ArrayVariable<IntVariable>> h = new VariableDescription<>("h",
+    private static final LocalVariableDescription<ArrayVariable<IntVariable>> h = new LocalVariableDescription<>("h",
             VariableType.arrayType(VariableType.IntVariable), true);
 
-    private static final VariableDescription<ArrayVariable<ArrayVariable<IntVariable>>> i = new VariableDescription<>(
+    private static final LocalVariableDescription<ArrayVariable<ArrayVariable<IntVariable>>> i = new LocalVariableDescription<>(
             "i", VariableType.arrayType(VariableType.arrayType(VariableType.IntVariable)), true);
-    private static final VariableDescription<ArrayVariable<ArrayVariable<IntVariable>>> j = new VariableDescription<>(
+    private static final LocalVariableDescription<ArrayVariable<ArrayVariable<IntVariable>>> j = new LocalVariableDescription<>(
             "j", VariableType.arrayType(VariableType.arrayType(VariableType.IntVariable)), true);
-    private static final VariableDescription<ArrayVariable<ArrayVariable<IntVariable>>> k = new VariableDescription<>(
+    private static final LocalVariableDescription<ArrayVariable<ArrayVariable<IntVariable>>> k = new LocalVariableDescription<>(
             "k", VariableType.arrayType(VariableType.arrayType(VariableType.IntVariable)), true);
 
-    private static final VariableDescription<BooleanVariable> guard = new VariableDescription<>("guard",
+    private static final LocalVariableDescription<BooleanVariable> guard = new LocalVariableDescription<>("guard",
             VariableType.BooleanVariable, true);
 
     @Test
@@ -1897,7 +1898,7 @@ public class ReadWrite {
         assertTrue(arraysModified.contains(i));
     }
 
-    public void testVarDef(ScopedVarSet m, VariableDescription<?> desc, TreeID declarationID,
+    public void testVarDef(ScopedVarSet m, LocalVariableDescription<?> desc, TreeID declarationID,
             TreeID... expectedWriteLocations) {
         assertTrue(m.containsVar(desc));
         VarDef v = m.getVarDef(desc);


### PR DESCRIPTION
### Description
Changing VariableDescription to an abstract class with local, global, and scratch subtypes.

Making an initial cut at changing the constructors in VariableNames so that they are the correct type and VariableDescription is no longer constructed directly.

Moved some methods into the subtypes, so the subtyping information can be maintained. Specifically this is done for methods to change the type of a variable represented by a variable description.

Replaced calls for rng names that are included directly into the output java code with calls to construct trees representing the values.

Modification to make sure that values declared in methods are of type local.

Adding in the use of global scope for class fields. Next step is setup the construction for scratch variables. Adding in the use of scratch to variable descriptions for scratch states.

Splitting out the generation of scratch fields. This will need pushing all the way through to the output class, but it is a good first step. We are not going to do the push through here as when we go to separate classes, the class will be constructed by the wrapper class and passed to the first core class. It will then be passed core class to core class when backends are changed.